### PR TITLE
Issue 76 - Code coverage on spinlock.c changes randomly as an if can't easily be specifically triggered

### DIFF
--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -113,6 +113,8 @@ bool spinlock_lock_internal(
         // TODO: implement spinlock auto balancing using the predicted_spins property of the lock struct
 
         if (spins == UINT32_MAX) {
+            spinlock_set_flag(spinlock, SPINLOCK_FLAG_POTENTIALLY_STUCK);
+
             LOG_E(TAG, "Possible stuck spinlock detected for thread %lu in %s at %s:%u",
                     pthread_self(), src_func, src_path, src_line);
         }

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -38,9 +38,11 @@ void spinlock_unlock(
         spinlock_lock_volatile_t* spinlock) {
 #if DEBUG == 1
     long thread_id = syscall(__NR_gettid);
-    assert(spinlock->lock == (uint16_t)thread_id);
+    uint8_t expected_lock = (uint8_t)thread_id;
+    assert(spinlock->lock == expected_lock);
 #endif
 
+    spinlock->flags = 0;
     spinlock->lock = SPINLOCK_UNLOCKED;
     MEMORY_FENCE_STORE();
 }
@@ -55,8 +57,8 @@ bool spinlock_try_lock(
         spinlock_lock_volatile_t *spinlock) {
 #if DEBUG == 1
     long thread_id = syscall(__NR_gettid);
-    uint16_t new_value = thread_id;
-    uint16_t expected_value = SPINLOCK_UNLOCKED;
+    uint8_t new_value = thread_id;
+    uint8_t expected_value = SPINLOCK_UNLOCKED;
 #else
     uint8_t new_value = SPINLOCK_LOCKED;
     uint8_t expected_value = SPINLOCK_UNLOCKED;

--- a/src/spinlock.h
+++ b/src/spinlock.h
@@ -10,19 +10,16 @@ extern "C" {
 #define SPINLOCK_UNLOCKED   0
 #define SPINLOCK_LOCKED     1
 
-#if DEBUG == 1
-#define SPINLOCK_MAGIC      42
-#endif
+#define SPINLOCK_FLAG_POTENTIALLY_STUCK     0x01
+
+typedef uint8_t spinlock_flag_t;
+typedef _Volatile(uint8_t) spinlock_flag_volatile_t;
 
 typedef struct spinlock_lock spinlock_lock_t;
 typedef _Volatile(spinlock_lock_t) spinlock_lock_volatile_t;
 struct spinlock_lock {
-#if DEBUG == 1
-    uint16_volatile_t lock;
-#else
     uint8_volatile_t lock;
-    uint8_t padding;
-#endif
+    spinlock_flag_volatile_t flags;
     uint16_t predicted_spins;
 } __attribute__((aligned(4)));
 

--- a/src/spinlock.h
+++ b/src/spinlock.h
@@ -51,11 +51,6 @@ void spinlock_unlock(
 #define spinlock_lock(spinlock, retry) \
     spinlock_lock_internal(spinlock, retry, CACHEGRAND_SRC_PATH, __func__, __LINE__)
 
-#define spinlock_section(spinlock, ...) \
-    spinlock_lock(spinlock, true); \
-    __VA_ARGS__ \
-    spinlock_unlock(spinlock);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/spinlock.h
+++ b/src/spinlock.h
@@ -42,6 +42,18 @@ bool spinlock_lock_internal(
 void spinlock_unlock(
         spinlock_lock_volatile_t* spinlock);
 
+void spinlock_set_flag(
+        spinlock_lock_volatile_t *spinlock,
+        spinlock_flag_t flag);
+
+bool spinlock_unset_flag(
+        spinlock_lock_volatile_t *spinlock,
+        spinlock_flag_t flag);
+
+bool spinlock_has_flag(
+        spinlock_lock_volatile_t *spinlock,
+        spinlock_flag_t flag);
+
 /**
  * Uses a macro to wrap _spinlock_lock to automatically define the path, func and line args
  */

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -33,7 +33,7 @@ void* test_spinlock_lock_lock_retry_try_lock_thread_func(void* rawdata) {
     }
 }
 
-// Increments a number a number of times using the spinlock for each increment
+// Increments a number of times using the spinlock for each increment
 struct test_spinlock_lock_counter_thread_func_data {
     uint8_t* start_flag;
     uint32_t thread_num;

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -215,7 +215,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
             uint32_t threads_count = cores_count * 2;
 
             // Magic numbers to run enough thread in parallel for 1-2s after the thread creation.
-            // The test can be quite time consuming when with an attached debugger.
+            // The test can be quite time-consuming when with an attached debugger.
             increments_per_thread = (uint64_t)(20000 /  ((float)threads_count / 48.0));
 
             REQUIRE(pthread_attr_init(&attr) == 0);

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -90,7 +90,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
             REQUIRE(spinlock_try_lock(&lock));
 #if DEBUG == 1
             long thread_id = syscall(__NR_gettid);
-            REQUIRE(lock.lock == (uint16_t)thread_id);
+            REQUIRE(lock.lock == (uint8_t)thread_id);
 #else
             REQUIRE(lock.lock == SPINLOCK_LOCKED);
 #endif
@@ -133,7 +133,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
 
 #if DEBUG == 1
             long thread_id = syscall(__NR_gettid);
-            REQUIRE(lock.lock == (uint16_t)thread_id);
+            REQUIRE(lock.lock == (uint8_t)thread_id);
 #else
             REQUIRE(lock.lock == SPINLOCK_LOCKED);
 #endif
@@ -149,7 +149,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
 
 #if DEBUG == 1
             long thread_id = syscall(__NR_gettid);
-            REQUIRE(lock.lock == (uint16_t)thread_id);
+            REQUIRE(lock.lock == (uint8_t)thread_id);
 #else
             REQUIRE(lock.lock == SPINLOCK_LOCKED);
 #endif
@@ -173,7 +173,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
 
 #if DEBUG == 1
             long thread_id = syscall(__NR_gettid);
-            REQUIRE(lock.lock == (uint16_t)thread_id);
+            REQUIRE(lock.lock == (uint8_t)thread_id);
 #else
             REQUIRE(lock.lock == SPINLOCK_LOCKED);
 #endif

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -18,7 +18,7 @@ using namespace std;
 
 // Returns 1 if it can do the initial lock, 2 instead if it's able to reach the point in which has
 // to wait for the spinlock to become free
-void* test_spinlock_lock__lock_retry_try_lock_thread_func(void* rawdata) {
+void* test_spinlock_lock_lock_retry_try_lock_thread_func(void* rawdata) {
     spinlock_lock_t* lock = (spinlock_lock_t*)rawdata;
     if (spinlock_lock(lock, false)) {
         return (void*)1;
@@ -34,7 +34,7 @@ void* test_spinlock_lock__lock_retry_try_lock_thread_func(void* rawdata) {
 }
 
 // Increments a number a number of times using the spinlock for each increment
-struct test_spinlock_lock__counter_thread_func_data {
+struct test_spinlock_lock_counter_thread_func_data {
     uint8_t* start_flag;
     uint32_t thread_num;
     pthread_t thread_id;
@@ -42,9 +42,9 @@ struct test_spinlock_lock__counter_thread_func_data {
     uint64_t increments;
     uint64_t* counter;
 };
-void* test_spinlock_lock__counter_thread_func(void* rawdata) {
-    struct test_spinlock_lock__counter_thread_func_data* data =
-            (struct test_spinlock_lock__counter_thread_func_data*)rawdata;
+void* test_spinlock_lock_counter_thread_func(void* rawdata) {
+    struct test_spinlock_lock_counter_thread_func_data* data =
+            (struct test_spinlock_lock_counter_thread_func_data*)rawdata;
 
     thread_current_set_affinity(data->thread_num);
 
@@ -179,7 +179,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
 #endif
 
             // Create the thread that wait for unlock
-            res = pthread_create(&pthread, &attr, &test_spinlock_lock__lock_retry_try_lock_thread_func, (void*)&lock);
+            res = pthread_create(&pthread, &attr, &test_spinlock_lock_lock_retry_try_lock_thread_func, (void*)&lock);
             if (res != 0) {
                 perror("pthread_create");
             }
@@ -220,10 +220,10 @@ TEST_CASE("spinlock.c", "[spinlock]") {
 
             REQUIRE(pthread_attr_init(&attr) == 0);
 
-            struct test_spinlock_lock__counter_thread_func_data* threads_info =
-                    (struct test_spinlock_lock__counter_thread_func_data*)calloc(
+            struct test_spinlock_lock_counter_thread_func_data* threads_info =
+                    (struct test_spinlock_lock_counter_thread_func_data*)calloc(
                             threads_count,
-                            sizeof(test_spinlock_lock__counter_thread_func_data));
+                            sizeof(test_spinlock_lock_counter_thread_func_data));
 
             REQUIRE(threads_info != NULL);
 
@@ -239,7 +239,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
                 REQUIRE(pthread_create(
                         &threads_info[thread_num].thread_id,
                         &attr,
-                        &test_spinlock_lock__counter_thread_func,
+                        &test_spinlock_lock_counter_thread_func,
                         &threads_info[thread_num]) == 0);
             }
 

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -12,9 +12,9 @@ using namespace std;
 
 #include "exttypes.h"
 #include "memory_fences.h"
-#include "spinlock.h"
 #include "utils_cpu.h"
 #include "thread.h"
+#include "spinlock.h"
 
 // Returns 1 if it can do the initial lock, 2 instead if it's able to reach the point in which has
 // to wait for the spinlock to become free

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -345,4 +345,73 @@ TEST_CASE("spinlock.c", "[spinlock]") {
             free(threads_info);
         }
     }
+
+    SECTION("spinlock_set_flag") {
+        SECTION("one flag") {
+            spinlock_lock_volatile_t lock = { 0 };
+
+            spinlock_set_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK);
+
+            REQUIRE(lock.flags == SPINLOCK_FLAG_POTENTIALLY_STUCK);
+        }
+
+        SECTION("two flag") {
+            spinlock_lock_volatile_t lock = { 0 };
+
+            spinlock_set_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK);
+
+            // This flag currently doesn't exist, it's just to test the code
+            spinlock_set_flag(&lock, 0x04);
+
+            REQUIRE(lock.flags == (SPINLOCK_FLAG_POTENTIALLY_STUCK | 0x04));
+        }
+    }
+
+    SECTION("spinlock_unset_flag") {
+        SECTION("one flag") {
+            spinlock_lock_volatile_t lock = { 0 };
+            lock.flags = SPINLOCK_FLAG_POTENTIALLY_STUCK;
+
+            spinlock_unset_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK);
+
+            REQUIRE(lock.flags == 0);
+        }
+
+        SECTION("two flag") {
+            spinlock_lock_volatile_t lock = { 0 };
+            lock.flags = SPINLOCK_FLAG_POTENTIALLY_STUCK | 0x04;
+
+            spinlock_unset_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK);
+
+            REQUIRE(lock.flags == 0x04);
+        }
+    }
+
+    SECTION("spinlock_has_flag") {
+        SECTION("one flag") {
+            spinlock_lock_volatile_t lock = { 0 };
+            lock.flags = SPINLOCK_FLAG_POTENTIALLY_STUCK;
+            REQUIRE(spinlock_has_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK));
+        }
+
+        SECTION("two flag") {
+            spinlock_lock_volatile_t lock = { 0 };
+            lock.flags = SPINLOCK_FLAG_POTENTIALLY_STUCK | 0x04;
+            REQUIRE(spinlock_has_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK));
+            REQUIRE(spinlock_has_flag(&lock, 0x04));
+        }
+
+        SECTION("non existent flag without other flags set") {
+            spinlock_lock_volatile_t lock = { 0 };
+            REQUIRE(spinlock_has_flag(&lock, 0x08) == false);
+        }
+
+        SECTION("non existent flag with other flags set") {
+            spinlock_lock_volatile_t lock = { 0 };
+            lock.flags = SPINLOCK_FLAG_POTENTIALLY_STUCK | 0x04;
+            REQUIRE(spinlock_has_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK));
+            REQUIRE(spinlock_has_flag(&lock, 0x04));
+            REQUIRE(spinlock_has_flag(&lock, 0x08) == false);
+        }
+    }
 }

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -331,6 +331,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
             start_flag = true;
             MEMORY_FENCE_STORE();
 
+            // TODO: should implement a timeout
             do {
                 MEMORY_FENCE_LOAD();
             } while (!spinlock_has_flag(&lock, SPINLOCK_FLAG_POTENTIALLY_STUCK));

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -38,7 +38,7 @@ struct test_spinlock_lock_counter_thread_func_data {
     uint8_t* start_flag;
     uint32_t thread_num;
     pthread_t thread_id;
-    spinlock_lock_t* lock;
+    spinlock_lock_volatile_t* lock;
     uint64_t increments;
     uint64_t* counter;
 };
@@ -207,7 +207,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
         SECTION("test lock parallelism") {
             void* ret;
             uint8_t start_flag;
-            spinlock_lock_t lock = { 0 };
+            spinlock_lock_volatile_t lock = { 0 };
             pthread_attr_t attr;
             uint64_t increments_per_thread_sum = 0, increments_per_thread;
 


### PR DESCRIPTION
This PR contains a number of changes aiming to improve spinlock testing, introducing testing for the possible spinlock stuck detection mechanism and also improving a number of additional small things:
- avoid having structs with different sizes between debug and release builds
- add some compiler barriers (using volatile) to ensure that the compiler doesn't assume that the spinlock pointer value can be hardcoded, not really needed but better to have it
- looking forward to future improvements, introduce a flags bitset field for the spinlock, currently used only to mark the spinlock as possibly stuck

Closes #76 
