### PR TITLE
Replace the deprecated pthread_yield with sched_yield

### DIFF
--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -225,7 +225,7 @@ void worker_network_listeners_listen_pre(
 void worker_wait_running(
         worker_context_t *worker_context) {
     do {
-        pthread_yield();
+        sched_yield();
         usleep(10000);
         MEMORY_FENCE_LOAD();
     } while(!worker_context->running && !worker_context->aborted);

--- a/tests/test-program-redis-commands.cpp
+++ b/tests/test-program-redis-commands.cpp
@@ -38,7 +38,7 @@
 
 #define PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(WORKER_CONTEXT, RUNNING) { \
     do { \
-        pthread_yield(); \
+        sched_yield(); \
         usleep(10000); \
         MEMORY_FENCE_LOAD(); \
     } while((WORKER_CONTEXT)->running == !RUNNING); \
@@ -337,7 +337,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(worker_context, false);
         usleep((WORKER_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
     }
-    pthread_yield();
+    sched_yield();
 
     program_workers_cleanup(
             worker_context,

--- a/tests/test-program.cpp
+++ b/tests/test-program.cpp
@@ -92,7 +92,7 @@ void* test_program_wait_loop_terminate(
 
 #define PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(WORKER_CONTEXT, RUNNING) { \
     do { \
-        pthread_yield(); \
+        sched_yield(); \
         usleep(10000); \
         MEMORY_FENCE_LOAD(); \
     } while((WORKER_CONTEXT)->running == !RUNNING); \
@@ -191,7 +191,7 @@ TEST_CASE("program.c", "[program]") {
                 (void*)&terminate_event_loop) == 0);
 
         usleep(25000);
-        pthread_yield();
+        sched_yield();
 
         REQUIRE(pthread_create(
                 &pthread_terminate,
@@ -200,7 +200,7 @@ TEST_CASE("program.c", "[program]") {
                 (void*)&terminate_event_loop) == 0);
 
         usleep((WORKER_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-        pthread_yield();
+        sched_yield();
 
         REQUIRE(pthread_join(pthread_terminate, NULL) == 0);
 
@@ -234,7 +234,7 @@ TEST_CASE("program.c", "[program]") {
         // Wait for the thread to end
         PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(worker_context, false);
         usleep((WORKER_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-        pthread_yield();
+        sched_yield();
 
         // Check if the worker terminated
         REQUIRE(pthread_kill(worker_context->pthread, 0) == ESRCH);
@@ -263,7 +263,7 @@ TEST_CASE("program.c", "[program]") {
         // Wait for the thread to end
         PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(worker_context, false);
         usleep((WORKER_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-        pthread_yield();
+        sched_yield();
 
         program_workers_cleanup(
                 worker_context,

--- a/tests/test-signal-handler-thread.cpp
+++ b/tests/test-signal-handler-thread.cpp
@@ -203,20 +203,20 @@ TEST_CASE("signal_handler_thread.c", "[signal_handler_thread]") {
                 &waitset) == 0);
 
         usleep(25000);
-        pthread_yield();
+        sched_yield();
 
         SECTION("teardown with terminate_event_loop") {
             terminate_event_loop = true;
             MEMORY_FENCE_STORE();
 
             usleep((SIGNAL_HANDLER_THREAD_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-            pthread_yield();
+            sched_yield();
 
             REQUIRE(pthread_kill(context.pthread, 0) == ESRCH);
             REQUIRE(pthread_join(context.pthread, NULL) == 0);
 
             usleep((SIGNAL_HANDLER_THREAD_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-            pthread_yield();
+            sched_yield();
         }
 
         signal_handler_thread_internal_context = NULL;
@@ -243,14 +243,14 @@ TEST_CASE("signal_handler_thread.c", "[signal_handler_thread]") {
                 &context) == 0);
 
         usleep(25000);
-        pthread_yield();
+        sched_yield();
 
         SECTION("teardown with terminate_event_loop") {
             terminate_event_loop = true;
             MEMORY_FENCE_STORE();
 
             usleep((SIGNAL_HANDLER_THREAD_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-            pthread_yield();
+            sched_yield();
 
             REQUIRE(pthread_kill(context.pthread, 0) == ESRCH);
             REQUIRE(pthread_join(context.pthread, NULL) == 0);
@@ -260,7 +260,7 @@ TEST_CASE("signal_handler_thread.c", "[signal_handler_thread]") {
             REQUIRE(kill(0, SIGCHLD) == 0);
 
             usleep((SIGNAL_HANDLER_THREAD_LOOP_MAX_WAIT_TIME_MS + 100) * 1000);
-            pthread_yield();
+            sched_yield();
 
             REQUIRE(pthread_kill(context.pthread, 0) == ESRCH);
             REQUIRE(pthread_join(context.pthread, NULL) == 0);


### PR DESCRIPTION
This PR fixes a few warnings that popup when compiling cachegrand on Ubuntu 22.04, pthread_yield has been deprecated in favour of sched_yield.