### PR TITLE
Refactor logging

### DIFF
--- a/src/fatal.c
+++ b/src/fatal.c
@@ -62,7 +62,7 @@ void fatal_log_message(log_producer_t* tag, const char* message, va_list args) {
 
     log_message(tag, LOG_LEVEL_ERROR, "A fatal error has been throw, unable to continue.");
     log_message(tag, LOG_LEVEL_ERROR, "Please, review the details below.");
-    log_message_vargs(tag, LOG_LEVEL_ERROR, message, args);
+    log_message_internal(tag, LOG_LEVEL_ERROR, message, args);
     log_message(tag, LOG_LEVEL_ERROR, "OS Error: %s (%d)", error_message, errno);
 
 #if defined(__MINGW32__)

--- a/src/fatal.h
+++ b/src/fatal.h
@@ -1,7 +1,6 @@
 #ifndef CACHEGRAND_FATAL_H
 #define CACHEGRAND_FATAL_H
 
-#include <log.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/hashtable/hashtable.c
+++ b/src/hashtable/hashtable.c
@@ -11,16 +11,6 @@
 #include "hashtable/hashtable_config.h"
 #include "hashtable/hashtable_data.h"
 
-log_producer_t* hashmap_log_producer;
-
-void __attribute__((constructor)) init_hashmap_log(){
-    hashmap_log_producer = init_log_producer("hashtable");
-}
-
-void __attribute__((destructor)) deinit_hashmap_log(){
-    free(hashmap_log_producer);
-}
-
 hashtable_t* hashtable_init(hashtable_config_t* hashtable_config) {
     hashtable_bucket_count_t buckets_count = pow2_next(hashtable_config->initial_size);
     hashtable_t* hashtable = (hashtable_t*)xalloc_alloc(sizeof(hashtable_t));

--- a/src/hashtable/hashtable.h
+++ b/src/hashtable/hashtable.h
@@ -1,8 +1,6 @@
 #ifndef CACHEGRAND_HASHTABLE_H
 #define CACHEGRAND_HASHTABLE_H
 
-#include <log.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/hashtable/hashtable.h
+++ b/src/hashtable/hashtable.h
@@ -62,9 +62,6 @@ struct hashtable_config {
  * in ad-hoc allocated memory if needed.
  * The struct is aligned to 32 byte to ensure to fit the first half or the second half of a cache-line
  */
-extern log_producer_t* hashmap_log_producer;
-
-
 typedef struct hashtable_key_value hashtable_key_value_t;
 typedef _Volatile(hashtable_key_value_t) hashtable_key_value_volatile_t;
 struct hashtable_key_value {

--- a/src/hashtable/hashtable_data.c
+++ b/src/hashtable/hashtable_data.c
@@ -15,7 +15,6 @@
 
 hashtable_data_t* hashtable_data_init(hashtable_bucket_count_t buckets_count) {
     if (pow2_is(buckets_count) == false) {
-        LOG_E(hashmap_log_producer, "The buckets_count %lu is not power of 2", buckets_count);
         return NULL;
     }
 

--- a/src/log.c
+++ b/src/log.c
@@ -70,7 +70,7 @@ void log_message_internal_printer(const char* tag, log_level_t level, const char
 }
 
 void log_message_internal(log_producer_t *producer, log_level_t level, const char *message, va_list args) {
-    for(uint8_t i = 0; i < log_sinks_registered_count; ++i){
+    for(uint8_t i = 0; i < log_sinks_registered_count && i < LOG_SINK_REGISTERED_MAX; ++i){
         log_sink_t* sink = &log_sinks_registered_list[i];
         if ((level & sink->levels) != level) {
             continue;

--- a/src/log.c
+++ b/src/log.c
@@ -1,10 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
 #include <locale.h>
 
+#include "misc.h"
 #include "log.h"
+#include "xalloc.h"
 
 /**
  * TODO:

--- a/src/log.c
+++ b/src/log.c
@@ -55,20 +55,21 @@ void log_message_internal(const char* tag, log_level_t level, const char* messag
     fprintf(out, "\n");
     fflush(out);
 }
-void log_message_vargs(log_producer_t *tag, log_level_t level, const char *message, va_list args) {
     for(int i =0; i<= log_service->size-1; ++i){
         log_sink_t* sink = log_service->sinks[i];
+void log_message_internal(log_producer_t *producer, log_level_t level, const char *message, va_list args) {
         if ((level & sink->levels) != level) {
             continue;
         }
-        log_message_internal(tag->tag, level, message, args,sink->out);
+        log_message_internal_printer(producer->tag, level, message, args,sink->out);
     }
 }
-void log_message(log_producer_t* tag, log_level_t level, const char* message, ...) {
+
+void log_message(log_producer_t* producer, log_level_t level, const char* message, ...) {
     va_list args;
     va_start(args, message);
 
-    log_message_vargs(tag,level,message,args);
+    log_message_internal(producer, level,message,args);
 
     va_end(args);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -9,11 +9,6 @@
 #include "log.h"
 #include "xalloc.h"
 
-/**
- * TODO:
- *
- * Implement a log producers, sink & formatters patterns
- */
 static log_sink_t log_sinks_registered_list[LOG_SINK_REGISTERED_MAX] = {0};
 static uint8_t log_sinks_registered_count = 0;
 

--- a/src/log.c
+++ b/src/log.c
@@ -71,12 +71,16 @@ void log_message_internal_printer(const char* tag, log_level_t level, const char
 
 void log_message_internal(log_producer_t *producer, log_level_t level, const char *message, va_list args) {
     for(uint8_t i = 0; i < log_sinks_registered_count && i < LOG_SINK_REGISTERED_MAX; ++i){
-        log_sink_t* sink = &log_sinks_registered_list[i];
-        if ((level & sink->levels) != level) {
+        if ((level & log_sinks_registered_list[i].levels) != level) {
             continue;
         }
 
-        log_message_internal_printer(producer->tag, level, message, args,sink->out);
+        log_message_internal_printer(
+                producer->tag,
+                level,
+                message,
+                args,
+                log_sinks_registered_list[i].out);
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -58,7 +58,7 @@ void log_message_internal(const char* tag, log_level_t level, const char* messag
 void log_message_vargs(log_producer_t *tag, log_level_t level, const char *message, va_list args) {
     for(int i =0; i<= log_service->size-1; ++i){
         log_sink_t* sink = log_service->sinks[i];
-        if (level > sink->min_level) {
+        if ((level & sink->levels) != level) {
             continue;
         }
         log_message_internal(tag->tag, level, message, args,sink->out);
@@ -96,7 +96,7 @@ void log_sink_register(log_sink_t *sink) {
 log_sink_t *init_log_sink(FILE *out, log_level_t min_level) {
     log_sink_t* result = (log_sink_t*)malloc(sizeof(log_sink_t));
     result->out = out;
-    result->min_level = min_level;
+    result->levels = levels;
     return result;
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -44,6 +44,8 @@ const char* log_level_to_string(log_level_t level) {
             return "RECOVERABLE";
         case LOG_LEVEL_ERROR:
             return "ERROR";
+        default:
+            return "UNKNOWN";
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -11,6 +11,19 @@
  *
  * Implement a log producers, sink & formatters patterns
  */
+static log_sink_t log_sinks_registered_list[LOG_SINK_REGISTERED_MAX] = {0};
+static uint8_t log_sinks_registered_count = 0;
+
+static log_sink_t *log_sink_default_console;
+
+FUNCTION_CTOR(log_sink_init_console, {
+    log_sink_default_console = log_sink_init(stdout, LOG_LEVEL_ALL);
+    log_sink_register(log_sink_default_console);
+})
+
+FUNCTION_DTOR(log_sink_free_console, {
+    log_sink_free(log_sink_default_console);
+})
 
 const char* log_level_to_string(log_level_t level) {
     switch(level) {
@@ -55,12 +68,14 @@ void log_message_internal(const char* tag, log_level_t level, const char* messag
     fprintf(out, "\n");
     fflush(out);
 }
-    for(int i =0; i<= log_service->size-1; ++i){
-        log_sink_t* sink = log_service->sinks[i];
+
 void log_message_internal(log_producer_t *producer, log_level_t level, const char *message, va_list args) {
+    for(uint8_t i = 0; i < log_sinks_registered_count; ++i){
+        log_sink_t* sink = &log_sinks_registered_list[i];
         if ((level & sink->levels) != level) {
             continue;
         }
+
         log_message_internal_printer(producer->tag, level, message, args,sink->out);
     }
 }
@@ -74,36 +89,28 @@ void log_message(log_producer_t* producer, log_level_t level, const char* messag
     va_end(args);
 }
 
-void __attribute__((destructor)) deinit_log_service() {
-    free(log_service->sinks);
-    free(log_service);
-}
-
-void __attribute__((constructor)) init_log_service() {
-    log_service = (log_service_t*)malloc(sizeof(log_service));
-    //init console out
-    log_sink_t* console = init_log_sink(stdout, LOG_LEVEL_INFO);
-    log_service->sinks = malloc(sizeof(log_sink_t));
-    *log_service->sinks = console;
-    log_service->size = 1;
-}
-
 void log_sink_register(log_sink_t *sink) {
-    ++log_service->size;
-    log_service->sinks = realloc(log_service->sinks, sizeof(log_sink_t)*log_service->size);
-    *(log_service->sinks + log_service->size - 1) = sink;
+    log_sinks_registered_list[log_sinks_registered_count] = *sink;
+    log_sinks_registered_count++;
 }
 
-log_sink_t *init_log_sink(FILE *out, log_level_t min_level) {
-    log_sink_t* result = (log_sink_t*)malloc(sizeof(log_sink_t));
+log_sink_t *log_sink_init(FILE *out, log_level_t levels) {
+    log_sink_t* result = (log_sink_t*)xalloc_alloc(sizeof(log_sink_t));
     result->out = out;
     result->levels = levels;
     return result;
 }
 
-log_producer_t *init_log_producer(char *tag) {
-    log_producer_t* result = malloc(sizeof(log_producer_t));
-    result->service = log_service;
+log_sink_t* log_sink_free(log_sink_t* log_sink) {
+    xalloc_free(log_sink);
+}
+
+log_producer_t *log_producer_init(char *tag) {
+    log_producer_t* result = xalloc_alloc(sizeof(log_producer_t));
     result->tag = tag;
     return result;
+}
+
+log_producer_t* log_producer_free(log_producer_t* log_producer) {
+    xalloc_free(log_producer);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -56,7 +56,7 @@ char* log_message_timestamp(char* dest, size_t maxlen) {
     return dest;
 }
 
-void log_message_internal(const char* tag, log_level_t level, const char* message, va_list args, FILE* out) {
+void log_message_internal_printer(const char* tag, log_level_t level, const char* message, va_list args, FILE* out) {
     char t_str[LOG_MESSAGE_TIMESTAMP_MAX_LENGTH] = {0};
 
     fprintf(out,

--- a/src/log.h
+++ b/src/log.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <log_debug.h>
 #include <stdio.h>
 
-#define LOG_SINK_REGISTERED_MAX             5
+#define LOG_SINK_REGISTERED_MAX             4
 #define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH    50
 
 #define LOG_E(tag, message, ...) \

--- a/src/log.h
+++ b/src/log.h
@@ -9,8 +9,8 @@ extern "C" {
 #include <log_debug.h>
 #include <stdio.h>
 
-#define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH 25
 #define LOG_SINK_REGISTERED_MAX             10
+#define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH    50
 
 #define LOG_E(tag, message, ...) \
     log_message(tag, LOG_LEVEL_ERROR, message, __VA_ARGS__)

--- a/src/log.h
+++ b/src/log.h
@@ -56,13 +56,7 @@ typedef struct {
     log_level_t levels;
 } log_sink_t;
 
-typedef struct {
-    log_sink_t** sinks;
-    int size;
-} log_service_t;
-
 typedef struct{
-    log_service_t* service;
     char* tag;
 } log_producer_t;
 
@@ -73,11 +67,6 @@ char* log_message_timestamp(char* dest, size_t maxlen);
 void log_message_internal_printer(const char* tag, log_level_t level, const char* message, va_list args, FILE* out);
 void log_message_internal(log_producer_t *tag, log_level_t level, const char *message, va_list args);
 void log_message(log_producer_t* tag, log_level_t level, const char* message, ...);
-
-static log_service_t* log_service;
-
-void __attribute__((constructor)) init_log_service();
-void __attribute__((destructor)) deinit_log_service();
 
 void log_sink_register(log_sink_t *sink);
 #ifndef DEBUG

--- a/src/log.h
+++ b/src/log.h
@@ -12,18 +12,18 @@ extern "C" {
 #define LOG_SINK_REGISTERED_MAX             4
 #define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH    50
 
-#define LOG_E(tag, message, ...) \
-    log_message(tag, LOG_LEVEL_ERROR, message, __VA_ARGS__)
-#define LOG_R(tag, message, ...) \
-    log_message(tag, LOG_LEVEL_RECOVERABLE, message, __VA_ARGS__)
-#define LOG_W(tag, message, ...) \
-    log_message(tag, LOG_LEVEL_WARNING, message, __VA_ARGS__)
-#define LOG_I(tag, message, ...) \
-    log_message(tag, LOG_LEVEL_INFO, message, __VA_ARGS__)
-#define LOG_V(tag, message, ...) \
-    log_message(tag, LOG_LEVEL_VERBOSE, message, __VA_ARGS__)
-#define LOG_D(tag, message, ...) \
-    log_message(tag, LOG_LEVEL_DEBUG, message, __VA_ARGS__)
+#define LOG_E(producer, message, ...) \
+    log_message(producer, LOG_LEVEL_ERROR, message, __VA_ARGS__)
+#define LOG_R(producer, message, ...) \
+    log_message(producer, LOG_LEVEL_RECOVERABLE, message, __VA_ARGS__)
+#define LOG_W(producer, message, ...) \
+    log_message(producer, LOG_LEVEL_WARNING, message, __VA_ARGS__)
+#define LOG_I(producer, message, ...) \
+    log_message(producer, LOG_LEVEL_INFO, message, __VA_ARGS__)
+#define LOG_V(producer, message, ...) \
+    log_message(producer, LOG_LEVEL_VERBOSE, message, __VA_ARGS__)
+#define LOG_D(producer, message, ...) \
+    log_message(producer, LOG_LEVEL_DEBUG, message, __VA_ARGS__)
 
 #define LOG_PRODUCER_DEFAULT PRODUCER
 
@@ -61,15 +61,15 @@ typedef struct{
     char* tag;
 } log_producer_t;
 
-log_producer_t* log_producer_init(char* tag);
-log_producer_t* log_producer_free(log_producer_t* log_producer);
+log_producer_t* log_producer_init(char *tag);
+log_producer_t* log_producer_free(log_producer_t *log_producer);
 log_sink_t* log_sink_init(FILE* out, log_level_t levels);
-log_sink_t* log_sink_free(log_sink_t* log_sink);
+log_sink_t* log_sink_free(log_sink_t *log_sink);
 const char* log_level_to_string(log_level_t level);
-char* log_message_timestamp(char* dest, size_t maxlen);
-void log_message_internal_printer(const char* tag, log_level_t level, const char* message, va_list args, FILE* out);
-void log_message_internal(log_producer_t *tag, log_level_t level, const char *message, va_list args);
-void log_message(log_producer_t* tag, log_level_t level, const char* message, ...);
+char* log_message_timestamp(char *dest, size_t maxlen);
+void log_message_internal_printer(const char *tag, log_level_t level, const char *message, va_list args, FILE *out);
+void log_message_internal(log_producer_t *producer, log_level_t level, const char *message, va_list args);
+void log_message(log_producer_t *producer, log_level_t level, const char *message, ...);
 
 void log_sink_register(log_sink_t *sink);
 #ifndef DEBUG

--- a/src/log.h
+++ b/src/log.h
@@ -39,19 +39,21 @@ extern "C" {
     LOG_PRODUCER_CREATE_LOCAL(TAG, SUFFIX, LOG_PRODUCER_DEFAULT)
     
 enum log_level {
-    LOG_LEVEL_ERROR,
-    LOG_LEVEL_RECOVERABLE,
-    LOG_LEVEL_WARNING,
-    LOG_LEVEL_INFO,
-    LOG_LEVEL_VERBOSE,
-    LOG_LEVEL_DEBUG,
-    LOG_LEVEL_DEBUG_INTERNALS,
+    LOG_LEVEL_ERROR = 1u << 6u,
+    LOG_LEVEL_RECOVERABLE = 1u << 5u,
+    LOG_LEVEL_WARNING = 1u << 4u,
+    LOG_LEVEL_INFO = 1u << 3u,
+    LOG_LEVEL_VERBOSE = 1u << 2u,
+    LOG_LEVEL_DEBUG = 1u << 1u,
+    LOG_LEVEL_DEBUG_INTERNALS = 1u << 0u,
 };
 typedef enum log_level log_level_t;
 
+#define LOG_LEVEL_ALL ((uint8_t)LOG_LEVEL_ERROR << 1u) - 1u
+
 typedef struct {
     FILE* out;
-    log_level_t min_level;
+    log_level_t levels;
 } log_sink_t;
 
 typedef struct {

--- a/src/log.h
+++ b/src/log.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <log_debug.h>
 #include <stdio.h>
 
-#define LOG_SINK_REGISTERED_MAX             10
+#define LOG_SINK_REGISTERED_MAX             5
 #define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH    50
 
 #define LOG_E(tag, message, ...) \

--- a/src/log.h
+++ b/src/log.h
@@ -24,6 +24,20 @@ extern "C" {
 #define LOG_D(tag, message, ...) \
     log_message(tag, LOG_LEVEL_DEBUG, message, __VA_ARGS__)
 
+#define LOG_PRODUCER_DEFAULT PRODUCER
+
+#define LOG_PRODUCER_CREATE_LOCAL(TAG, SUFFIX, VAR) \
+    static log_producer_t* VAR; \
+    FUNCTION_CTOR(concat(log_producer_local_init, SUFFIX), { \
+        VAR = log_producer_init(TAG); \
+    }) \
+    FUNCTION_DTOR(concat(log_producer_local_free, SUFFIX), { \
+        log_producer_free(VAR); \
+    })
+
+#define LOG_PRODUCER_CREATE_LOCAL_DEFAULT(TAG, SUFFIX) \
+    LOG_PRODUCER_CREATE_LOCAL(TAG, SUFFIX, LOG_PRODUCER_DEFAULT)
+    
 enum log_level {
     LOG_LEVEL_ERROR,
     LOG_LEVEL_RECOVERABLE,

--- a/src/log.h
+++ b/src/log.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <stdio.h>
 
 #define LOG_MESSAGE_TIMESTAMP_MAX_LENGTH 25
+#define LOG_SINK_REGISTERED_MAX             10
 
 #define LOG_E(tag, message, ...) \
     log_message(tag, LOG_LEVEL_ERROR, message, __VA_ARGS__)
@@ -37,7 +38,7 @@ extern "C" {
 
 #define LOG_PRODUCER_CREATE_LOCAL_DEFAULT(TAG, SUFFIX) \
     LOG_PRODUCER_CREATE_LOCAL(TAG, SUFFIX, LOG_PRODUCER_DEFAULT)
-    
+
 enum log_level {
     LOG_LEVEL_ERROR = 1u << 6u,
     LOG_LEVEL_RECOVERABLE = 1u << 5u,
@@ -60,8 +61,10 @@ typedef struct{
     char* tag;
 } log_producer_t;
 
-log_producer_t* init_log_producer(char* tag);
-log_sink_t* init_log_sink(FILE* out, log_level_t min_level);
+log_producer_t* log_producer_init(char* tag);
+log_producer_t* log_producer_free(log_producer_t* log_producer);
+log_sink_t* log_sink_init(FILE* out, log_level_t levels);
+log_sink_t* log_sink_free(log_sink_t* log_sink);
 const char* log_level_to_string(log_level_t level);
 char* log_message_timestamp(char* dest, size_t maxlen);
 void log_message_internal_printer(const char* tag, log_level_t level, const char* message, va_list args, FILE* out);

--- a/src/log.h
+++ b/src/log.h
@@ -70,9 +70,9 @@ log_producer_t* init_log_producer(char* tag);
 log_sink_t* init_log_sink(FILE* out, log_level_t min_level);
 const char* log_level_to_string(log_level_t level);
 char* log_message_timestamp(char* dest, size_t maxlen);
-void log_message_internal(const char* tag, log_level_t level, const char* message, va_list args, FILE* out);
+void log_message_internal_printer(const char* tag, log_level_t level, const char* message, va_list args, FILE* out);
+void log_message_internal(log_producer_t *tag, log_level_t level, const char *message, va_list args);
 void log_message(log_producer_t* tag, log_level_t level, const char* message, ...);
-void log_message_vargs(log_producer_t* tag, log_level_t level, const char* message, va_list args);
 
 static log_service_t* log_service;
 

--- a/src/log.h
+++ b/src/log.h
@@ -40,13 +40,13 @@ extern "C" {
     LOG_PRODUCER_CREATE_LOCAL(TAG, SUFFIX, LOG_PRODUCER_DEFAULT)
 
 enum log_level {
-    LOG_LEVEL_ERROR = 1u << 6u,
-    LOG_LEVEL_RECOVERABLE = 1u << 5u,
-    LOG_LEVEL_WARNING = 1u << 4u,
-    LOG_LEVEL_INFO = 1u << 3u,
-    LOG_LEVEL_VERBOSE = 1u << 2u,
-    LOG_LEVEL_DEBUG = 1u << 1u,
-    LOG_LEVEL_DEBUG_INTERNALS = 1u << 0u,
+    LOG_LEVEL_ERROR = 0x40,
+    LOG_LEVEL_RECOVERABLE = 0x20,
+    LOG_LEVEL_WARNING = 0x10,
+    LOG_LEVEL_INFO = 0x08,
+    LOG_LEVEL_VERBOSE = 0x04,
+    LOG_LEVEL_DEBUG = 0x02,
+    LOG_LEVEL_DEBUG_INTERNALS = 0x01,
 };
 typedef enum log_level log_level_t;
 

--- a/src/log_debug.c
+++ b/src/log_debug.c
@@ -59,7 +59,7 @@ void log_message_debug(const char* src_path, const char* src_func, const int src
     va_list args;
     va_start(args, message);
 
-    log_message_internal(tag, LOG_LEVEL_DEBUG_INTERNALS, message, args, stdout);
+    log_message_internal_printer(tag, LOG_LEVEL_DEBUG_INTERNALS, message, args, stdout);
 
     va_end(args);
     free(tag);

--- a/src/log_debug.h
+++ b/src/log_debug.h
@@ -19,33 +19,25 @@ extern "C" {
 
 #define LOG_MESSAGE_DEBUG_RULES_SRC_PATH_INCLUDE
 
-#define LOG_MESSAGE_DEBUG_RULES_SRC_PATH_EXCLUDE
+#define LOG_MESSAGE_DEBUG_RULES_SRC_PATH_EXCLUDE \
+        "tests/test-support.c",
 
 #define LOG_MESSAGE_DEBUG_RULES_SRC_FUNC_INCLUDE
 
 #define LOG_MESSAGE_DEBUG_RULES_SRC_FUNC_EXCLUDE \
         "hashtable_op_get", \
         "hashtable_op_set", \
+        "hashtable_op_delete", \
         "hashtable_support_op_search_key_avx2", \
         "hashtable_support_op_search_key_or_create_new_avx2", \
-        "hashtable_support_op_half_hashes_chunk_lock_avx2", \
-        "hashtable_support_op_half_hashes_chunk_unlock_avx2", \
         "hashtable_support_op_search_key_avx", \
         "hashtable_support_op_search_key_or_create_new_avx", \
-        "hashtable_support_op_half_hashes_chunk_lock_avx", \
-        "hashtable_support_op_half_hashes_chunk_unlock_avx", \
         "hashtable_support_op_search_key_sse42", \
         "hashtable_support_op_search_key_or_create_new_sse42", \
-        "hashtable_support_op_half_hashes_chunk_lock_sse42", \
-        "hashtable_support_op_half_hashes_chunk_unlock_sse42", \
         "hashtable_support_op_search_key_genericx86", \
         "hashtable_support_op_search_key_or_create_new_genericx86", \
-        "hashtable_support_op_half_hashes_chunk_lock_genericx86", \
-        "hashtable_support_op_half_hashes_chunk_unlock_genericx86", \
         "hashtable_support_op_search_key_defaultopt", \
-        "hashtable_support_op_search_key_or_create_new_defaultopt", \
-        "hashtable_support_op_half_hashes_chunk_lock_defaultopt", \
-        "hashtable_support_op_half_hashes_chunk_unlock_defaultopt",
+        "hashtable_support_op_search_key_or_create_new_defaultopt",
 
 #define LOG_MESSAGE_DEBUG_RULES(var, TYPE, INCLUDE_OR_EXCLUDE) \
     const char* var[] = { LOG_MESSAGE_DEBUG_RULES_##TYPE##_##INCLUDE_OR_EXCLUDE NULL }

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <malloc.h>
 
+#include "misc.h"
 #include "log.h"
 #include "fatal.h"
 #include "random.h"

--- a/src/main.c
+++ b/src/main.c
@@ -7,23 +7,22 @@
 #include "fatal.h"
 #include "random.h"
 
+LOG_PRODUCER_CREATE_LOCAL_DEFAULT("main", main)
 
 int main()
 {
-    log_producer_t* TAG = init_log_producer("main");
-    LOG_D(TAG, "Debug log message: %d", 999);
-    LOG_V(TAG, "Verbose log message: %d", 888);
-    LOG_I(TAG, "Info log message: %d", 777);
+    LOG_D(LOG_PRODUCER_DEFAULT, "Debug log message: %d", 999);
+    LOG_V(LOG_PRODUCER_DEFAULT, "Verbose log message: %d", 888);
+    LOG_I(LOG_PRODUCER_DEFAULT, "Info log message: %d", 777);
 
 
-    LOG_D(TAG, "Debug log message: %d", 666);
-    LOG_V(TAG, "Verbose log message: %d", 555);
-    LOG_I(TAG, "Info log message: %d", 444);
-    LOG_W(TAG, "Warning log message: %d", 333);
-    LOG_R(TAG, "Recoverable log message: %d", 222);
-    LOG_E(TAG, "Error log message: %d", 111);
+    LOG_D(LOG_PRODUCER_DEFAULT, "Debug log message: %d", 666);
+    LOG_V(LOG_PRODUCER_DEFAULT, "Verbose log message: %d", 555);
+    LOG_I(LOG_PRODUCER_DEFAULT, "Info log message: %d", 444);
+    LOG_W(LOG_PRODUCER_DEFAULT, "Warning log message: %d", 333);
+    LOG_R(LOG_PRODUCER_DEFAULT, "Recoverable log message: %d", 222);
+    LOG_E(LOG_PRODUCER_DEFAULT, "Error log message: %d", 111);
 
-    FATAL(TAG, "KAbooommmmm %d", 000);
-    free(TAG);
+    FATAL(LOG_PRODUCER_DEFAULT, "KAbooommmmm %d", 000);
     return 0;
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -37,7 +37,7 @@ extern "C" {
         FUNC_BODY \
     } \
     \
-    static void (*concat(concat(NAME, SECTION_TYPE), fp))(void) ELF_SECTION(SECTION_TYPE_STR) = \
+    void (*concat(concat(NAME, SECTION_TYPE), fp))(void) ELF_SECTION(SECTION_TYPE_STR) = \
         concat(NAME, SECTION_TYPE); \
 
 #define FUNCTION_CTOR(NAME, ...) FUNCTION_CTOR_DTOR(ctors, ".ctors", NAME, __VA_ARGS__)

--- a/src/misc.h
+++ b/src/misc.h
@@ -14,6 +14,8 @@ extern "C" {
 #define likely(x)      __builtin_expect(!!(x), 1)
 #define unlikely(x)    __builtin_expect(!!(x), 0)
 
+#define ELF_SECTION( S ) __attribute__ ((section ( S )))
+
 #define concat_(a, b)   a ## _ ## b
 #define concat(a, b)    concat_(a, b)
 
@@ -29,6 +31,17 @@ extern "C" {
    ({ __typeof__ (a) _a = (a); \
        __typeof__ (b) _b = (b); \
      _a < _b ? _a : _b; })
+
+#define FUNCTION_CTOR_DTOR(SECTION_TYPE, SECTION_TYPE_STR, NAME, FUNC_BODY) \
+    static void concat(NAME, SECTION_TYPE) (){ \
+        FUNC_BODY \
+    } \
+    \
+    static void (*concat(concat(NAME, SECTION_TYPE), fp))(void) ELF_SECTION(SECTION_TYPE_STR) = \
+        concat(NAME, SECTION_TYPE); \
+
+#define FUNCTION_CTOR(NAME, ...) FUNCTION_CTOR_DTOR(ctors, ".ctors", NAME, __VA_ARGS__)
+#define FUNCTION_DTOR(NAME, ...) FUNCTION_CTOR_DTOR(dtors, ".dtors", NAME, __VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/src/signal_handler_sigsegv.c
+++ b/src/signal_handler_sigsegv.c
@@ -1,12 +1,15 @@
+#include <stdlib.h>
 #include <signal.h>
 
+#include "misc.h"
+#include "log.h"
 #include "fatal.h"
 #include "signal_handler_sigsegv.h"
 
-static const char* TAG = "signal_handler/sigsegv";
+LOG_PRODUCER_CREATE_LOCAL_DEFAULT("signal_handler/sigsegv", signal_handler_sigsegv)
 
 void signal_handler_sigsegv_handler(int sig) {
-    fatal(TAG, "Error: signal %d:\n", sig);
+    fatal(LOG_PRODUCER_DEFAULT, "Error: signal %d:\n", sig);
 }
 
 void signal_handler_sigsegv_init() {

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -11,15 +11,7 @@
 #include "log.h"
 #include "fatal.h"
 
-static log_producer_t* spinlock_log_producer;
-
-static void __attribute__((constructor)) init_spinlock_log(){
-    spinlock_log_producer = init_log_producer("spinlock");
-}
-
-static void __attribute__((constructor)) deinit_spinlock_log(){
-    free(spinlock_log_producer);
-}
+LOG_PRODUCER_CREATE_LOCAL_DEFAULT("spinlock", spinlock)
 
 void spinlock_init(
         spinlock_lock_volatile_t* spinlock) {
@@ -84,7 +76,7 @@ bool spinlock_lock_internal(
         // TODO: implement spinlock auto balancing using the predicted_spins property of the lock struct
 
         if (spins == UINT32_MAX) {
-            LOG_E(spinlock_log_producer, "Possible stuck spinlock detected for thread %d in %s at %s:%u",
+            LOG_E(LOG_PRODUCER_DEFAULT, "Possible stuck spinlock detected for thread %d in %s at %s:%u",
                     pthread_self(), src_func, src_path, src_line);
         }
     }

--- a/src/spinlock_ticket.c
+++ b/src/spinlock_ticket.c
@@ -14,15 +14,7 @@
 #include "fatal.h"
 #include "spinlock_ticket.h"
 
-static log_producer_t* spinlock_ticket_log_producer;
-
-static void __attribute__((constructor)) init_spinlock_log(){
-    spinlock_ticket_log_producer = init_log_producer("spinlock_ticket");
-}
-
-static void __attribute__((constructor)) deinit_spinlock_log(){
-    free(spinlock_ticket_log_producer);
-}
+LOG_PRODUCER_CREATE_LOCAL_DEFAULT("spinlock_ticket", spinlock_ticket)
 
 static inline spinlock_ticket_number_t spinlock_ticket_acquire(
         spinlock_ticket_lock_volatile_t *spinlock_ticket)
@@ -64,7 +56,7 @@ spinlock_ticket_number_t spinlock_ticket_lock_internal(
         }
 
         if (spins++ == UINT32_MAX) {
-            LOG_E(spinlock_ticket_log_producer, "Possible stuck spinlock detected for thread %d in %s at %s:%u",
+            LOG_E(LOG_PRODUCER_DEFAULT, "Possible stuck spinlock detected for thread %d in %s at %s:%u",
                   pthread_self(), src_func, src_path, src_line);
         }
     }

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -8,9 +8,11 @@
 #include <windows.h>
 #endif
 
+#include "log.h"
+#include "misc.h"
 #include "fatal.h"
 
-static const char* TAG = "xalloc";
+LOG_PRODUCER_CREATE_LOCAL_DEFAULT("xalloc", xalloc)
 
 void* xalloc_alloc(size_t size) {
     void* memptr;
@@ -18,7 +20,7 @@ void* xalloc_alloc(size_t size) {
     memptr = malloc(size);
 
     if (memptr == NULL) {
-        FATAL(TAG, "Unable to allocate the requested memory %d", size);
+        FATAL(LOG_PRODUCER_DEFAULT, "Unable to allocate the requested memory %d", size);
     }
 
     return memptr;
@@ -49,7 +51,7 @@ void* xalloc_alloc_aligned(size_t alignment, size_t size) {
 #endif
 
     if (failed) {
-        FATAL(TAG, "Unable to allocate the requested memory %d aligned to %d", size, alignment);
+        FATAL(LOG_PRODUCER_DEFAULT, "Unable to allocate the requested memory %d aligned to %d", size, alignment);
     }
 
     return memptr;
@@ -130,7 +132,7 @@ void* xalloc_mmap_alloc(size_t size) {
 #endif
 
     if (failed) {
-        FATAL(TAG, "Unable to allocate the requested memory %d", size);
+        FATAL(LOG_PRODUCER_DEFAULT, "Unable to allocate the requested memory %d", size);
     }
 
     return memptr;

--- a/tests/test-spinlock-ticket.cpp
+++ b/tests/test-spinlock-ticket.cpp
@@ -142,7 +142,7 @@ TEST_CASE("spinlock_ticket.c", "[spinlock_ticket]") {
 
             // Magic numbers to run enough thread in parallel for 1-2s after the thread creation.
             // The test can be quite time consuming when with an attached debugger.
-            increments_per_thread = (uint64_t)(250 /  ((float)threads_count / 24.0));
+            increments_per_thread = (uint64_t)(100 /  ((float)threads_count / 24.0));
 
             REQUIRE(pthread_attr_init(&attr) == 0);
 

--- a/tests/test-support.c
+++ b/tests/test-support.c
@@ -40,14 +40,7 @@
 
 #include "test-support.h"
 
-static log_producer_t* support_log_producer;
-static void __attribute__((constructor)) init_support_log(){
-    support_log_producer = init_log_producer("test-support");
-}
-static void __attribute__((constructor)) deinit_support_log(){
-    free(support_log_producer);
-}
-
+LOG_PRODUCER_CREATE_LOCAL_DEFAULT("test-support", test_support)
 
 void test_support_hashtable_print_heatmap(
         hashtable_t* hashtable,
@@ -505,7 +498,7 @@ char* test_support_init_keys(
 
     switch (keys_generator_method) {
         default:
-            FATAL(support_log_producer, "Keyset genererator method <%d> unsupported", keys_generator_method);
+            FATAL(LOG_PRODUCER_DEFAULT, "Keyset genererator method <%d> unsupported", keys_generator_method);
             break;
 
         case TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_MAX_LENGTH:


### PR DESCRIPTION
This PR refactor some of the work done by @fireuse and extends it, high level changes:
- reduce code duplication and boiler plate using the .ctors and .dtors sections to declare multiple constructor / destructors (works better then the attributes constructor / destructor)
- drop the dynamic list of sinks, if the day will come we will need to have more than 10 sinks probably a major refactor will be needed
- drop the service, used only to hold the list of sinks but now it's static, also avoids dynamic memory allocation and re-allocation
- also refactor the function names to keep them more in line with what the rest of the code is using 