### PR TITLE
Keep track of distance in chunk slot

### DIFF
--- a/benches/bench-support.cpp
+++ b/benches/bench-support.cpp
@@ -37,7 +37,7 @@ void bench_support_collect_hashtable_stats(
     *return_overflowed_chunks_count = 0;
 
     for(hashtable_chunk_index_t chunk_index = 0; chunk_index < ht_data->chunks_count; chunk_index++) {
-        if (ht_data->half_hashes_chunk[chunk_index].half_hashes[0] == 0) {
+        if (ht_data->half_hashes_chunk[chunk_index].half_hashes[0].slot_id == 0) {
             continue;
         }
 

--- a/src/hashtable/hashtable_op_delete.c
+++ b/src/hashtable/hashtable_op_delete.c
@@ -74,7 +74,7 @@ bool hashtable_op_delete(
 
         half_hashes_chunk->metadata.is_full = 0;
 
-        half_hashes_chunk->half_hashes[chunk_slot_index] = 0;
+        half_hashes_chunk->half_hashes[chunk_slot_index].slot_id = 0;
 
         HASHTABLE_MEMORY_FENCE_STORE();
 

--- a/src/hashtable/hashtable_op_delete.c
+++ b/src/hashtable/hashtable_op_delete.c
@@ -28,6 +28,14 @@ bool hashtable_op_delete(
     hashtable_key_value_volatile_t* key_value;
     bool deleted = false;
 
+    // TODO: the deletion algorithm needs to be updated to compact the keys stored in further away slots relying on the
+    //       distance.
+    //       Once a slot has been empty-ed, it has to use the AVX2/AVX instructions if available, if not a simple loop,
+    //       to search if chunks ahead (within the overflowed_chunks_counter margin) contain keys that can be moved
+    //       back to fill the slot.
+    //       At the end it has to update the original over overflowed_chunks_counter to restrict the search range if
+    //       there was any compaction.
+
     hash = hashtable_support_hash_calculate(key, key_size);
 
     LOG_DI("key (%d) = %s", key_size, key);

--- a/src/hashtable/hashtable_support_hash.c
+++ b/src/hashtable/hashtable_support_hash.c
@@ -25,3 +25,7 @@ hashtable_hash_t hashtable_support_hash_calculate(hashtable_key_data_t *key, has
 hashtable_hash_half_t hashtable_support_hash_half(hashtable_hash_t hash) {
     return (hash >> 32u) | 0x80000000u;
 }
+
+hashtable_hash_quarter_t hashtable_support_hash_quarter(hashtable_hash_half_t hash_half) {
+    return hash_half & 0xFFFFu;
+}

--- a/src/hashtable/hashtable_support_hash.h
+++ b/src/hashtable/hashtable_support_hash.h
@@ -22,6 +22,9 @@ hashtable_hash_t hashtable_support_hash_calculate(
 hashtable_hash_half_t hashtable_support_hash_half(
         hashtable_hash_t hash);
 
+hashtable_hash_quarter_t hashtable_support_hash_quarter(
+        hashtable_hash_half_t hash_half);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/fixtures-hashtable.h
+++ b/tests/fixtures-hashtable.h
@@ -25,13 +25,13 @@ char test_key_1[] = "test key 1";
 hashtable_key_size_t test_key_1_len = 10;
 hashtable_hash_t test_key_1_hash = (hashtable_hash_t)0xf1bdcc8aaccb614c;
 hashtable_hash_half_t test_key_1_hash_half = (test_key_1_hash >> 32u) | 0x80000000u;
-hashtable_bucket_index_t test_index_1_buckets_count_42 = test_key_1_hash % buckets_count_42;
+hashtable_hash_quarter_t test_key_1_hash_quarter = test_key_1_hash_half & 0xFFFF;
 
 char test_key_2[] = "test key 2";
 hashtable_key_size_t test_key_2_len = 10;
 hashtable_hash_t test_key_2_hash = (hashtable_hash_t)0x8c8b1b670da1324d;
 hashtable_hash_half_t test_key_2_hash_half = (test_key_2_hash >> 32u) | 0x80000000u;
-hashtable_bucket_index_t test_index_2_buckets_count_42 = test_key_2_hash % buckets_count_42;
+hashtable_hash_quarter_t test_key_2_hash_quarter = test_key_2_hash_half & 0xFFFF;
 
 #define HASHTABLE_DATA(buckets_count_v, ...) \
 { \
@@ -70,8 +70,10 @@ hashtable_bucket_index_t test_index_2_buckets_count_42 = test_key_2_hash % bucke
     hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)]
 
 #define HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value) \
-    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index] = \
-        (hash >> 32u) | 0x80000000; \
+    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].quarter_hash = \
+        (hash >> 32u) & 0xFFFFu; \
+    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].distance = 0; \
+    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].filled = true; \
     HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).data = value;
 
 #define HASHTABLE_SET_KEY_INLINE_BY_INDEX(chunk_index, chunk_slot_index, hash, key, key_size, value) \

--- a/tests/test-hashtable-data.cpp
+++ b/tests/test-hashtable-data.cpp
@@ -25,7 +25,7 @@ TEST_CASE("hashtable/hashtable_data.c", "[hashtable][hashtable_data]") {
                         hashtable_chunk_slot_index_t chunk_slot_index = 0;
                         chunk_slot_index < HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT;
                         chunk_slot_index++) {
-                    REQUIRE(hashtable_data->half_hashes_chunk[chunk_index].half_hashes[chunk_slot_index] == 0);
+                    REQUIRE(hashtable_data->half_hashes_chunk[chunk_index].half_hashes[chunk_slot_index].slot_id == 0);
                 }
             }
 

