### PR TITLE
Improve testing and code coverage in test-hashtable-support-hash-search.cpp

### DIFF
--- a/src/hashtable/hashtable_support_hash_search.c
+++ b/src/hashtable/hashtable_support_hash_search.c
@@ -15,11 +15,10 @@ hashtable_chunk_slot_index_t hashtable_support_hash_search(
         uint32_t skip_indexes)
 __attribute__ ((ifunc ("hashtable_support_hash_search_resolve")));
 
-static void *hashtable_support_hash_search_resolve(void)
-{
+static void *hashtable_support_hash_search_resolve(void) {
     __builtin_cpu_init();
 
-    LOG_DI("Selecting optimal hashtable_support_hash_search_resolve");
+    LOG_DI("Selecting optimal hashtable_support_hash_search");
 
 #if defined(__x86_64__)
     LOG_DI("CPU FOUND: %s", "X64");

--- a/tests/test-hashtable-support-hash-search.cpp
+++ b/tests/test-hashtable-support-hash-search.cpp
@@ -2,6 +2,7 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "misc.h"
 #include "log.h"
 
 #include "hashtable/hashtable.h"
@@ -11,8 +12,8 @@
 
 #include "fixtures-hashtable.h"
 
-#define TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(INSTRUCTION_SET) \
-    SECTION("hashtable_support_hash_search_##INSTRUCTION_SET##_14") { \
+#define TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(SUFFIX) \
+    SECTION("hashtable_support_hash_search" STRINGIZE(SUFFIX)) { \
         SECTION("hash - found") { \
             hashtable_hash_half_volatile_t hashes[HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT] = { \
                     123, 234, 345, 456, 567, 678, 789, 890, 901, 012, 987, 876, 765, 654 \
@@ -20,7 +21,7 @@
             hashtable_hash_half_t hash = 345; \
             uint32_t skip_indexes_mask = 0; \
         \
-            REQUIRE(hashtable_support_hash_search_##INSTRUCTION_SET##_14(hash, hashes, skip_indexes_mask) == 2); \
+            REQUIRE(hashtable_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == 2); \
         } \
         \
         SECTION("hash - not found") { \
@@ -30,7 +31,7 @@
             hashtable_hash_half_t hash = 999999; \
             uint32_t skip_indexes_mask = 0; \
         \
-            REQUIRE(hashtable_support_hash_search_##INSTRUCTION_SET##_14(hash, hashes, skip_indexes_mask) == HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX); \
+            REQUIRE(hashtable_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX); \
         } \
         \
         SECTION("hash - multiple - find first") { \
@@ -40,7 +41,7 @@
             hashtable_hash_half_t hash = 234; \
             uint32_t skip_indexes_mask = 0; \
         \
-            REQUIRE(hashtable_support_hash_search_##INSTRUCTION_SET##_14(hash, hashes, skip_indexes_mask) == 1); \
+            REQUIRE(hashtable_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == 1); \
         } \
         \
         SECTION("hash - multiple - find second") { \
@@ -50,7 +51,7 @@
             hashtable_hash_half_t hash = 234; \
             uint32_t skip_indexes_mask = 1 << 1; \
         \
-            REQUIRE(hashtable_support_hash_search_##INSTRUCTION_SET##_14(hash, hashes, skip_indexes_mask) == 5); \
+            REQUIRE(hashtable_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == 5); \
         } \
     }
 
@@ -58,11 +59,15 @@ TEST_CASE("hashtable/hashtable_support_hash_search.c",
         "[hashtable][hashtable_support][hashtable_support_hash][hashtable_support_hash_search]") {
 #if defined(__x86_64__)
 #if CACHEGRAND_CMAKE_CONFIG_HOST_HAS_AVX2 == 1
-    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(avx2)
+    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(_avx2_14)
 #endif
 #if CACHEGRAND_CMAKE_CONFIG_HOST_HAS_AVX == 1
-    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(avx)
+    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(_avx_14)
 #endif
 #endif
-    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(loop)
+    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT(_loop_14)
+
+    // Same as one of the tested above but via ifunc and resolver, needed to check if the resolver is functioning
+    // properly and for code coverage
+    TEST_HASHTABLE_SUPPORT_HASH_SEARCH_PLATFORM_DEPENDENT()
 }


### PR DESCRIPTION
This PR reorganise the test for hashtable_support_hash_search.c to match the structure of hash_crc32c.c to both improve the testing, the ifunc resolver is now tested, and the code coverage.