### PR TITLE
Improve hash_crc32c testing

### DIFF
--- a/tests/hash/test-hash-crc32c.cpp
+++ b/tests/hash/test-hash-crc32c.cpp
@@ -1,15 +1,29 @@
-#include "catch.hpp"
+#include "../catch.hpp"
 
 #include "misc.h"
 #include "hash/hash_crc32c.h"
 
 char test_key_1[] = "test key 1";
 size_t test_key_1_len = 10;
+char test_key_2[26076];
+size_t test_key_2_len = 26076;
 
 #define TEST_HASH_CRC32C_PLATFORM_DEPENDENT(SUFFIX) \
+    for(size_t i = 0; i < test_key_2_len; i++) { \
+        test_key_2[i] = i & 0xFF; \
+    } \
     SECTION("hash_crc32c" STRINGIZE(SUFFIX)) { \
-        SECTION("valid crc32") { \
+        SECTION("valid crc32 - short key - aligned") { \
             REQUIRE(hash_crc32c##SUFFIX(test_key_1, test_key_1_len, 0x0000002AU) == 184302627); \
+        } \
+        SECTION("valid crc32 - short key - unaligned") { \
+            REQUIRE(hash_crc32c##SUFFIX(test_key_1 + 1, test_key_1_len - 2, 0x0000002AU) == 1263559083); \
+        } \
+        SECTION("valid crc32 - long key - aligned") { \
+            REQUIRE(hash_crc32c##SUFFIX(test_key_2, test_key_2_len, 0x0000002AU) == 1418798321); \
+        } \
+        SECTION("valid crc32 - long key - unaligned") { \
+            REQUIRE(hash_crc32c##SUFFIX(test_key_2 + 1, test_key_2_len - 2, 0x0000002AU) == 90191070); \
         } \
         SECTION("seed 0") { \
             REQUIRE(hash_crc32c##SUFFIX(test_key_1, test_key_1_len, 0x00000000U) == 3252784223); \


### PR DESCRIPTION
This PR contains a number of fixes and general improvements to the testing of hash_crc32c:
- the code has been moved into a subfolder to match the source folders structure
- has been added testing for long buffers
- has been added testing for unaligned buffers