### PR TITLE
Improve LLVM support introducing an ad-hoc type to implement the _Ato…

### DIFF
--- a/src/hashtable/hashtable.h
+++ b/src/hashtable/hashtable.h
@@ -5,11 +5,13 @@
 extern "C" {
 #endif
 
-/**
- * TODO:
- * - the data storage is not managed by the hashtable library on purpose, to have more flexibility, but it would be
- *   better to have a smart way to handle the key storage when they are not inline (ie. with a SLAB allocator)
- */
+#if defined(__clang__) && defined(__has_feature)
+#if !__has_feature(c_atomic)
+
+#endif
+#else
+#define _Atomic(T) T volatile
+#endif
 
 #define HASHTABLE_MEMORY_FENCE_LOAD() atomic_thread_fence(memory_order_acquire)
 #define HASHTABLE_MEMORY_FENCE_STORE() atomic_thread_fence(memory_order_release)
@@ -87,6 +89,8 @@ typedef char hashtable_key_data_t;
 typedef uintptr_t hashtable_value_data_t;
 typedef uint8_t hashtable_search_key_or_create_new_ret_t;
 
+typedef _Atomic(hashtable_bucket_hash_t) hashtable_bucket_hash_atomic_t;
+
 enum {
     HASHTABLE_BUCKET_KEY_VALUE_FLAG_DELETED         = 0x01u,
     HASHTABLE_BUCKET_KEY_VALUE_FLAG_FILLED          = 0x02u,
@@ -159,7 +163,7 @@ struct hashtable_data {
     bool can_be_deleted;
     size_t hashes_size;
     size_t keys_values_size;
-    hashtable_bucket_hash_t* volatile hashes;
+    hashtable_bucket_hash_atomic_t* hashes;
     hashtable_bucket_key_value_t* volatile keys_values;
 };
 typedef struct hashtable_data hashtable_data_t;

--- a/src/hashtable/hashtable_data.c
+++ b/src/hashtable/hashtable_data.c
@@ -46,7 +46,7 @@ hashtable_data_t* hashtable_data_init(hashtable_bucket_count_t buckets_count, ui
     hashtable_data->cachelines_to_probe = cachelines_to_probe;
     hashtable_data->hashes_size = hashes_size;
     hashtable_data->keys_values_size = keys_values_size;
-    hashtable_data->hashes = (hashtable_bucket_hash_t*)xalloc_mmap_alloc(hashes_size);
+    hashtable_data->hashes = (hashtable_bucket_hash_atomic_t*)xalloc_mmap_alloc(hashes_size);
     hashtable_data->keys_values = (hashtable_bucket_key_value_t*)xalloc_mmap_alloc(keys_values_size);
 
     return hashtable_data;

--- a/src/hashtable/hashtable_support_op.c
+++ b/src/hashtable/hashtable_support_op.c
@@ -5,8 +5,6 @@
 #include <stdatomic.h>
 #include <string.h>
 
-#include "xalloc.h"
-
 #include "hashtable.h"
 #include "hashtable_support_index.h"
 #include "hashtable_support_op.h"


### PR DESCRIPTION
This PR contains the necessary changes to improve the LLVM support:
- an ad-hoc type has been introduced to handle the _Atomic wrapper on LLVM that fails back a plain volatile on GCC
- the structs being used as part of atomic operations have been updated to use the new type
- the code performing atomic operations has been updated update the code to rely on the right type