### PR TITLE
Add previously existing build and test workflow back to the repository

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,63 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "Ubuntu Latest",
+            os: ubuntu-latest,
+            triplet: x64-linux,
+            cc: "gcc",
+            cxx: "g++"
+          }
+
+    steps:
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{github.workspace}}/build
+
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: CC=/usr/bin/gcc-9 CXX=/usr/bin/g++-9 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASHTABLE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
+
+      - name: Build All
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: cmake --build . --target cachegrand-tests -- -j 4
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: tests/cachegrand-tests
+
+      - name: Code Coverage - Generation
+        uses: danielealbano/lcov-action@v2
+        with:
+          remove_patterns: 3rdparty,tests
+
+      - name: Code Coverage - Upload to codecov.io
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: bash <(curl -s https://codecov.io/bash) -X gcov -Z -f coverage.info


### PR DESCRIPTION
This PR contains a workflow for GitHub to build and test cachegrand on pushes onto master and pull requests.

This is not a new workflow, it had been removed for the past migration to GitLab and this PR is just adding it back to the repository to switch back to GitHub.