### PR TITLE
Minor fiber switching & execution cleanup

### DIFF
--- a/src/fiber.h
+++ b/src/fiber.h
@@ -32,11 +32,6 @@ struct fiber {
     char *name;
     bool terminate;
     int error_number;
-    struct {
-        uint64_t cycles;
-        uint8_t warnings;
-        bool postpone_execution;
-    } cost;
     union {
         void* ptr_value;
         int int_value;

--- a/src/fiber_scheduler.c
+++ b/src/fiber_scheduler.c
@@ -171,27 +171,14 @@ void fiber_scheduler_switch_to(
     unsigned stack_id = VALGRIND_STACK_REGISTER(fiber->stack_base, fiber->stack_base + fiber->stack_size);
 #endif
 
-    uint32_t aux = 0;
-    uint64_t cost_cycles_start = intrinsic_rdtscp(&aux);
-
     // Switch to the new fiber
     fiber_context_swap(
             previous_fiber,
             fiber);
 
-    uint64_t cost_cycles_end = intrinsic_rdtscp(&aux);
-
 #if defined(HAS_VALGRIND)
     VALGRIND_STACK_DEREGISTER(stack_id);
 #endif
-
-    if (likely(cost_cycles_end > cost_cycles_start)) {
-        fiber->cost.cycles = cost_cycles_end - cost_cycles_start;
-    } else if (cost_cycles_end < cost_cycles_start) {
-        fiber->cost.cycles = cost_cycles_start - cost_cycles_end;
-    } else {
-        fiber->cost.cycles = UINT64_MAX;
-    }
 
     LOG_D(TAG, "Switching back from fiber <%s>, file <%s:%d>, to fiber <%s>, file <%s:%d>",
           fiber->name,

--- a/src/worker/worker_iouring.c
+++ b/src/worker/worker_iouring.c
@@ -287,26 +287,8 @@ bool worker_iouring_process_events_loop(
                     "Malformed io_uring cqe, fiber is null!");
         }
 
-//        // TODO: the logic that handles the cost of a fiber and it postponement if needed has to be moved into the
-//        //       fiber scheduler, as it's not tied to the worker itself. It requires though to change how the
-//        //       fiber scheduler is initialized (no more thread local variables to handle the nested fibers or the
-//        //       related data.
-//        //       The fiber scheduler will also have to calculate the X percentile to be used as reference when
-//        //       deciding if a fiber has to be warned or punished (skipping its execution).
-        if (likely(!fiber->cost.postpone_execution)) {
-            fiber->ret.ptr_value = cqe;
-            fiber_scheduler_switch_to(fiber);
-        }
-
-//        fiber->cost.postpone_execution = false;
-//        if (fiber->cost.cycles > __CALCULATE_COST__) {
-//            fiber->cost.warnings++;
-//            if (fiber->cost.warnings > FIBER_SCHEDULER_COST_WARNINGS_LIMIT) {
-//                fiber->cost.postpone_execution = true;
-//            }
-//        } else if (fiber->cost.warnings > 0){
-//            fiber->cost.warnings--;
-//        }
+        fiber->ret.ptr_value = cqe;
+        fiber_scheduler_switch_to(fiber);
     }
 
     io_uring_support_cq_advance(context->ring, count);


### PR DESCRIPTION
This PR drops the mostly commented out code to track the cost of executing a fiber as it wasn't in use and wasn't completed in preparation to the v0.1