### PR TITLE
Expand the exttypes.h and fix and expand the tests

### DIFF
--- a/src/exttypes.h
+++ b/src/exttypes.h
@@ -5,12 +5,18 @@
 extern "C" {
 #endif
 
-#define _Volatile(T)    volatile T
-
+// Defines the int128_t and uint128_t
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
+// Defines the wrapper for the volatile type and creates a set of types based off the standard uint* using it
+#define _Volatile(T)    volatile T
+
 typedef _Volatile(uint8_t)  uint8_volatile_t;
+typedef _Volatile(uint16_t)  uint16_volatile_t;
+typedef _Volatile(uint32_t)  uint32_volatile_t;
+typedef _Volatile(uint64_t)  uint64_volatile_t;
+typedef _Volatile(uint128_t)  uint128_volatile_t;
 
 #ifdef __cplusplus
 }

--- a/tests/test-exttypes.cpp
+++ b/tests/test-exttypes.cpp
@@ -1,15 +1,21 @@
 #include "catch.hpp"
 
 #include "exttypes.h"
-#include "spinlock.h"
-
-#include "hashtable/hashtable.h"
-#include "hashtable/hashtable_config.h"
-
-#include "fixtures-hashtable.h"
 
 TEST_CASE("exttypes.h", "[exttypes]") {
-    SECTION("sizeof(uint8_atomic_t) == 1") {
+    SECTION("sizeof(uint8_volatile_t) == 1") {
         REQUIRE(sizeof(uint8_volatile_t) == 1);
+    }
+
+    SECTION("sizeof(uint16_volatile_t) == 2") {
+        REQUIRE(sizeof(uint16_volatile_t) == 2);
+    }
+
+    SECTION("sizeof(uint32_volatile_t) == 4") {
+        REQUIRE(sizeof(uint32_volatile_t) == 4);
+    }
+
+    SECTION("sizeof(uint64_volatile_t) == 8") {
+        REQUIRE(sizeof(uint64_volatile_t) == 8);
     }
 }


### PR DESCRIPTION
This PR expands the exttypes.h to have volatile types for uint16_t, uint32_t uint64_t and fix and expand the tests