### PR TITLE
Fix liburing install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -us -uc -rfakeroot
 # In the parent directory there will be now a number of deb files that can be installed
 # To install the packages it's necessary to use sudo
 cd ..
-sudo dpkg -o liburing-dev_0.7-1_amd64.deb liburing1_0.7-1_amd64.deb
+sudo dpkg -i liburing-dev_0.7-1_amd64.deb liburing1_0.7-1_amd64.deb
 ```
 
 For pratical reasons liburing is internally marked as optional but once the network layer will be implemented it will

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ On Ubuntu 20.04 it's possible to use
  - the below snippet to download, patch, compile and install liburing from the repository 
 
 ```bash
+# Install dh-make to be able to build the deb packages
+sudo apt -y install dh-make
+
 # Create a temporary directory and move inside it
 mkdir temp && cd temp
 


### PR DESCRIPTION
This PR contains a few fixes for the snippet included in the README.md on how to build and install the liburing packages on Ubuntu 20.04.