### PR TITLE
Add debug internals logging

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -37,8 +37,9 @@ const char* log_level_to_string(log_level_t level) {
 }
 
 char* log_message_timestamp(char* t_str) {
+    struct tm tm = {0};
     time_t t = time(NULL);
-    struct tm* tm = localtime(&t);
+    gmtime_r(&t, &tm);
 
     sprintf(t_str, "%04d-%02d-%02dT%02d:%02d:%02dZ",
             1900 + tm.tm_year, tm.tm_mon, tm.tm_mday,

--- a/src/log.c
+++ b/src/log.c
@@ -7,6 +7,7 @@
 #include <signal.h>
 #include <locale.h>
 
+#include "cmake_config.h"
 #include "log.h"
 
 #define LOG_MESSAGE_OUTPUT stdout
@@ -17,10 +18,12 @@
  * Implement a log producers, sink & formatters patterns
  */
 
-static log_level_t _log_level = LOG_LEVEL_DEBUG;
+static log_level_t _log_level = LOG_LEVEL_DEBUG_INTERNALS;
 
 const char* log_level_to_string(log_level_t level) {
     switch(level) {
+        case LOG_LEVEL_DEBUG_INTERNALS:
+            return "DEBUGINT";
         case LOG_LEVEL_DEBUG:
             return "DEBUG";
         case LOG_LEVEL_VERBOSE:
@@ -67,6 +70,22 @@ void log_message_internal(const char* tag, log_level_t level, const char* messag
 
 void log_set_log_level(log_level_t level) {
     _log_level = level;
+}
+
+void log_message_debug(const char* src_path, const char* src_func, int src_line, const char* message, ...) {
+#if DEBUG == 1
+    char* tag;
+
+    tag = (char*)malloc(strlen(src_path) + /*][*/ 2 + strlen(src_func) + /*():*/ 3 + 10 + 1);
+    sprintf(tag, "%s][%s():%d", src_path, src_func, src_line);
+
+    va_list args;
+    va_start(args, message);
+
+    log_message_internal(tag, LOG_LEVEL_DEBUG_INTERNALS, message, args);
+
+    va_end(args);
+#endif
 }
 
 void log_message(const char* tag, log_level_t level, const char* message, ...) {

--- a/src/log.h
+++ b/src/log.h
@@ -22,6 +22,13 @@ extern "C" {
 #define LOG_D(tag, message, ...) \
     log_message(tag, LOG_LEVEL_DEBUG, message, __VA_ARGS__)
 
+#if DEBUG == 1
+#define LOG_DI(...) \
+    log_message_debug(CACHEGRAND_SRC_PATH, __func__, __LINE__, __VA_ARGS__)
+#else
+#define LOG_DI(...) /* Internal debug logs disabled */
+#endif // DEBUG == 1
+
 enum log_level {
     LOG_LEVEL_ERROR,
     LOG_LEVEL_RECOVERABLE,
@@ -29,6 +36,7 @@ enum log_level {
     LOG_LEVEL_INFO,
     LOG_LEVEL_VERBOSE,
     LOG_LEVEL_DEBUG,
+    LOG_LEVEL_DEBUG_INTERNALS,
 };
 typedef enum log_level log_level_t;
 
@@ -36,6 +44,7 @@ const char* log_level_to_string(log_level_t level);
 char* log_message_timestamp(char* t_str);
 void log_message_internal(const char* tag, log_level_t level, const char* message, va_list args);
 void log_set_log_level(log_level_t level);
+void log_message_debug(const char* src_path, const char* src_func, int src_line, const char* message, ...);
 void log_message(const char* tag, log_level_t level, const char* message, ...);
 
 #ifdef __cplusplus

--- a/tools/cmake/compiler/compiler.cmake
+++ b/tools/cmake/compiler/compiler.cmake
@@ -15,4 +15,7 @@ else()
     message(STATUS "Cross-compiling: no")
 endif()
 
+string(LENGTH "${CMAKE_SOURCE_DIR}/" CACHEGRAND_CMAKE_CONFIG_SOURCE_PATH_SIZE)
+add_definitions("-DCACHEGRAND_CMAKE_CONFIG_SOURCE_PATH_SIZE=${CACHEGRAND_CMAKE_CONFIG_SOURCE_PATH_SIZE}")
+
 include(compiler-ccache)


### PR DESCRIPTION
To improve the debugging capabilities within cachegrand, a log_message_debug function has been implemented to print out a number of additional information like the current source file, function and line number of the message.

An additional macro function as been defined as well to simplify the invocation and reduce the boilerplate.

This function is a noop when compiled in release mode, all the debugging will be automatically dropped by GCC during the optimisation phase.