### PR TITLE
Fix logging when linked with C++ binary

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -41,8 +41,8 @@ char* log_message_timestamp(char* t_str) {
     struct tm* tm = localtime(&t);
 
     sprintf(t_str, "%04d-%02d-%02dT%02d:%02d:%02dZ",
-            1900 + tm.tm_year, tm.tm_mon, tm.tm_mday,
-            tm.tm_hour, tm.tm_min, tm.tm_sec);
+            1900 + tm->tm_year, tm->tm_mon, tm->tm_mday,
+            tm->tm_hour, tm->tm_min, tm->tm_sec);
 
     return t_str;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -40,10 +40,9 @@ char* log_message_timestamp(char* t_str, size_t t_str_size) {
     time_t t = time(NULL);
     struct tm* tm = localtime(&t);
 
-    if (strftime(t_str, t_str_size, LOG_MESSAGE_TIMESTAMP_FORMAT, tm) == 0) {
-        perror("Unable to format the timestamp for the logs");
-        exit(-1);
-    }
+    sprintf(t_str, "%04d-%02d-%02dT%02d:%02d:%02dZ",
+            1900 + tm.tm_year, tm.tm_mon, tm.tm_mday,
+            tm.tm_hour, tm.tm_min, tm.tm_sec);
 
     return t_str;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -36,7 +36,7 @@ const char* log_level_to_string(log_level_t level) {
     }
 }
 
-char* log_message_timestamp(char* t_str, size_t t_str_size) {
+char* log_message_timestamp(char* t_str) {
     time_t t = time(NULL);
     struct tm* tm = localtime(&t);
 

--- a/src/log.c
+++ b/src/log.c
@@ -56,7 +56,7 @@ void log_message_internal(const char* tag, log_level_t level, const char* messag
 
     fprintf(LOG_MESSAGE_OUTPUT,
             "[%s][%-11s][%s] ",
-            log_message_timestamp(t_str, LOG_MESSAGE_TIMESTAMP_MAX_LENGTH),
+            log_message_timestamp(t_str),
             log_level_to_string(level),
             tag);
     vfprintf(LOG_MESSAGE_OUTPUT, message, args);

--- a/src/log.c
+++ b/src/log.c
@@ -48,7 +48,7 @@ char* log_message_timestamp(char* t_str, size_t t_str_size) {
 }
 
 void log_message_internal(const char* tag, log_level_t level, const char* message, va_list args) {
-    char t_str[LOG_MESSAGE_TIMESTAMP_MAX_LENGTH];
+    char t_str[LOG_MESSAGE_TIMESTAMP_MAX_LENGTH] = {0};
 
     if (level > _log_level) {
         return;

--- a/src/log.h
+++ b/src/log.h
@@ -33,7 +33,7 @@ enum log_level {
 typedef enum log_level log_level_t;
 
 const char* log_level_to_string(log_level_t level);
-char* log_message_timestamp(char* t_str, size_t t_str_size);
+char* log_message_timestamp(char* t_str);
 void log_message_internal(const char* tag, log_level_t level, const char* message, va_list args);
 void log_set_log_level(log_level_t level);
 void log_message(const char* tag, log_level_t level, const char* message, ...);

--- a/src/log.h
+++ b/src/log.h
@@ -7,11 +7,6 @@ extern "C" {
 
 #include <stdarg.h>
 
-#if defined(__MINGW32__)
-#define LOG_MESSAGE_TIMESTAMP_FORMAT "%Y-%m-%d %H:%M:%S"
-#else
-#define LOG_MESSAGE_TIMESTAMP_FORMAT "%F %T"
-#endif
 #define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH 25
 
 #define LOG_E(tag, message, ...) \


### PR DESCRIPTION
Invoking strftime from a C library that gets linked to a C++ binary triggers a sigsegv, a memory violation occurs causing a fatal crash.

This PR switch to use sprintf to build the timestamp printed out with the logs because the usage is pretty basic and nothing advanced as strftime is required.