### PR TITLE
Set fetch-depth to 2 to let codecov properly identify the commit

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-dept: 2
 
       - name: Install required dependencies
         run: sudo apt-get install -y build-essential cmake pkg-config git libssl1.1 libssl-dev libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev


### PR DESCRIPTION
This PR contains a simple fix for the build pipeline to sort out a warning reported by codecov, the code coverage upload script has an hard time properly detecting the commit sha of the build and it's suggesting to enforce it to 0 or set it to a value greater than 2.