### PR TITLE
Add liburing dependency

### DIFF
--- a/tools/cmake/deps/deps.cmake
+++ b/tools/cmake/deps/deps.cmake
@@ -2,3 +2,4 @@
 list(APPEND DEPS_LIST_LIBRARIES pthread)
 
 include(openssl)
+include(liburing)

--- a/tools/cmake/deps/liburing.cmake
+++ b/tools/cmake/deps/liburing.cmake
@@ -1,0 +1,14 @@
+include(FindPkgConfig)
+
+pkg_check_modules(LIBURING liburing>=0.7)
+
+if (LIBURING_FOUND)
+    list(APPEND DEPS_LIST_INCLUDE_DIRS ${LIBURING_INCLUDE_DIRS})
+    list(APPEND DEPS_LIST_LIBRARY_DIRS ${LIBURING_LIBRARY_DIRS})
+    list(APPEND DEPS_LIST_LIBRARIES ${LIBURING_LIBRARIES})
+else()
+    set(LIBURING_FOUND "0")
+
+    message(STATUS "liburing 0.7 may haven't been released yet, if you are running debian / ubuntu you can easily " +
+            "build it from the sources, all the necessary files to create the proper package are already available")
+endif()


### PR DESCRIPTION
This PR adds the liburing dependency, a new cmake file has been created, liburing.cmake, and it's included it in deps.cmake to add the dependency.
The requested library has been currently compiled from the sources because it hasn't been released yet (matter of days most likely).