### PR TITLE
Issue 72 - Remove the "connection" timeout from the config file, it's unsupported

### DIFF
--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -24,7 +24,6 @@ network:
   protocols:
     - type: redis
       timeout:
-        connection: 2000
         read: 2000
         write: 2000
         inactivity: 2000


### PR DESCRIPTION
This PR drops the `connection` timeout from the skel config file as it's unsupported and causes an error when cachegrand starts with the default configuration.