### PR TITLE
Update the workflow to try to get at least 200 2MB hugepages free

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
+      - name: Ensure 200 2MB Hugepages free (required for comprehensive testing)
+        shell: bash
+        timeout-minutes: 5
+        run: while [ $(cat /proc/meminfo | grep HugePages_Free | awk '{ printf $2 }') -lt 200 ]; do echo "Requesting 256 2MB hugepages"; echo 250 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages; cat /proc/meminfo | grep HugePages_; done
+
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This PR add a step to the **Build & Test** workflow to try to get at least 200 2MB hugepages free.

The logic in the step is pretty simple and can cause an infinite loop therefore the timeout for the step is set to 5 minutes to ensure it will be killed if it will not be possible to allocate the requested hugepages.

The step is actually requesting 250 and not 200 2MB hugepages free as there is no safe/easy way to ensure that the amount of 200 will actually be free when the test will start so an extra 50 are being requested for padding.

Enabling the hugepages during the test phase will allow a number of branches of the code to be tested as they are dependent on it and it's not possible to test them without the hugepages.