### PR TITLE
Issue 104 add valgrind memory tracking to the slab allocator

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-dept: 2
 
       - name: Install required dependencies
-        run: sudo apt-get install -y build-essential cmake pkg-config git libssl1.1 libssl-dev libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev
+        run: sudo apt-get install -y build-essential cmake pkg-config git libssl1.1 libssl-dev libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev valgrind
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -89,6 +89,10 @@ network_op_result_t network_receive(
         return NETWORK_OP_RESULT_ERROR;
     }
 
+    if (channel->status == NETWORK_CHANNEL_STATUS_CLOSED) {
+        return NETWORK_OP_RESULT_CLOSE_SOCKET;
+    }
+
     int32_t receive_length = (int32_t)worker_op_network_receive(
             channel,
             buffer,

--- a/src/signal_handler_thread.c
+++ b/src/signal_handler_thread.c
@@ -149,6 +149,8 @@ bool signal_handler_thread_teardown(
     LOG_V(TAG, "Tearing down signal handler thread");
 
     xalloc_free(log_producer_early_prefix_thread);
+    log_unset_early_prefix_thread();
+
     sigprocmask(SIG_UNBLOCK, waitset, NULL);
 
     for(uint8_t i = 0; i < signal_handler_thread_managed_signals_count; i++) {

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -459,6 +459,10 @@ void* slab_allocator_mem_alloc_hugepages(
 
     spinlock_unlock(&core_metadata->spinlock);
 
+#if defined(HAS_VALGRIND)
+    VALGRIND_MEMPOOL_ALLOC(slab_slice->data.page_addr, slab_slot->data.memptr, size);
+#endif
+
     return slab_slot->data.memptr;
 }
 
@@ -519,6 +523,10 @@ void slab_allocator_mem_free_hugepages(
         }
     }
     spinlock_unlock(&core_metadata->spinlock);
+
+#if defined(HAS_VALGRIND)
+    VALGRIND_MEMPOOL_FREE(slab_slice->data.page_addr, memptr);
+#endif
 
     if (can_free_slab_slice) {
 #if defined(HAS_VALGRIND)

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -568,6 +568,8 @@ void* slab_allocator_mem_realloc(
         size_t current_size,
         size_t new_size,
         bool zero_new_memory) {
+    // TODO: the implementation is terrible, it's not even checking if the new size fits within the provided slot
+    //       because in case nothing is needed
     void* new_memptr;
 
     new_memptr = slab_allocator_mem_alloc(new_size);

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -12,6 +12,11 @@
 #include <string.h>
 #include <stdatomic.h>
 
+#if __has_include(<valgrind/valgrind.h>)
+#include <valgrind/valgrind.h>
+#define HAS_VALGRIND
+#endif
+
 #include "misc.h"
 #include "exttypes.h"
 #include "memory_fences.h"

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -431,6 +431,10 @@ void* slab_allocator_mem_alloc_hugepages(
         if (slab_allocator_slice_try_acquire(slab_allocator, numa_node_index, core_index) == false) {
             void* hugepage_addr = hugepage_cache_pop();
 
+#if defined(HAS_VALGRIND)
+            VALGRIND_CREATE_MEMPOOL(hugepage_addr, 0, false);
+#endif
+
             slab_allocator_grow(
                     slab_allocator,
                     numa_node_index,
@@ -517,6 +521,10 @@ void slab_allocator_mem_free_hugepages(
     spinlock_unlock(&core_metadata->spinlock);
 
     if (can_free_slab_slice) {
+#if defined(HAS_VALGRIND)
+        VALGRIND_DESTROY_MEMPOOL(slab_slice->data.page_addr);
+#endif
+
         hugepage_cache_push(slab_slice->data.page_addr);
     }
 }


### PR DESCRIPTION
This PR implements the Valgrind memory pools and memory slots tracking to the slab_allocator and fixes a few invalid reads (read after free) identified by Valgrind after being able to track the memory provided via the slab allocator.

Closes #104 