--- a/tests/test-hashtable-op-delete.cpp
+++ b/tests/test-hashtable-op-delete.cpp
@@ -44,7 +44,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_1_len,
                         test_value_1));
 
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == test_key_1_hash_half);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags != HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
                 REQUIRE(hashtable_op_delete(
@@ -52,7 +52,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_1,
                         test_key_1_len));
 
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
             })
         }
@@ -75,7 +75,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_1_len,
                         test_value_1));
 
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == test_key_1_hash_half);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags != HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
                 REQUIRE(hashtable_op_delete(
@@ -83,7 +83,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_1,
                         test_key_1_len));
 
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
                 REQUIRE(hashtable_op_set(
@@ -92,7 +92,9 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_1_len,
                         test_value_1));
 
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == test_key_1_hash_half);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags != HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
                 REQUIRE(hashtable_op_delete(
@@ -100,7 +102,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_1,
                         test_key_1_len));
 
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
             })
         }
@@ -137,7 +139,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                 hashtable_key_value_volatile_t * key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index_base, random_slot_index)];
 
-                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
                 REQUIRE(key_value->data == test_value_1 + random_slot_index);
 
@@ -177,7 +179,7 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                 hashtable_key_value_volatile_t * key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index_base, random_slot_index)];
 
-                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
                 REQUIRE(key_value->data == test_value_1 + random_slot_index);
 
@@ -187,8 +189,10 @@ TEST_CASE("hashtable/hashtable_op_delete.c", "[hashtable][hashtable_op][hashtabl
                         test_key_same_bucket[slots_to_fill - 1].key_len,
                         test_value_1 + slots_to_fill - 1));
 
-                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index] ==
-                    test_key_same_bucket[slots_to_fill - 1].key_hash_half);
+                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index].filled == true);
+                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index].distance == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[random_slot_index].quarter_hash ==
+                        test_key_same_bucket[slots_to_fill - 1].key_hash_quarter);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_FILLED);
                 REQUIRE(key_value->data == test_value_1 + slots_to_fill - 1);
 

--- a/tests/test-hashtable-op-get.cpp
+++ b/tests/test-hashtable-op-get.cpp
@@ -193,6 +193,7 @@ TEST_CASE("hashtable/hashtable_op_get.c", "[hashtable][hashtable_op][hashtable_o
                 hashtable->ht_current->half_hashes_chunk[chunk_index_base].metadata.overflowed_chunks_counter =
                         ceil((double)slots_to_fill / HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT);
 
+
                 for(hashtable_chunk_slot_index_t i = 0; i < slots_to_fill; i++) {
                     hashtable_chunk_index_t chunk_index =
                             chunk_index_base + (int)(i / HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT);
@@ -206,6 +207,8 @@ TEST_CASE("hashtable/hashtable_op_get.c", "[hashtable][hashtable_op][hashtable_o
                             test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i);
+                    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].distance =
+                            chunk_index - chunk_index_base;
                 }
 
                 for(hashtable_chunk_slot_index_t i = 0; i < slots_to_fill; i++) {

--- a/tests/test-hashtable-op-set.cpp
+++ b/tests/test-hashtable-op-set.cpp
@@ -4,6 +4,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "misc.h"
+#include "log.h"
 
 #include "hashtable/hashtable.h"
 #include "hashtable/hashtable_config.h"
@@ -22,7 +24,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_key_1_hash));
                 hashtable_chunk_slot_index_t chunk_slot_index = 0;
 
-                hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk =
+                hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk =
                         &hashtable->ht_current->half_hashes_chunk[chunk_index];
                 hashtable_key_value_volatile_t * key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
@@ -38,7 +40,9 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
 
                 // Check if the first slot of the chain ring contains the correct key/value
                 REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == test_key_1_hash_half);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags ==
                         (HASHTABLE_KEY_VALUE_FLAG_FILLED | HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE));
                 REQUIRE(strncmp(
@@ -48,7 +52,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                 REQUIRE(key_value->data == test_value_1);
 
                 // Check if the subsequent element has been affected by the changes
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index + 1] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index + 1].slot_id == 0);
             })
         }
 
