### PR TITLE
Issue 71 - Honor the pidfile_path setting

### DIFF
--- a/src/config_cyaml_schema.c
+++ b/src/config_cyaml_schema.c
@@ -261,7 +261,7 @@ const cyaml_schema_field_t config_fields_schema[] = {
                 config_t, run_in_foreground),
         CYAML_FIELD_STRING_PTR(
                 "pidfile_path", CYAML_FLAG_POINTER,
-                config_t, pidfile_path, 0, CYAML_UNLIMITED),
+                config_t, pidfile_path, 0, CYAML_UNLIMITED | CYAML_FLAG_OPTIONAL),
         CYAML_FIELD_BOOL_PTR(
                 "use_slab_allocator", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
                 config_t, use_slab_allocator),

--- a/src/hugepages.c
+++ b/src/hugepages.c
@@ -18,71 +18,17 @@
 
 #include "misc.h"
 #include "log/log.h"
+#include "support/simple_file_io.h"
 
 #include "hugepages.h"
 
 #define TAG "hugepages"
 
-bool hugepages_file_read(
-        const char* path,
-        char* out_data,
-        size_t out_data_len) {
-    int fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        LOG_W(TAG, "Unable to open %s: %s", path, strerror(errno));
-        return false;
-    }
-
-    size_t len = read(fd, out_data, out_data_len);
-    int read_errno = errno;
-    close(fd);
-
-    if (len < 0) {
-        LOG_W(TAG, "Error while reading from %s: %s", path, strerror(read_errno));
-        return false;
-    }
-
-    out_data[len] = '\0';
-
-    return true;
-}
-
-bool hugepages_file_read_uint32(
-        const char* path,
-        uint32_t* out_data) {
-    char* remaining_data;
-    char data[256] = { 0 };
-
-    if (!hugepages_file_read(path, data, sizeof(data))) {
-        return false;
-    }
-
-    *out_data = strtol(data, &remaining_data, 0);
-
-    // A new line is expected
-    if (*remaining_data != 0x0a || data == remaining_data) {
-        LOG_E(TAG, "Unable to read %s: invalid number", path);
-        return false;
-    }
-
-    return true;
-}
-
-uint32_t hugepages_file_path_uint32_return(
-        const char* path) {
-    uint32_t value;
-    if (!hugepages_file_read_uint32(path, &value)) {
-        return 0;
-    }
-
-    return value;
-}
-
 bool hugepages_2mb_is_available(
         int min_available) {
-    uint32_t nr_hugepages = hugepages_file_path_uint32_return(
+    uint32_t nr_hugepages = simple_file_io_read_uint32_return(
             HUGEPAGES_SYSFS_2MB_PATH HUGEPAGES_SYSFS_FREE_HUGEPAGES_FILENAME);
-    uint32_t resv_hugepages = hugepages_file_path_uint32_return(
+    uint32_t resv_hugepages = simple_file_io_read_uint32_return(
             HUGEPAGES_SYSFS_2MB_PATH HUGEPAGES_SYSFS_RESV_HUGEPAGES_FILENAME);
 
     return nr_hugepages - resv_hugepages > min_available;
@@ -90,10 +36,10 @@ bool hugepages_2mb_is_available(
 
 bool hugepages_1024mb_is_available(
         int min_available) {
-    uint32_t nr_hugepages = hugepages_file_path_uint32_return(
+    uint32_t nr_hugepages = simple_file_io_read_uint32_return(
             HUGEPAGES_SYSFS_1024MB_PATH HUGEPAGES_SYSFS_FREE_HUGEPAGES_FILENAME);
-    uint32_t resv_hugepages = hugepages_file_path_uint32_return(
-        HUGEPAGES_SYSFS_1024MB_PATH HUGEPAGES_SYSFS_RESV_HUGEPAGES_FILENAME);
+    uint32_t resv_hugepages = simple_file_io_read_uint32_return(
+            HUGEPAGES_SYSFS_1024MB_PATH HUGEPAGES_SYSFS_RESV_HUGEPAGES_FILENAME);
 
     return nr_hugepages - resv_hugepages > min_available;
 }

--- a/src/hugepages.h
+++ b/src/hugepages.h
@@ -15,18 +15,6 @@ extern "C" {
 #define HUGEPAGES_SYSFS_RESV_HUGEPAGES_FILENAME "resv_hugepages"
 #define HUGEPAGES_SYSFS_FREE_HUGEPAGES_FILENAME "free_hugepages"
 
-bool hugepages_file_read(
-        const char* path,
-        char* out_data,
-        size_t out_data_len);
-
-bool hugepages_file_read_uint32(
-        const char* path,
-        uint32_t* out_data);
-
-uint32_t hugepages_file_path_uint32_return(
-        const char* path);
-
 bool hugepages_2mb_is_available(
         int min_available);
 

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -84,11 +84,16 @@ bool pidfile_create(
     int fd;
 
     if ((fd = pidfile_open(pidfile_path)) < 0) {
-        FATAL(TAG, "Failed to open the pid file <%s>", pidfile_path);
+        LOG_E(TAG, "Failed to open the pid file <%s>", pidfile_path);
+        LOG_E_OS_ERROR(TAG);
+        return false;
     }
 
     if (!pidfile_request_close_on_exec(fd)) {
-        FATAL(TAG, "Failed to set the close-on-exec flag for the pid file <%s>", pidfile_path);
+        LOG_E(TAG, "Failed to set the close-on-exec flag for the pid file <%s>", pidfile_path);
+        LOG_E_OS_ERROR(TAG);
+        pidfile_close(fd);
+        return false;
     }
 
     if (!pidfile_request_lock(fd)) {
@@ -102,7 +107,10 @@ bool pidfile_create(
     }
 
     if (!pidfile_write_pid(fd, (long)getpid())) {
-        FATAL(TAG, "Failed write the pid to the pid file <%s>", pidfile_path);
+        LOG_E(TAG, "Failed write the pid to the pid file <%s>", pidfile_path);
+        LOG_E_OS_ERROR(TAG);
+        pidfile_close(fd);
+        return false;
     }
 
     pidfile_owned = true;

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2020-2021 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <sys/file.h>
+
+#include "misc.h"
+#include "log/log.h"
+#include "fatal.h"
+#include "support/simple_file_io.h"
+#include "pidfile.h"
+
+#define TAG "pidfile"
+
+bool pidfile_owned = false;
+int pidfile_fd = -1;
+
+bool pidfile_request_close_on_exec(
+        int fd) {
+    int flags;
+
+    if ((flags = fcntl(fd, F_GETFD)) == -1) {
+        return false;
+    }
+
+    flags |= FD_CLOEXEC;
+    if (fcntl(fd, F_SETFD, flags) == -1) {
+        return false;
+    }
+
+    return true;
+}
+
+bool pidfile_request_lock(
+        int fd) {
+    struct flock lock = { 0 };
+
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    if (fcntl(fd, F_SETLK, &lock) == -1) {
+        return false;
+    }
+
+    return true;
+}
+
+int pidfile_open(
+        const char* pidfile_path) {
+    return open(pidfile_path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+}
+
+bool pidfile_write_pid(
+        int fd,
+        long pid) {
+    char buf[64];
+
+    if (ftruncate(fd, 0) == -1) {
+        return false;
+    }
+
+    snprintf(buf, sizeof(buf) - 1, "%ld\n", pid);
+    if (write(fd, buf, strlen(buf)) != strlen(buf)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool pidfile_create(
+        const char* pidfile_path) {
+    int fd;
+
+    if ((fd = pidfile_open(pidfile_path)) < 0) {
+        FATAL(TAG, "Failed to open the pid file <%s>", pidfile_path);
+    }
+
+    if (!pidfile_request_close_on_exec(fd)) {
+        FATAL(TAG, "Failed to set the close-on-exec flag for the pid file <%s>", pidfile_path);
+    }
+
+    if (!pidfile_request_lock(fd)) {
+        LOG_E(
+                TAG,
+                "The pid file <%s> is owned by process id <%u>",
+                pidfile_path,
+                simple_file_io_read_uint32_return(pidfile_path));
+        pidfile_close(fd);
+        return false;
+    }
+
+    if (!pidfile_write_pid(fd, (long)getpid())) {
+        FATAL(TAG, "Failed write the pid to the pid file <%s>", pidfile_path);
+    }
+
+    pidfile_owned = true;
+    pidfile_fd = fd;
+
+    return true;
+}
+
+void pidfile_close(
+        int fd) {
+    close(fd);
+
+    pidfile_fd = -1;
+    pidfile_owned = false;
+}
+
+bool pidfile_is_owned() {
+    return pidfile_owned;
+}
+
+int pidfile_get_fd() {
+    return pidfile_fd;
+}

--- a/src/pidfile.h
+++ b/src/pidfile.h
@@ -1,0 +1,35 @@
+#ifndef CACHEGRAND_PIDFILE_H
+#define CACHEGRAND_PIDFILE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool pidfile_request_close_on_exec(
+        int fd);
+
+bool pidfile_request_lock(
+        int fd);
+
+int pidfile_open(
+        const char* pidfile_path);
+
+bool pidfile_write_pid(
+        int fd,
+        long pid);
+
+bool pidfile_create(
+        const char* pidfile_path);
+
+void pidfile_close(
+        int fd);
+
+bool pidfile_is_owned();
+
+int pidfile_get_fd();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_PIDFILE_H

--- a/src/pidfile.h
+++ b/src/pidfile.h
@@ -21,7 +21,7 @@ bool pidfile_write_pid(
 bool pidfile_create(
         const char* pidfile_path);
 
-void pidfile_close(
+bool pidfile_close(
         int fd);
 
 bool pidfile_is_owned();

--- a/src/program.c
+++ b/src/program.c
@@ -24,6 +24,7 @@
 #include "utils_numa.h"
 #include "exttypes.h"
 #include "xalloc.h"
+#include "pidfile.h"
 #include "log/log.h"
 #include "log/sink/log_sink.h"
 #include "log/sink/log_sink_console.h"
@@ -432,6 +433,15 @@ void program_setup_sentry(
     sentry_support_init(
             program_context.config->sentry->data_path,
             program_context.config->sentry->dsn);
+}
+
+bool program_setup_pidfile(
+        program_context_t program_context) {
+    if (program_context.config->pidfile_path == NULL) {
+        return true;
+    }
+
+    return pidfile_create(program_context.config->pidfile_path);
 }
 
 bool program_setup_ulimit_wrapper(

--- a/src/program.c
+++ b/src/program.c
@@ -523,6 +523,11 @@ void program_cleanup(
     }
 
     log_sink_registered_free();
+
+    if (pidfile_is_owned()) {
+        pidfile_close(pidfile_get_fd());
+    }
+
     sentry_support_shutdown();
 }
 
@@ -548,6 +553,11 @@ int program_main(
     }
 
     program_setup_sentry(program_context);
+
+    if (program_setup_pidfile(program_context) == false) {
+        program_cleanup(&program_context);
+        return 1;
+    }
 
     if (program_config_thread_affinity_set_selected_cpus(&program_context) == false) {
         LOG_E(TAG, "Unable to setup cpu affinity");

--- a/src/program.h
+++ b/src/program.h
@@ -42,6 +42,9 @@ void program_workers_cleanup(
         worker_context_t* worker_context,
         uint32_t workers_count);
 
+bool program_setup_pidfile(
+        program_context_t program_context);
+
 bool program_setup_ulimit_wrapper(
         __rlimit_resource_t resource,
         ulong value);

--- a/src/program.h
+++ b/src/program.h
@@ -58,6 +58,9 @@ bool program_setup_ulimit();
 bool program_config_thread_affinity_set_selected_cpus(
         program_context_t* program_context);
 
+void program_cleanup(
+        program_context_t* program_context);
+
 int program_main(
         int argc,
         char** argv);

--- a/src/support/simple_file_io.c
+++ b/src/support/simple_file_io.c
@@ -1,0 +1,71 @@
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "misc.h"
+#include "log/log.h"
+#include "fatal.h"
+#include "support/simple_file_io.h"
+
+#define TAG "support/simple_file_io"
+
+bool simple_file_io_read(
+        const char* path,
+        char* out_data,
+        size_t out_data_len) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        LOG_W(TAG, "Unable to open %s: %s", path, strerror(errno));
+        return false;
+    }
+
+    size_t len = read(fd, out_data, out_data_len);
+    int read_errno = errno;
+    close(fd);
+
+    if (len < 0) {
+        LOG_W(TAG, "Error while reading from %s: %s", path, strerror(read_errno));
+        return false;
+    }
+
+    out_data[len] = '\0';
+
+    return true;
+}
+
+bool simple_file_io_read_uint32(
+        const char* path,
+        uint32_t* out_data) {
+    char* remaining_data;
+    char data[256] = { 0 };
+
+    if (!simple_file_io_read(path, data, sizeof(data))) {
+        return false;
+    }
+
+    *out_data = strtol(data, &remaining_data, 0);
+
+    // A new line is expected
+    if (*remaining_data != 0x0a || data == remaining_data) {
+        LOG_E(TAG, "Unable to read %s: invalid number", path);
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t simple_file_io_read_uint32_return(
+        const char* path) {
+    uint32_t value;
+    if (!simple_file_io_read_uint32(path, &value)) {
+        return 0;
+    }
+
+    return value;
+}

--- a/src/support/simple_file_io.h
+++ b/src/support/simple_file_io.h
@@ -1,0 +1,24 @@
+#ifndef CACHEGRAND_SIMPLE_FILE_IO_H
+#define CACHEGRAND_SIMPLE_FILE_IO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool simple_file_io_read(
+        const char *path,
+        char *out_data,
+        size_t out_data_len);
+
+bool simple_file_io_read_uint32(
+        const char *path,
+        uint32_t *out_data);
+
+uint32_t simple_file_io_read_uint32_return(
+        const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_SIMPLE_FILE_IO_H

--- a/tests/support/test-simple-file-io.cpp
+++ b/tests/support/test-simple-file-io.cpp
@@ -87,6 +87,11 @@ TEST_CASE("support/simple_file_io.c", "[support][simple_file_io]") {
 
             REQUIRE(strcmp(buf, simple_file_io_fixture_data_invalid_no_newline_uint32_str) == 0);
         }
+
+        SECTION("invalid path") {
+            char buf[512];
+            REQUIRE(!simple_file_io_read("/non/existing/path/leading/nowhere", buf, sizeof(buf)));
+        }
     }
 
     SECTION("simple_file_io_read_uint32") {
@@ -141,6 +146,11 @@ TEST_CASE("support/simple_file_io.c", "[support][simple_file_io]") {
 
             REQUIRE(val == 0);
         }
+
+        SECTION("invalid path") {
+            uint32_t val;
+            REQUIRE(!simple_file_io_read_uint32("/non/existing/path/leading/nowhere", &val));
+        }
     }
 
     SECTION("simple_file_io_read_uint32_return") {
@@ -194,6 +204,10 @@ TEST_CASE("support/simple_file_io.c", "[support][simple_file_io]") {
                     });
 
             REQUIRE(val == 0);
+        }
+
+        SECTION("invalid path") {
+            REQUIRE(simple_file_io_read_uint32_return("/non/existing/path/leading/nowhere") == 0);
         }
     }
 }

--- a/tests/support/test-simple-file-io.cpp
+++ b/tests/support/test-simple-file-io.cpp
@@ -1,0 +1,199 @@
+#include <string.h>
+#include <catch2/catch.hpp>
+
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "support/simple_file_io.h"
+
+bool test_simple_file_io_fixture_file_from_data_create(
+        char* path,
+        int path_suffix_len,
+        const char* data,
+        size_t data_len) {
+
+    if (!mkstemps(path, path_suffix_len)) {
+        return false;
+    }
+
+    FILE* fp = fopen(path, "w");
+    if (fp == NULL) {
+        return false;
+    }
+
+    size_t res;
+    if ((res = fwrite(data, 1, data_len, fp)) != data_len) {
+        fclose(fp);
+        unlink(path);
+        return false;
+    }
+
+    if (fflush(fp) != 0) {
+        fclose(fp);
+        unlink(path);
+        return false;
+    }
+
+    fclose(fp);
+
+    return true;
+}
+
+void test_simple_file_io_fixture_file_from_data_cleanup(
+        const char* path) {
+    unlink(path);
+}
+
+#define TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(DATA, DATA_LEN, CONFIG_PATH, ...) { \
+    { \
+        char CONFIG_PATH[] = "/tmp/cachegrand-tests-XXXXXX.tmp"; \
+        int CONFIG_PATH_suffix_len = 4; /** .tmp **/ \
+        REQUIRE(test_simple_file_io_fixture_file_from_data_create(CONFIG_PATH, CONFIG_PATH_suffix_len, DATA, DATA_LEN)); \
+        __VA_ARGS__; \
+        test_simple_file_io_fixture_file_from_data_cleanup(CONFIG_PATH); \
+    } \
+}
+
+TEST_CASE("support/simple_file_io.c", "[support][simple_file_io]") {
+    const char* simple_file_io_fixture_data_invalid_no_newline_uint32_str = "12345";
+    const char* simple_file_io_fixture_data_invalid_only_newline_uint32_str = "\n";
+    const char* simple_file_io_fixture_data_invalid_empty_uint32_str = "";
+    const char* simple_file_io_fixture_data_valid_uint32_str = "12345\n";
+    uint32_t simple_file_io_fixture_data_valid_uint32 = 12345;
+
+    SECTION("simple_file_io_read") {
+        SECTION("valid number") {
+            char buf[512];
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_valid_uint32_str,
+                    strlen(simple_file_io_fixture_data_valid_uint32_str),
+                    uint32_file_path,
+                    {
+                        REQUIRE(simple_file_io_read(uint32_file_path, buf, sizeof(buf)));
+                    });
+
+            REQUIRE(strcmp(buf, simple_file_io_fixture_data_valid_uint32_str) == 0);
+        }
+
+        SECTION("invalid number - no newline") {
+            char buf[512];
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_no_newline_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_no_newline_uint32_str),
+                    uint32_file_path,
+                    {
+                        REQUIRE(simple_file_io_read(uint32_file_path, buf, sizeof(buf)));
+                    });
+
+            REQUIRE(strcmp(buf, simple_file_io_fixture_data_invalid_no_newline_uint32_str) == 0);
+        }
+    }
+
+    SECTION("simple_file_io_read_uint32") {
+        SECTION("valid number") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_valid_uint32_str,
+                    strlen(simple_file_io_fixture_data_valid_uint32_str),
+                    uint32_file_path,
+                    {
+                        REQUIRE(simple_file_io_read_uint32(uint32_file_path, &val));
+                    });
+
+            REQUIRE(val == simple_file_io_fixture_data_valid_uint32);
+        }
+
+        SECTION("invalid number - no newline") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_no_newline_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_no_newline_uint32_str),
+                    uint32_file_path,
+                    {
+                        REQUIRE(!simple_file_io_read_uint32(uint32_file_path, &val));
+                    });
+
+            REQUIRE(val == 12345);
+        }
+
+        SECTION("invalid number - only newline") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_only_newline_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_only_newline_uint32_str),
+                    uint32_file_path,
+                    {
+                        REQUIRE(!simple_file_io_read_uint32(uint32_file_path, &val));
+                    });
+
+            REQUIRE(val == 0);
+        }
+
+        SECTION("invalid number - empty") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_empty_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_empty_uint32_str),
+                    uint32_file_path,
+                    {
+                        REQUIRE(!simple_file_io_read_uint32(uint32_file_path, &val));
+                    });
+
+            REQUIRE(val == 0);
+        }
+    }
+
+    SECTION("simple_file_io_read_uint32_return") {
+        SECTION("valid number") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_valid_uint32_str,
+                    strlen(simple_file_io_fixture_data_valid_uint32_str),
+                    uint32_file_path,
+                    {
+                        val = simple_file_io_read_uint32_return(uint32_file_path);
+                    });
+
+            REQUIRE(val == simple_file_io_fixture_data_valid_uint32);
+        }
+
+        SECTION("invalid number - no newline") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_no_newline_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_no_newline_uint32_str),
+                    uint32_file_path,
+                    {
+                        val = simple_file_io_read_uint32_return(uint32_file_path);
+                    });
+
+            REQUIRE(val == 0);
+        }
+
+        SECTION("invalid number - only newline") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_only_newline_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_only_newline_uint32_str),
+                    uint32_file_path,
+                    {
+                        val = simple_file_io_read_uint32_return(uint32_file_path);
+                    });
+
+            REQUIRE(val == 0);
+        }
+
+        SECTION("invalid number - empty") {
+            uint32_t val;
+            TEST_SIMPLE_FILE_IO_FIXTURE_FILE_FROM_DATA(
+                    simple_file_io_fixture_data_invalid_empty_uint32_str,
+                    strlen(simple_file_io_fixture_data_invalid_empty_uint32_str),
+                    uint32_file_path,
+                    {
+                        val = simple_file_io_read_uint32_return(uint32_file_path);
+                    });
+
+            REQUIRE(val == 0);
+        }
+    }
+}

