### PR TITLE
Update the todo list in the README.md for the v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Here the general grand-plan:
             - [ ] ITERATE
             - [ ] DELETE, when deleting move back the far-est key of the chunk usind the distance
     - [ ] Networking
+        - [ ] Add support for workers that do not rely on SO_REUSEPORT (it's Linux only and performance costly)
         - [ ] Switch to use the SLAB allocator
     - [ ] Storage:
         - [ ] Implement garbage collection


### PR DESCRIPTION
After extensive testing I have noticed that SO_REUSEPORT, when running multiple listeners on the same port, literally is twice slower. To drop being dependant on it (and linux) and improve the performances with a very specific application for our context (instead of the general implementation behind that flag) the todo list in the README.md for the v0.2 has been updated to include a new component to avoid using SO_REUSEPORT.