### PR TITLE
Drop non test code from test-hashtable-support-hash-search.cpp

### DIFF
--- a/tests/test-hashtable-support-hash-search.cpp
+++ b/tests/test-hashtable-support-hash-search.cpp
@@ -68,30 +68,3 @@ TEST_CASE("hashtable/hashtable_support_hash_search.c",
 #endif
     TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(loop)
 }
-
-static void *hashtable_support_hash_search_resolve(void)
-{
-    __builtin_cpu_init();
-
-    LOG_DI("Selecting optimal hashtable_support_hash_search_resolve");
-
-#if defined(__x86_64__)
-    LOG_DI("CPU FOUND: %s", "X64");
-    LOG_DI(">  HAS AVX: %s", __builtin_cpu_supports("avx") ? "yes" : "no");
-    LOG_DI("> HAS AVX2: %s", __builtin_cpu_supports("avx2") ? "yes" : "no");
-
-    if (__builtin_cpu_supports("avx2")) {
-        LOG_DI("Selecting AVX2");
-
-        return HASHTABLE_SUPPORT_HASH_SEARCH_METHOD_SIZE(avx2, 14);
-    } else if (__builtin_cpu_supports("avx")) {
-        LOG_DI("Selecting AVX");
-
-        return HASHTABLE_SUPPORT_HASH_SEARCH_METHOD_SIZE(avx, 14);
-    }
-#endif
-
-    LOG_DI("No optimization available, selecting loop-based search algorithm");
-
-    return HASHTABLE_SUPPORT_HASH_SEARCH_METHOD_SIZE(loop, 14);
-}


### PR DESCRIPTION
This PR drops non test code from test-hashtable-support-hash-search.cpp, it is the result of a copy & paste that slipped through a previous PR.