### PR TITLE
Update sentry-native to 0.4.17 to support the latest gcc

### DIFF
--- a/3rdparty/sentry.cmake
+++ b/3rdparty/sentry.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
         sentry
         GIT_REPOSITORY https://github.com/getsentry/sentry-native
-        GIT_TAG        0.4.9
+        GIT_TAG        0.4.17
 )
 
 FetchContent_MakeAvailable(sentry)


### PR DESCRIPTION
This PR updates the sentry-native version to version 0.4.17 to support gcc 11