@@ -59,7 +63,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_key_1_hash));
                 hashtable_chunk_slot_index_t chunk_slot_index = 0;
 
-                hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk =
+                hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk =
                         &hashtable->ht_current->half_hashes_chunk[chunk_index];
                 hashtable_key_value_volatile_t * key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
@@ -77,7 +81,9 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_value_1 + 1));
                 // Check if the first slot of the chain ring contains the correct key/value
                 REQUIRE(half_hashes_chunk->metadata.changes_counter == 2);
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == test_key_1_hash_half);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags ==
                         (HASHTABLE_KEY_VALUE_FLAG_FILLED | HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE));
                 REQUIRE(strncmp(
@@ -87,7 +93,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                 REQUIRE(key_value->data == test_value_1 + 1);
 
                 // Check if the subsequent element has been affected by the changes
-                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index + 1] == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index + 1].slot_id == 0);
             })
         }
 
@@ -98,7 +104,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_key_1_hash));
                 hashtable_chunk_slot_index_t chunk_slot_index1 = 0;
 
-                hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk1 =
+                hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk1 =
                         &hashtable->ht_current->half_hashes_chunk[chunk_index1];
                 hashtable_key_value_volatile_t * key_value1 =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index1, chunk_slot_index1)];
@@ -109,7 +115,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_key_2_hash));
                 hashtable_chunk_slot_index_t chunk_slot_index2 = 0;
 
-                hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk2 =
+                hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk2 =
                         &hashtable->ht_current->half_hashes_chunk[chunk_index2];
                 hashtable_key_value_volatile_t * key_value2 =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index2, chunk_slot_index2)];
@@ -127,7 +133,9 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         test_value_2));
 
                 // Check the first set
-                REQUIRE(half_hashes_chunk1->half_hashes[chunk_slot_index1] == test_key_1_hash_half);
+                REQUIRE(half_hashes_chunk1->half_hashes[chunk_slot_index1].filled == true);
+                REQUIRE(half_hashes_chunk1->half_hashes[chunk_slot_index1].distance == 0);
+                REQUIRE(half_hashes_chunk1->half_hashes[chunk_slot_index1].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value1->flags ==
                         (HASHTABLE_KEY_VALUE_FLAG_FILLED | HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE));
                 REQUIRE(strncmp(
@@ -137,7 +145,9 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                 REQUIRE(key_value1->data == test_value_1);
 
                 // Check the second set
-                REQUIRE(half_hashes_chunk2->half_hashes[chunk_slot_index2] == test_key_2_hash_half);
+                REQUIRE(half_hashes_chunk2->half_hashes[chunk_slot_index2].filled == true);
+                REQUIRE(half_hashes_chunk2->half_hashes[chunk_slot_index2].distance == 0);
+                REQUIRE(half_hashes_chunk2->half_hashes[chunk_slot_index2].quarter_hash == test_key_2_hash_quarter);
                 REQUIRE(key_value2->flags ==
                         (HASHTABLE_KEY_VALUE_FLAG_FILLED | HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE));
                 REQUIRE(strncmp(
@@ -151,7 +161,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
         SECTION("fill entire half hashes chunk - key with same prefix - key not inline") {
             HASHTABLE(0x7FFF, false, {
                 hashtable_chunk_slot_index_t slots_to_fill = HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT;
-                test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
@@ -170,12 +180,14 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                                 test_key_same_bucket[0].key_hash));
 
                 for(hashtable_chunk_index_t i = 0; i < slots_to_fill; i++) {
-                    hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk =
+                    hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk =
                             &hashtable->ht_current->half_hashes_chunk[chunk_index_base];
                     hashtable_key_value_volatile_t * key_value =
                             &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index_base, i)];
 
-                    REQUIRE(half_hashes_chunk->half_hashes[i] == test_key_same_bucket[i].key_hash_half);
+                    REQUIRE(half_hashes_chunk->half_hashes[i].filled == true);
+                    REQUIRE(half_hashes_chunk->half_hashes[i].distance == 0);
+                    REQUIRE(half_hashes_chunk->half_hashes[i].quarter_hash == test_key_same_bucket[i].key_hash_quarter);
                     REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_FILLED);
 
                     REQUIRE(strncmp(
@@ -195,7 +207,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                 hashtable_chunk_count_t chunks_to_overflow = 3;
                 hashtable_chunk_slot_index_t slots_to_fill =
                         (HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT * chunks_to_overflow) + 3;
-                test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
@@ -213,19 +225,27 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                                 hashtable->ht_current->buckets_count,
                                 test_key_same_bucket[0].key_hash));
 
+                LOG_DI("chunk_index_base = %lu", chunk_index_base);
                 for(uint32_t i = 0; i < slots_to_fill; i++) {
                     hashtable_chunk_index_t chunk_index =
                             chunk_index_base + (int)(i / HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT);
                     hashtable_chunk_slot_index_t chunk_slot_index =
                             i % HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT;
 
-                    hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk =
+                    hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk =
                             &hashtable->ht_current->half_hashes_chunk[chunk_index];
 
-                    hashtable_key_value_volatile_t * key_value =
+                    hashtable_key_value_volatile_t *key_value =
                             &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
-                    REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index] == test_key_same_bucket[i].key_hash_half);
+                    LOG_DI("chunk_index = %lu", chunk_index);
+                    LOG_DI("chunk_slot_index = %lu", chunk_slot_index);
+                    LOG_DI("slot_id_wrapper.filled = %lu", half_hashes_chunk->half_hashes[chunk_slot_index].filled);
+                    LOG_DI("slot_id_wrapper.distance = %lu", half_hashes_chunk->half_hashes[chunk_slot_index].distance);
+                    LOG_DI("slot_id_wrapper.quarter_hash = %lu", half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash);
+                    REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
+                    REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == chunk_index - chunk_index_base);
+                    REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_same_bucket[i].key_hash_quarter);
                     REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_FILLED);
 
                     REQUIRE(strncmp(
@@ -245,7 +265,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                 hashtable_chunk_count_t chunks_to_overflow = 3;
                 hashtable_chunk_slot_index_t slots_to_fill =
                         (HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT * chunks_to_overflow) + 3;
-                test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
@@ -262,7 +282,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket[0].key_hash));
 
