### PR TITLE
Refactor pow2 related code

### DIFF
--- a/src/hashtable/hashtable.c
+++ b/src/hashtable/hashtable.c
@@ -5,28 +5,14 @@
 #include "exttypes.h"
 #include "spinlock.h"
 #include "xalloc.h"
+#include "pow2.h"
 
 #include "hashtable/hashtable.h"
 #include "hashtable/hashtable_config.h"
 #include "hashtable/hashtable_data.h"
 
-//https://jameshfisher.com/2018/03/30/round-up-power-2/
-uint64_t next_pow2m1(uint64_t x) {
-    x |= x>>1;
-    x |= x>>2;
-    x |= x>>4;
-    x |= x>>8;
-    x |= x>>16;
-    x |= x>>32;
-
-    return x;
-}
-uint64_t next_pow2(uint64_t x) {
-    return next_pow2m1(x-1)+1;
-}
-
 hashtable_t* hashtable_init(hashtable_config_t* hashtable_config) {
-    hashtable_bucket_count_t buckets_count = next_pow2(hashtable_config->initial_size);
+    hashtable_bucket_count_t buckets_count = pow2_next(hashtable_config->initial_size);
     hashtable_t* hashtable = (hashtable_t*)xalloc_alloc(sizeof(hashtable_t));
     hashtable_data_t* hashtable_data = hashtable_data_init(buckets_count);
 

--- a/src/hashtable/hashtable_data.c
+++ b/src/hashtable/hashtable_data.c
@@ -7,18 +7,15 @@
 #include "spinlock.h"
 #include "xalloc.h"
 #include "log.h"
+#include "pow2.h"
 
 #include "hashtable/hashtable.h"
 #include "hashtable/hashtable_data.h"
 
 static const char* TAG = "hashtable/data";
 
-bool is_power_of_2(uint32_t x) {
-    return x && (!(x&(x-1)));
-}
-
 hashtable_data_t* hashtable_data_init(hashtable_bucket_count_t buckets_count) {
-    if (is_power_of_2(buckets_count) == false) {
+    if (pow2_is(buckets_count) == false) {
         LOG_E(TAG, "The buckets_count %lu is not power of 2", buckets_count);
         return NULL;
     }

--- a/src/hashtable/hashtable_op_delete.c
+++ b/src/hashtable/hashtable_op_delete.c
@@ -16,7 +16,6 @@
 #include "hashtable/hashtable_support_hash.h"
 #include "hashtable/hashtable_support_op.h"
 
-// TODO: support the new data structure
 bool hashtable_op_delete(
         hashtable_t* hashtable,
         hashtable_key_data_t* key,

--- a/src/misc.h
+++ b/src/misc.h
@@ -1,6 +1,10 @@
 #ifndef CACHEGRAND_MISC_H
 #define CACHEGRAND_MISC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef DEBUG
 #ifdef NDEBUG
 #error "Can't define at the same time DEBUG and NDEBUG"
@@ -22,5 +26,9 @@
    ({ __typeof__ (a) _a = (a); \
        __typeof__ (b) _b = (b); \
      _a < _b ? _a : _b; })
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //CACHEGRAND_MISC_H

--- a/src/pow2.c
+++ b/src/pow2.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+//https://jameshfisher.com/2018/03/30/round-up-power-2/
+uint64_t pow2_next_pow2m1(uint64_t x) {
+    x |= x>>1;
+    x |= x>>2;
+    x |= x>>4;
+    x |= x>>8;
+    x |= x>>16;
+    x |= x>>32;
+
+    return x;
+}
+uint64_t pow2_next(uint64_t x) {
+    return pow2_next_pow2m1(x-1)+1;
+}
+
+bool pow2_is(uint64_t x) {
+    return x && (!(x&(x-1)));
+}

--- a/src/pow2.h
+++ b/src/pow2.h
@@ -1,0 +1,16 @@
+#ifndef CACHEGRAND_MISC_H
+#define CACHEGRAND_MISC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t pow2_next_pow2m1(uint64_t x);
+uint64_t pow2_next(uint64_t x);
+bool pow2_is(uint64_t x);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_MISC_H

--- a/tests/test-hashtable-op-delete.cpp
+++ b/tests/test-hashtable-op-delete.cpp
@@ -5,7 +5,6 @@
 #include "exttypes.h"
 #include "spinlock.h"
 #include "random.h"
-#include "log.h"
 
 #include "hashtable/hashtable.h"
 #include "hashtable/hashtable_config.h"

--- a/tests/test-pow2.cpp
+++ b/tests/test-pow2.cpp
@@ -1,0 +1,34 @@
+#include "catch.hpp"
+
+#include "pow2.h"
+
+TEST_CASE("pow2.c", "[pow2]") {
+    SECTION("pow2_is") {
+        SECTION("valid power of 2 numbers") {
+            REQUIRE(pow2_is(0x000Fu + 1u));
+            REQUIRE(pow2_is(0x00FFu + 1u));
+            REQUIRE(pow2_is(0x0FFFu + 1u));
+            REQUIRE(pow2_is(0xFFFFu + 1u));
+        }
+        SECTION("invalid power of 2 numbers") {
+            REQUIRE(!pow2_is(0x000Fu));
+            REQUIRE(!pow2_is(0x00FFu));
+            REQUIRE(!pow2_is(0x0FFFu));
+            REQUIRE(!pow2_is(0xFFFFu));
+        }
+    }
+
+    SECTION("pow2_next_pow2m1") {
+        REQUIRE(pow2_next_pow2m1(0x000Fu - 1u) == 0x000Fu);
+        REQUIRE(pow2_next_pow2m1(0x00FFu - 1u) == 0x00FFu);
+        REQUIRE(pow2_next_pow2m1(0x0FFFu - 1u) == 0x0FFFu);
+        REQUIRE(pow2_next_pow2m1(0xFFFFu - 1u) == 0xFFFFu);
+    }
+
+    SECTION("pow2_next") {
+        REQUIRE(pow2_next(0x000Fu) == 0x000Fu + 1u);
+        REQUIRE(pow2_next(0x00FFu) == 0x00FFu + 1u);
+        REQUIRE(pow2_next(0x0FFFu) == 0x0FFFu + 1u);
+        REQUIRE(pow2_next(0xFFFFu) == 0xFFFFu + 1u);
+    }
+}


### PR DESCRIPTION
This PR moves the code for the power of two related functions into their own pow2.c/.h files and update the code depending on them to use the new names and import the new header.

The PR contains also the tests implemented for the refactored functions.

This refactor fix also an issue that was causing a failure in certain conditions when the HASHTABLE_USE_UINT64 define was set to 1 because is_power_of_2 was using 32 bit numbers.