### PR TITLE
Add test case to fill the hashtable and fail

### DIFF
--- a/tests/test-hashtable-op-set.cpp
+++ b/tests/test-hashtable-op-set.cpp
@@ -4,6 +4,7 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "log.h"
 
 #include "hashtable/hashtable.h"
 #include "hashtable/hashtable_config.h"
@@ -269,6 +270,35 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                 test_support_same_hash_mod_fixtures_free(test_key_same_bucket);
             })
         }
+
+        SECTION("fill entire hashtable and fail") {
+            HASHTABLE(0x7F, false, {
+                uint32_t slots_to_fill = 448 + 1;
+                test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        hashtable->ht_current->buckets_count,
+                        test_key_same_bucket_key_prefix_external,
+                        slots_to_fill);
+
+                LOG_DI("slots_to_fill = %d", slots_to_fill);
+                uint32_t i = 0;
+                for(; i < slots_to_fill - 1; i++) {
+                    REQUIRE(hashtable_op_set(
+                            hashtable,
+                            (char*)test_key_same_bucket[i].key,
+                            test_key_same_bucket[i].key_len,
+                            test_value_1 + i));
+                }
+
+                REQUIRE(!hashtable_op_set(
+                        hashtable,
+                        (char*)test_key_same_bucket[i].key,
+                        test_key_same_bucket[i].key_len,
+                        test_value_1 + i));
+
+                test_support_same_hash_mod_fixtures_free(test_key_same_bucket);
+            })
+        }
+
 
 //        SECTION("parallel inserts - check storage") {
 //            HASHTABLE(1000000, false, {

--- a/tests/test-hashtable-op-set.cpp
+++ b/tests/test-hashtable-op-set.cpp
@@ -278,7 +278,6 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
 
-                LOG_DI("slots_to_fill = %d", slots_to_fill);
                 uint32_t i = 0;
                 for(; i < slots_to_fill - 1; i++) {
                     REQUIRE(hashtable_op_set(

--- a/tests/test-hashtable-op-set.cpp
+++ b/tests/test-hashtable-op-set.cpp
@@ -4,7 +4,6 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
-#include "log.h"
 
 #include "hashtable/hashtable.h"
 #include "hashtable/hashtable_config.h"


### PR DESCRIPTION
This PR contains an additional test case for hashtable_op_set to ensure that once it's full the new inserts fail