-                hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk =
+                hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk =
                         &hashtable->ht_current->half_hashes_chunk[chunk_index];
                 REQUIRE(half_hashes_chunk->metadata.overflowed_chunks_counter == chunks_to_overflow);
 
@@ -273,7 +293,7 @@ TEST_CASE("hashtable/hashtable_op_set.c", "[hashtable][hashtable_op][hashtable_o
         SECTION("fill entire hashtable and fail") {
             HASHTABLE(0x7F, false, {
                 uint32_t slots_to_fill = 448 + 1;
-                test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);

--- a/tests/test-support.c
+++ b/tests/test-support.c
@@ -101,7 +101,7 @@ void test_support_hashtable_print_heatmap(
                 hashtable_chunk_slot_index_t chunk_slot_index = 0;
                 chunk_slot_index < HASHTABLE_HALF_HASHES_CHUNK_SLOTS_COUNT;
                 chunk_slot_index++) {
-            if (ht_data->half_hashes_chunk[chunk_index].half_hashes[chunk_slot_index] == 0) {
+            if (ht_data->half_hashes_chunk[chunk_index].half_hashes[chunk_slot_index].slot_id == 0) {
                 continue;
             }
             slots_used++;
@@ -231,7 +231,9 @@ test_key_same_bucket_t* test_support_same_hash_mod_fixtures_generate(
             test_key_same_bucket_fixtures[matches_counter].key_len = strlen(key_test);
             test_key_same_bucket_fixtures[matches_counter].key_hash = hash_test;
             test_key_same_bucket_fixtures[matches_counter].key_hash_half =
-                    hashtable_support_hash_half(hash_test) | 0x80000000;
+                    hashtable_support_hash_half(hash_test);
+            test_key_same_bucket_fixtures[matches_counter].key_hash_quarter =
+                    hashtable_support_hash_quarter(hashtable_support_hash_half(hash_test));
 
             matches_counter++;
 

--- a/tests/test-support.h
+++ b/tests/test-support.h
@@ -35,6 +35,7 @@ struct test_key_same_bucket {
     hashtable_key_size_t key_len;
     hashtable_hash_t key_hash;
     hashtable_hash_half_t key_hash_half;
+    hashtable_hash_quarter_t key_hash_quarter;
 };
 
 typedef struct keyset_generator_thread_info keyset_generator_thread_info_t;


### PR DESCRIPTION
This PR implements the necessary changes to keep track of the distance when inserting the hashes into the slots.

The change itself reduce the hash from 32bit to 16bit inside the single slots but this is not impacting the distribution because the 64bit version of the hash is still used to decide the initial place of the hash.
In addition, the search algorithm takes care of including the expected distance while searching the 16bit version of the hash to reduce the possible collisions.

Even filling the whole search line, composed by 32 chunks, 14 hashes per chunk, only 448 hashes may be stored so the is still extremely low infact no slow down came out after running the benchmarks several time up to hashtables of 133mln of elements (the testing was stopped there for a matter of time).

These changes are the base to be able to implement the compaction algorithm upon deletion to entirely avoid tombstones.