--- a/tests/test-hugepages.cpp
+++ b/tests/test-hugepages.cpp
@@ -1,208 +1,15 @@
-#include <string.h>
 #include <catch2/catch.hpp>
 
-#include <unistd.h>
-#include <sys/syscall.h>
-
+#include "support/simple_file_io.h"
 #include "hugepages.h"
 
-bool test_hugepages_fixture_file_from_data_create(
-        char* path,
-        int path_suffix_len,
-        const char* data,
-        size_t data_len) {
-
-    if (!mkstemps(path, path_suffix_len)) {
-        return false;
-    }
-
-    FILE* fp = fopen(path, "w");
-    if (fp == NULL) {
-        return false;
-    }
-
-    size_t res;
-    if ((res = fwrite(data, 1, data_len, fp)) != data_len) {
-        fclose(fp);
-        unlink(path);
-        return false;
-    }
-
-    if (fflush(fp) != 0) {
-        fclose(fp);
-        unlink(path);
-        return false;
-    }
-
-    fclose(fp);
-
-    return true;
-}
-
-void test_hugepages_fixture_file_from_data_cleanup(
-        const char* path) {
-    unlink(path);
-}
-
-#define TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(DATA, DATA_LEN, CONFIG_PATH, ...) { \
-    { \
-        char CONFIG_PATH[] = "/tmp/cachegrand-tests-XXXXXX.tmp"; \
-        int CONFIG_PATH_suffix_len = 4; /** .tmp **/ \
-        REQUIRE(test_hugepages_fixture_file_from_data_create(CONFIG_PATH, CONFIG_PATH_suffix_len, DATA, DATA_LEN)); \
-        __VA_ARGS__; \
-        test_hugepages_fixture_file_from_data_cleanup(CONFIG_PATH); \
-    } \
-}
-
 TEST_CASE("hugepages.c", "[hugepages]") {
-    const char* hugepages_fixture_data_invalid_no_newline_uint32_str = "12345";
-    const char* hugepages_fixture_data_invalid_only_newline_uint32_str = "\n";
-    const char* hugepages_fixture_data_invalid_empty_uint32_str = "";
-    const char* hugepages_fixture_data_valid_uint32_str = "12345\n";
-    uint32_t hugepages_fixture_data_valid_uint32 = 12345;
-
-    SECTION("hugepages_file_read") {
-        SECTION("valid number") {
-            char buf[512];
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_valid_uint32_str,
-                    strlen(hugepages_fixture_data_valid_uint32_str),
-                    uint32_file_path,
-                    {
-                        REQUIRE(hugepages_file_read(uint32_file_path, buf, sizeof(buf)));
-                    });
-
-            REQUIRE(strcmp(buf, hugepages_fixture_data_valid_uint32_str) == 0);
-        }
-
-        SECTION("invalid number - no newline") {
-            char buf[512];
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_no_newline_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_no_newline_uint32_str),
-                    uint32_file_path,
-                    {
-                        REQUIRE(hugepages_file_read(uint32_file_path, buf, sizeof(buf)));
-                    });
-
-            REQUIRE(strcmp(buf, hugepages_fixture_data_invalid_no_newline_uint32_str) == 0);
-        }
-    }
-
-    SECTION("hugepages_file_read_uint32") {
-        SECTION("valid number") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_valid_uint32_str,
-                    strlen(hugepages_fixture_data_valid_uint32_str),
-                    uint32_file_path,
-                    {
-                        REQUIRE(hugepages_file_read_uint32(uint32_file_path, &val));
-                    });
-
-            REQUIRE(val == hugepages_fixture_data_valid_uint32);
-        }
-
-        SECTION("invalid number - no newline") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_no_newline_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_no_newline_uint32_str),
-                    uint32_file_path,
-                    {
-                        REQUIRE(!hugepages_file_read_uint32(uint32_file_path, &val));
-                    });
-
-            REQUIRE(val == 12345);
-        }
-
-        SECTION("invalid number - only newline") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_only_newline_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_only_newline_uint32_str),
-                    uint32_file_path,
-                    {
-                        REQUIRE(!hugepages_file_read_uint32(uint32_file_path, &val));
-                    });
-
-            REQUIRE(val == 0);
-        }
-
-        SECTION("invalid number - empty") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_empty_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_empty_uint32_str),
-                    uint32_file_path,
-                    {
-                        REQUIRE(!hugepages_file_read_uint32(uint32_file_path, &val));
-                    });
-
-            REQUIRE(val == 0);
-        }
-    }
-
-    SECTION("hugepages_file_path_uint32_return") {
-        SECTION("valid number") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_valid_uint32_str,
-                    strlen(hugepages_fixture_data_valid_uint32_str),
-                    uint32_file_path,
-                    {
-                        val = hugepages_file_path_uint32_return(uint32_file_path);
-                    });
-
-            REQUIRE(val == hugepages_fixture_data_valid_uint32);
-        }
-
-        SECTION("invalid number - no newline") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_no_newline_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_no_newline_uint32_str),
-                    uint32_file_path,
-                    {
-                        val = hugepages_file_path_uint32_return(uint32_file_path);
-                    });
-
-            REQUIRE(val == 0);
-        }
-
-        SECTION("invalid number - only newline") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_only_newline_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_only_newline_uint32_str),
-                    uint32_file_path,
-                    {
-                        val = hugepages_file_path_uint32_return(uint32_file_path);
-                    });
-
-            REQUIRE(val == 0);
-        }
-
-        SECTION("invalid number - empty") {
-            uint32_t val;
-            TEST_HUGEPAGES_FIXTURE_FILE_FROM_DATA(
-                    hugepages_fixture_data_invalid_empty_uint32_str,
-                    strlen(hugepages_fixture_data_invalid_empty_uint32_str),
-                    uint32_file_path,
-                    {
-                        val = hugepages_file_path_uint32_return(uint32_file_path);
-                    });
-
-            REQUIRE(val == 0);
-        }
-    }
-
     SECTION("hugepages_2mb_is_available") {
         const char* free_hugepages_2mb_path = HUGEPAGES_SYSFS_2MB_PATH HUGEPAGES_SYSFS_FREE_HUGEPAGES_FILENAME;
         const char* resv_hugepages_2mb_path = HUGEPAGES_SYSFS_2MB_PATH HUGEPAGES_SYSFS_RESV_HUGEPAGES_FILENAME;
 
-        uint32_t free_hugepages = hugepages_file_path_uint32_return(free_hugepages_2mb_path);
-        uint32_t resv_hugepages = hugepages_file_path_uint32_return(resv_hugepages_2mb_path);
+        uint32_t free_hugepages = simple_file_io_read_uint32_return(free_hugepages_2mb_path);
+        uint32_t resv_hugepages = simple_file_io_read_uint32_return(resv_hugepages_2mb_path);
 
         bool has_at_least_one_hugepage_2mb = (free_hugepages - resv_hugepages) > 0;
         REQUIRE(hugepages_2mb_is_available(0) == has_at_least_one_hugepage_2mb);
@@ -212,8 +19,8 @@ TEST_CASE("hugepages.c", "[hugepages]") {
         const char* free_hugepages_1024mb_path = HUGEPAGES_SYSFS_1024MB_PATH HUGEPAGES_SYSFS_FREE_HUGEPAGES_FILENAME;
         const char* resv_hugepages_1024mb_path = HUGEPAGES_SYSFS_1024MB_PATH HUGEPAGES_SYSFS_RESV_HUGEPAGES_FILENAME;
 
-        uint32_t free_hugepages = hugepages_file_path_uint32_return(free_hugepages_1024mb_path);
-        uint32_t resv_hugepages = hugepages_file_path_uint32_return(resv_hugepages_1024mb_path);
+        uint32_t free_hugepages = simple_file_io_read_uint32_return(free_hugepages_1024mb_path);
+        uint32_t resv_hugepages = simple_file_io_read_uint32_return(resv_hugepages_1024mb_path);
 
         bool has_at_least_one_hugepage_1024mb = (free_hugepages - resv_hugepages) > 0;
         REQUIRE(hugepages_1024mb_is_available(0) == has_at_least_one_hugepage_1024mb);

--- a/tests/test-pidfile.cpp
+++ b/tests/test-pidfile.cpp
@@ -1,0 +1,163 @@
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <catch2/catch.hpp>
+
+#include "support/simple_file_io.h"
+#include "pidfile.h"
+
+extern bool pidfile_owned;
+extern int pidfile_fd;
+
+bool test_pidfile_get_fnctl_lock(
+        const char* path,
+        struct flock *lock) {
+    int pipe_fd[2];
+    pid_t pid;
+
+    // The locks set via fnctl can't be read by the same process as F_GETLK returns if the current process can apply
+    // the lock requested in the struct passed as data and not "get" an applied lock.
+    // This, though, doesn't apply to forked processes as forks don't inherit locks applied via F_SETLK/F_SETLKW.
+    // Therefore, the function takes care of spawning up a pipe, forking the current process, with the child trying to
+    // read the lock applied and writing it to the pipe and with the parent (the test itself) waiting for the data on
+    // the pipe to copy it into the lock variable passed to the func.
+
+    if (pipe(pipe_fd) == -1) {
+        return false;
+    }
+
+    if ((pid = fork()) < 0) {
+        return false;
+    }
+
+    if (pid == 0) {
+        // Child process
+        int fd;
+        struct flock child_lock = { 0 };
+
+        if ((fd = open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)) > -1) {
+            if (fcntl(fd, F_GETLK, &child_lock) > -1) {
+                write(pipe_fd[1], &child_lock, sizeof(struct flock));
+                fsync(pipe_fd[1]);
+            }
+        }
+
+        close(fd);
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        exit(0);
+    } else {
+        // Parent process
+        size_t read_len = read(pipe_fd[0], lock, sizeof(struct flock));
+
+        close(pipe_fd[1]);
+        close(pipe_fd[0]);
+
+        if (read_len != sizeof(struct flock)) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+TEST_CASE("pidfile.c", "[pidfile]") {
+    char fixture_temp_path[] = "/tmp/cachegrand-tests-XXXXXX.tmp";
+    int fixture_temp_path_suffix_len = 4;
+    REQUIRE(mkstemps(fixture_temp_path, fixture_temp_path_suffix_len));
+    int fd = -1;
+
+    SECTION("pidfile_open") {
+        fd = pidfile_open(fixture_temp_path);
+        REQUIRE(fd > 0);
+    }
+
+    SECTION("pidfile_request_close_on_exec") {
+        fd = pidfile_open(fixture_temp_path);
+        REQUIRE(fd > 0);
+        REQUIRE(pidfile_request_close_on_exec(fd));
+
+        int flags = fcntl(fd, F_GETFD);
+        REQUIRE(flags != -1);
+        REQUIRE((flags & FD_CLOEXEC) == FD_CLOEXEC);
+    }
+
+    SECTION("pidfile_request_lock") {
+        struct flock lock = { 0 };
+
+        fd = pidfile_open(fixture_temp_path);
+        REQUIRE(fd > 0);
+
+        REQUIRE(pidfile_request_lock(fd));
+
+        REQUIRE(test_pidfile_get_fnctl_lock(fixture_temp_path, &lock));
+        REQUIRE(lock.l_start == 0);
+        REQUIRE(lock.l_len == 0);
+        REQUIRE(lock.l_pid == getpid());
+        REQUIRE(lock.l_type == F_WRLCK);
+    }
+
+    SECTION("pidfile_write_pid") {
+        fd = pidfile_open(fixture_temp_path);
+        REQUIRE(fd > 0);
+
+        REQUIRE(pidfile_write_pid(fd, 12345));
+        REQUIRE(simple_file_io_read_uint32_return(fixture_temp_path) == 12345);
+    }
+
+    SECTION("pidfile_close") {
+        fd = pidfile_open(fixture_temp_path);
+        REQUIRE(fd > 0);
+
+        pidfile_close(fd);
+
+        // TODO: check the fd is actually closed
+
+        // Set fd to -1 to avoid the testing code trying to close it
+        fd = -1;
+    }
+
+    SECTION("pidfile_create") {
+        struct flock lock = { 0 };
+
+        REQUIRE(pidfile_create(fixture_temp_path));
+        REQUIRE(pidfile_fd > -1);
+        REQUIRE(pidfile_owned == true);
+
+        REQUIRE(test_pidfile_get_fnctl_lock(fixture_temp_path, &lock));
+        REQUIRE(lock.l_start == 0);
+        REQUIRE(lock.l_len == 0);
+        REQUIRE(lock.l_pid == getpid());
+        REQUIRE(lock.l_type == F_WRLCK);
+
+        int flags = fcntl(pidfile_fd, F_GETFD);
+        REQUIRE(flags != -1);
+        REQUIRE((flags & FD_CLOEXEC) == FD_CLOEXEC);
+
+        REQUIRE(simple_file_io_read_uint32_return(fixture_temp_path) == (long)getpid());
+    }
+
+    SECTION("pidfile_is_owned") {
+        pidfile_owned = false;
+        REQUIRE(pidfile_is_owned() == false);
+
+        pidfile_owned = true;
+        REQUIRE(pidfile_is_owned() == true);
+    }
+
+    SECTION("pidfile_get_fd") {
+        pidfile_fd = -1;
+        REQUIRE(pidfile_get_fd() == -1);
+
+        pidfile_fd = 99;
+        REQUIRE(pidfile_get_fd() == 99);
+    }
+
+    if (fd > 0) {
+        close(fd);
+    }
+
+    pidfile_fd = -1;
+    pidfile_owned = false;
+    unlink(fixture_temp_path);
+}

--- a/tests/test-program.cpp
+++ b/tests/test-program.cpp
@@ -150,6 +150,26 @@ TEST_CASE("program.c", "[program]") {
             unlink(fixture_temp_path);
         }
 
+        SECTION("valid pidfile path cleanup") {
+            PROGRAM_CONFIG_AND_CONTEXT_REDIS_LOCALHOST_12345();
+
+            char fixture_temp_path[] = "/tmp/cachegrand-tests-XXXXXX.tmp";
+            int fixture_temp_path_suffix_len = 4;
+            REQUIRE(mkstemps(fixture_temp_path, fixture_temp_path_suffix_len));
+
+            program_context.config->pidfile_path = fixture_temp_path;
+
+            REQUIRE(program_setup_pidfile(program_context));
+
+            // Has to be set back to null otherwise when cyaml will try to free up the memory will trigger a segfault
+            program_context.config = NULL;
+
+            program_cleanup(&program_context);
+
+            REQUIRE(pidfile_get_fd() == -1);
+            REQUIRE(!pidfile_is_owned());
+        }
+
         SECTION("null pidfile path") {
             PROGRAM_CONFIG_AND_CONTEXT_REDIS_LOCALHOST_12345();
 


### PR DESCRIPTION
This PR focus around implementing support for the pidfile.

With this PR the pidfile_path parameter in the configuration is made optional, as it's not a mandatory parameter to manage pids, especially on Linux and *BSD systems, it also implement the management routines necessary to handle the pid file, with the related tests.

The locking code relies on fnctl instead of more portable solutions because with fnctl it's possible to test locks in forked processes, and this mechanism is implemented in the test for pidfile.c to ensure that the locking is correctly applied and enforced.

The PR also includes a minor refactoring, the pidfile.c requires to read the pid from the pidfile in case it already exists and because code to read numeric files was already implemented and available in the hugepages.c unit it has been extracted and refactored in a support unit together with testing.

Closes #71 