### PR TITLE
Update google-benchmark to v1.6.1 to support gcc 11

### DIFF
--- a/benches/CMakeLists.txt
+++ b/benches/CMakeLists.txt
@@ -5,7 +5,7 @@ set (CMAKE_CXX_STANDARD 17)
 ExternalProject_Add(benchmark-install
         PREFIX benchmark-sources
         INSTALL_DIR ${CMAKE_BINARY_DIR}/benchmark-install
-        URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz
+        URL https://github.com/google/benchmark/archive/v1.6.1.tar.gz
         CMAKE_CACHE_ARGS
             -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
             -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}

--- a/benches/bench-fibers.cpp
+++ b/benches/bench-fibers.cpp
@@ -9,6 +9,9 @@
 
 #include "fiber.h"
 
+#define FIBER_NAME "fiber-test"
+#define FIBER_NAME_LEN (strlen(FIBER_NAME))
+
 #define MSG_TEXT "tst"
 #define MSG_TEXT_SIZE (strlen(MSG_TEXT) + 1)
 
@@ -244,7 +247,7 @@ void BM_ContextSwitching_Fiber2XPinnedOverhead(benchmark::State& state) {
     CPU_SET(core_index, &cpuset);
     pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
 
-    fiber_t* child_fiber = fiber_new(getpagesize() * 8, fiber_func, nullptr);
+    fiber_t* child_fiber = fiber_new(FIBER_NAME, FIBER_NAME_LEN, getpagesize() * 8, fiber_func, nullptr);
 
     for (auto _ : state) {
         fiber_context_swap(&main_context, child_fiber);

--- a/benches/bench-hashtable-op-get.cpp
+++ b/benches/bench-hashtable-op-get.cpp
@@ -47,11 +47,11 @@ static void hashtable_op_get_not_found_key(benchmark::State& state) {
     static hashtable_t* hashtable;
     hashtable_value_data_t value;
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable = test_support_init_hashtable(state.range(0));
     }
 
-    test_support_set_thread_affinity(state.thread_index);
+    test_support_set_thread_affinity(state.thread_index());
 
     for (auto _ : state) {
         benchmark::DoNotOptimize(hashtable_mcmp_op_get(
@@ -61,7 +61,7 @@ static void hashtable_op_get_not_found_key(benchmark::State& state) {
                 &value));
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable_mcmp_free(hashtable);
     }
 }
@@ -75,7 +75,7 @@ static void hashtable_op_get_single_key_inline(benchmark::State& state) {
     bool result;
     char error_message[150] = {0};
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable = test_support_init_hashtable(state.range(0));
 
         bucket_index = test_key_1_hash % hashtable->ht_current->buckets_count;
@@ -91,7 +91,7 @@ static void hashtable_op_get_single_key_inline(benchmark::State& state) {
                 test_value_1);
     }
 
-    test_support_set_thread_affinity(state.thread_index);
+    test_support_set_thread_affinity(state.thread_index());
 
     for (auto _ : state) {
         benchmark::DoNotOptimize((result = hashtable_mcmp_op_get(
@@ -108,13 +108,13 @@ static void hashtable_op_get_single_key_inline(benchmark::State& state) {
                     bucket_index,
                     chunk_index,
                     chunk_slot_index,
-                    state.thread_index);
+                    state.thread_index());
             state.SkipWithError(error_message);
             break;
         }
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable_mcmp_free(hashtable);
     }
 }
@@ -128,7 +128,7 @@ static void hashtable_op_get_single_key_external(benchmark::State& state) {
     bool result;
     char error_message[150] = {0};
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable = test_support_init_hashtable(state.range(0));
 
         bucket_index = test_key_1_hash % hashtable->ht_current->buckets_count;
@@ -144,7 +144,7 @@ static void hashtable_op_get_single_key_external(benchmark::State& state) {
                 test_value_1);
     }
 
-    test_support_set_thread_affinity(state.thread_index);
+    test_support_set_thread_affinity(state.thread_index());
 
     for (auto _ : state) {
         benchmark::DoNotOptimize((result = hashtable_mcmp_op_get(
@@ -161,13 +161,13 @@ static void hashtable_op_get_single_key_external(benchmark::State& state) {
                     bucket_index,
                     chunk_index,
                     chunk_slot_index,
-                    state.thread_index);
+                    state.thread_index());
             state.SkipWithError(error_message);
             break;
         }
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable_mcmp_free(hashtable);
     }
 }

--- a/benches/bench-hashtable-op-set.cpp
+++ b/benches/bench-hashtable-op-set.cpp
@@ -95,13 +95,13 @@ static void hashtable_op_set_new(benchmark::State& state) {
     bool result;
     char error_message[150] = {0};
 
-    if (bench_support_check_if_too_many_threads_per_core(state.threads, BENCHES_MAX_THREADS_PER_CORE)) {
+    if (bench_support_check_if_too_many_threads_per_core(state.threads(), BENCHES_MAX_THREADS_PER_CORE)) {
         sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
         state.SkipWithError(error_message);
         return;
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable = test_support_init_hashtable(state.range(0));
 
         double requested_load_factor = (double)state.range(1) / 100;
@@ -120,10 +120,10 @@ static void hashtable_op_set_new(benchmark::State& state) {
         test_support_flush_data_cache(keyset, TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * requested_keyset_size);
     }
 
-    test_support_set_thread_affinity(state.thread_index);
+    test_support_set_thread_affinity(state.thread_index());
 
     for (auto _ : state) {
-        for(long int i = state.thread_index; i < requested_keyset_size; i += state.threads) {
+        for(long int i = state.thread_index(); i < requested_keyset_size; i += state.threads()) {
             uint64_t keyset_offset = TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * i;
             char* key = keyset + keyset_offset;
 
@@ -139,14 +139,14 @@ static void hashtable_op_set_new(benchmark::State& state) {
                         "Unable to set the key <%s> with index <%ld> for the thread <%d>",
                         key,
                         i,
-                        state.thread_index);
+                        state.thread_index());
                 state.SkipWithError(error_message);
                 break;
             }
         }
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         bench_support_collect_hashtable_stats_and_update_state(state, hashtable);
         hashtable_mcmp_free(hashtable);
     }
@@ -158,13 +158,13 @@ static void hashtable_op_set_update(benchmark::State& state) {
     bool result;
     char error_message[150] = {0};
 
-    if (bench_support_check_if_too_many_threads_per_core(state.threads, BENCHES_MAX_THREADS_PER_CORE)) {
+    if (bench_support_check_if_too_many_threads_per_core(state.threads(), BENCHES_MAX_THREADS_PER_CORE)) {
         sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
         state.SkipWithError(error_message);
         return;
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         hashtable = test_support_init_hashtable(state.range(0));
 
         double requested_load_factor = (double)state.range(1) / 100;
@@ -193,10 +193,10 @@ static void hashtable_op_set_update(benchmark::State& state) {
         test_support_flush_data_cache(keyset, TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * requested_keyset_size);
     }
 
-    test_support_set_thread_affinity(state.thread_index);
+    test_support_set_thread_affinity(state.thread_index());
 
     for (auto _ : state) {
-        for(long int i = state.thread_index; i < requested_keyset_size; i += state.threads) {
+        for(long int i = state.thread_index(); i < requested_keyset_size; i += state.threads()) {
             char* key = keyset + (TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * i);
 
             benchmark::DoNotOptimize((result = hashtable_mcmp_op_set(
@@ -211,14 +211,14 @@ static void hashtable_op_set_update(benchmark::State& state) {
                         "Unable to set the key <%s> with index <%ld> for the thread <%d>",
                         key,
                         i,
-                        state.thread_index);
+                        state.thread_index());
                 state.SkipWithError(error_message);
                 break;
             }
         }
     }
 
-    if (state.thread_index == 0) {
+    if (state.thread_index() == 0) {
         bench_support_collect_hashtable_stats_and_update_state(state, hashtable);
         hashtable_mcmp_free(hashtable);
     }

--- a/benches/bench-hashtable-support-hash-search.cpp
+++ b/benches/bench-hashtable-support-hash-search.cpp
@@ -33,7 +33,7 @@ uint32_t* init_hashes() {
     void bench_template_hashtable_mcmp_support_hash_search_##METHOD##_##SUFFIX(benchmark::State& state) { \
         uint32_t* hashes = NULL; \
         \
-        test_support_set_thread_affinity(state.thread_index); \
+        test_support_set_thread_affinity(state.thread_index()); \
         \
         for (auto _ : state) { \
             hashes = init_hashes(); \

--- a/benches/bench-slab-allocator.cpp
+++ b/benches/bench-slab-allocator.cpp
@@ -43,7 +43,7 @@ static void memory_allocation_slab_allocator_only_alloc(benchmark::State& state)
     size_t object_size = state.range(0);
     uint32_t objects_count = state.range(1);
 
-    thread_current_set_affinity(state.thread_index);
+    thread_current_set_affinity(state.thread_index());
 
     std::vector<void*> memptrs = std::vector<void*>(objects_count);
 
@@ -62,7 +62,7 @@ static void memory_allocation_slab_allocator_alloc_and_free(benchmark::State& st
     size_t object_size = state.range(0);
     uint32_t objects_count = state.range(1);
 
-    thread_current_set_affinity(state.thread_index);
+    thread_current_set_affinity(state.thread_index());
 
     std::vector<void*> memptrs = std::vector<void*>(objects_count);
 
@@ -82,7 +82,7 @@ static void memory_allocation_slab_allocator_fragment_memory(benchmark::State& s
     uint32_t objects_count = state.range(1);
     uint32_t objects_count_1_of_4 = objects_count >> 2;
 
-    thread_current_set_affinity(state.thread_index);
+    thread_current_set_affinity(state.thread_index());
 
     std::random_device rd;
     std::mt19937 g(rd());
@@ -157,7 +157,7 @@ static void memory_allocation_os_malloc_only_alloc(benchmark::State& state) {
     size_t object_size = state.range(0);
     uint32_t objects_count = state.range(1);
 
-    thread_current_set_affinity(state.thread_index);
+    thread_current_set_affinity(state.thread_index());
 
     void** memptrs = (void**)malloc(sizeof(void*) * objects_count);
     memset(memptrs, 0, sizeof(void*) * objects_count);
@@ -177,7 +177,7 @@ static void memory_allocation_os_malloc_alloc_and_free(benchmark::State& state) 
     size_t object_size = state.range(0);
     uint32_t objects_count = state.range(1);
 
-    thread_current_set_affinity(state.thread_index);
+    thread_current_set_affinity(state.thread_index());
 
     void** memptrs = (void**)malloc(sizeof(void*) * objects_count);
     memset(memptrs, 0, sizeof(void*) * objects_count);
@@ -198,7 +198,7 @@ static void memory_allocation_os_malloc_fragment_memory(benchmark::State& state)
     uint32_t objects_count = state.range(1);
     uint32_t objects_count_1_of_4 = objects_count >> 2;
 
-    thread_current_set_affinity(state.thread_index);
+    thread_current_set_affinity(state.thread_index());
 
     std::random_device rd;
     std::mt19937 g(rd());


### PR DESCRIPTION
This PR updates google-benchmark to v1.6.1 to support gcc 11.

It also contains minor code updates for the benchmarks to make them compatible with google-benchmark v1.6.1