### PR TITLE
Fix locking unlocking in op set delete

### DIFF
--- a/src/hashtable/hashtable_op_delete.c
+++ b/src/hashtable/hashtable_op_delete.c
@@ -22,7 +22,7 @@ bool hashtable_op_delete(
         hashtable_key_size_t key_size) {
     hashtable_hash_t hash;
     hashtable_key_value_flags_t key_value_flags = 0;
-    hashtable_chunk_index_t chunk_index = 0;
+    hashtable_chunk_index_t chunk_index = 0, chunk_index_start = 0;
     hashtable_chunk_slot_index_t chunk_slot_index = 0;
     hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk;
     hashtable_key_value_volatile_t* key_value;
@@ -58,6 +58,7 @@ bool hashtable_op_delete(
                 key,
                 key_size,
                 hash,
+                &chunk_index_start,
                 &chunk_index,
                 &chunk_slot_index,
                 &key_value) == false) {

--- a/src/hashtable/hashtable_op_get.c
+++ b/src/hashtable/hashtable_op_get.c
@@ -20,7 +20,7 @@ bool hashtable_op_get(
         hashtable_key_size_t key_size,
         hashtable_value_data_t *data) {
     hashtable_hash_t hash;
-    hashtable_chunk_index_t chunk_index = 0;
+    hashtable_chunk_index_t chunk_index = 0, chunk_index_start = 0;
     hashtable_chunk_slot_index_t chunk_slot_index = 0;
     hashtable_key_value_volatile_t* key_value = 0;
 
@@ -59,6 +59,7 @@ bool hashtable_op_get(
                 key,
                 key_size,
                 hash,
+                &chunk_index_start,
                 &chunk_index,
                 &chunk_slot_index,
                 &key_value) == false) {

--- a/src/hashtable/hashtable_op_set.c
+++ b/src/hashtable/hashtable_op_set.c
@@ -108,6 +108,9 @@ bool hashtable_op_set(
 
     // The unlock will perform the memory fence for us
     spinlock_unlock(&half_hashes_chunk->write_lock);
+    if (chunk_index_start != chunk_index) {
+        spinlock_unlock(&hashtable->ht_current->half_hashes_chunk[chunk_index_start].write_lock);
+    }
 
     LOG_DI("unlocking half_hashes_chunk 0x%016x", half_hashes_chunk);
 

--- a/src/hashtable/hashtable_op_set.c
+++ b/src/hashtable/hashtable_op_set.c
@@ -23,6 +23,7 @@ bool hashtable_op_set(
         hashtable_value_data_t value) {
     bool created_new;
     hashtable_hash_t hash;
+    hashtable_chunk_index_t chunk_index = 0, chunk_index_start = 0;
     hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk = 0;
     hashtable_key_value_volatile_t* key_value = 0;
 
@@ -42,6 +43,8 @@ bool hashtable_op_set(
             hash,
             true,
             &created_new,
+            &chunk_index_start,
+            &chunk_index,
             &half_hashes_chunk,
             &key_value);
 

--- a/src/hashtable/hashtable_support_op.c
+++ b/src/hashtable/hashtable_support_op.c
@@ -53,6 +53,7 @@ bool hashtable_support_op_search_key(
         hashtable_key_data_t *key,
         hashtable_key_size_t key_size,
         hashtable_hash_t hash,
+        hashtable_chunk_index_t *found_chunk_index_start,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_chunk_slot_index_t *found_chunk_slot_index,
         hashtable_key_value_volatile_t **found_key_value)
@@ -66,6 +67,8 @@ bool hashtable_support_op_search_key_or_create_new(
         hashtable_hash_t hash,
         bool create_new_if_missing,
         bool *created_new,
+        hashtable_chunk_index_t *found_chunk_index_start,
+        hashtable_chunk_index_t *found_chunk_index,
         hashtable_half_hashes_chunk_volatile_t **found_half_hashes_chunk,
         hashtable_key_value_volatile_t **found_key_value)
 __attribute__ ((ifunc ("hashtable_support_op_search_key_or_create_new_resolve")));

--- a/src/hashtable/hashtable_support_op.h
+++ b/src/hashtable/hashtable_support_op.h
@@ -10,6 +10,7 @@ extern bool hashtable_support_op_search_key(
         hashtable_key_data_t *key,
         hashtable_key_size_t key_size,
         hashtable_hash_t hash,
+        hashtable_chunk_index_t *found_chunk_index_start,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_chunk_slot_index_t *found_chunk_slot_index,
         hashtable_key_value_volatile_t **found_key_value);
@@ -21,6 +22,8 @@ extern bool hashtable_support_op_search_key_or_create_new(
         hashtable_hash_t hash,
         bool create_new_if_missing,
         bool *created_new,
+        hashtable_chunk_index_t *found_chunk_index_start,
+        hashtable_chunk_index_t *found_chunk_index,
         hashtable_half_hashes_chunk_volatile_t **found_half_hashes_chunk,
         hashtable_key_value_volatile_t **found_key_value);
 

--- a/src/hashtable/hashtable_support_op_arch.h
+++ b/src/hashtable/hashtable_support_op_arch.h
@@ -14,6 +14,7 @@ extern "C" {
             hashtable_key_data_t *key, \
             hashtable_key_size_t key_size, \
             hashtable_hash_t hash, \
+            hashtable_chunk_index_t *found_chunk_index_start, \
             hashtable_chunk_index_t *found_chunk_index, \
             hashtable_chunk_slot_index_t *found_chunk_slot_index, \
             hashtable_key_value_volatile_t **found_key_value); \
@@ -25,6 +26,7 @@ extern "C" {
             hashtable_hash_t hash, \
             bool create_new_if_missing, \
             bool *created_new, \
+            hashtable_chunk_index_t *found_chunk_index_start, \
             hashtable_half_hashes_chunk_volatile_t **found_half_hashes_chunk, \
             hashtable_key_value_volatile_t **found_key_value);
 


### PR DESCRIPTION
This PR fix the locking / unlocking in the set and delete ops, both the start chunk and the chunk containing the key needs to be unlocked by the caller, not only the latter.

Without this the set operation can try to update a value of an ongoing delete operation can try to delete a key.

PR as draft because it needs further testing and investigation.