### PR TITLE
General fixes and improvements (storage_db, slab allocator, redis get, etc.)

### DIFF
--- a/benches/bench-slab-allocator.cpp
+++ b/benches/bench-slab-allocator.cpp
@@ -17,6 +17,8 @@
 
 #define SET_BENCH_ARGS() \
     DisplayAggregatesOnly(true)-> \
+    Args({SLAB_OBJECT_SIZE_16, 0x1000})-> \
+    Args({SLAB_OBJECT_SIZE_32, 0x1000})-> \
     Args({SLAB_OBJECT_SIZE_64, 0x1000})-> \
     Args({SLAB_OBJECT_SIZE_128, 0x1000})-> \
     Args({SLAB_OBJECT_SIZE_256, 0x1000})-> \

--- a/src/network/protocol/redis/command/network_protocol_redis_command_get.c
+++ b/src/network/protocol/redis/command/network_protocol_redis_command_get.c
@@ -56,7 +56,7 @@ NETWORK_PROTOCOL_REDIS_COMMAND_FUNCPTR_END(get) {
 
     if (likely(entry_index)) {
         // Try to acquire a reader lock until it's successful or the entry index has been marked as deleted
-        storage_db_entry_index_status_acquire_reader_lock(
+        storage_db_entry_index_status_increase_readers_counter(
                 entry_index,
                 &old_status);
 
@@ -194,7 +194,7 @@ NETWORK_PROTOCOL_REDIS_COMMAND_FUNCPTR_END(get) {
 
 fail:
     if (entry_index) {
-        storage_db_entry_index_status_free_reader_lock(entry_index, NULL);
+        storage_db_entry_index_status_decrease_readers_counter(entry_index, NULL);
     }
 
     if (send_buffer) {

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -58,7 +58,7 @@ void slab_allocator_predefined_allocators_init() {
         uint32_t predefined_slab_allocators_index = slab_index_by_object_size(object_size);
 
         predefined_slab_allocators[predefined_slab_allocators_index] =
-                slab_allocator_init(SLAB_OBJECT_SIZE_64 << i);
+                slab_allocator_init(SLAB_OBJECT_SIZE_MIN << i);
     }
 }
 
@@ -88,8 +88,8 @@ uint8_t slab_index_by_object_size(
         size_t object_size) {
     assert(object_size <= SLAB_OBJECT_SIZE_MAX);
 
-    if (object_size < SLAB_OBJECT_SIZE_64) {
-        object_size = SLAB_OBJECT_SIZE_64;
+    if (object_size < SLAB_OBJECT_SIZE_MIN) {
+        object_size = SLAB_OBJECT_SIZE_MIN;
     }
 
     // Round up the object_size to the next power of 2

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -102,7 +102,7 @@ uint8_t slab_index_by_object_size(
     rounded_up_object_size |= rounded_up_object_size >> 16;
     rounded_up_object_size++;
 
-    return 32 - __builtin_clz(rounded_up_object_size) - 7;
+    return 32 - __builtin_clz(rounded_up_object_size) - (32 - __builtin_clz(SLAB_OBJECT_SIZE_MIN));
 }
 
 slab_allocator_t* slab_allocator_predefined_get_by_size(

--- a/src/slab_allocator.h
+++ b/src/slab_allocator.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#define SLAB_OBJECT_SIZE_16     0x00000010
+#define SLAB_OBJECT_SIZE_32     0x00000020
 #define SLAB_OBJECT_SIZE_64     0x00000040
 #define SLAB_OBJECT_SIZE_128    0x00000080
 #define SLAB_OBJECT_SIZE_256    0x00000100
@@ -16,12 +18,14 @@ extern "C" {
 #define SLAB_OBJECT_SIZE_16384  0x00004000
 #define SLAB_OBJECT_SIZE_32768  0x00008000
 #define SLAB_OBJECT_SIZE_65536  0x00010000
+#define SLAB_OBJECT_SIZE_MIN    SLAB_OBJECT_SIZE_16
 #define SLAB_OBJECT_SIZE_MAX    SLAB_OBJECT_SIZE_65536
 
-#define SLAB_PREDEFINED_OBJECT_SIZES    SLAB_OBJECT_SIZE_64, SLAB_OBJECT_SIZE_128, SLAB_OBJECT_SIZE_256, \
-                                        SLAB_OBJECT_SIZE_512, SLAB_OBJECT_SIZE_1024, SLAB_OBJECT_SIZE_2048, \
-                                        SLAB_OBJECT_SIZE_4096, SLAB_OBJECT_SIZE_8192, SLAB_OBJECT_SIZE_16384, \
-                                        SLAB_OBJECT_SIZE_32768, SLAB_OBJECT_SIZE_65536
+#define SLAB_PREDEFINED_OBJECT_SIZES    SLAB_OBJECT_SIZE_16, SLAB_OBJECT_SIZE_32, SLAB_OBJECT_SIZE_64, \
+                                        SLAB_OBJECT_SIZE_128, SLAB_OBJECT_SIZE_256, SLAB_OBJECT_SIZE_512, \
+                                        SLAB_OBJECT_SIZE_1024, SLAB_OBJECT_SIZE_2048, SLAB_OBJECT_SIZE_4096, \
+                                        SLAB_OBJECT_SIZE_8192, SLAB_OBJECT_SIZE_16384, SLAB_OBJECT_SIZE_32768, \
+                                        SLAB_OBJECT_SIZE_65536
 static const uint32_t slab_predefined_object_sizes[] = { SLAB_PREDEFINED_OBJECT_SIZES };
 #define SLAB_PREDEFINED_OBJECT_SIZES_COUNT (sizeof(slab_predefined_object_sizes) / sizeof(uint32_t))
 

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -594,6 +594,29 @@ void *storage_db_entry_index_free(
     slab_allocator_mem_free(entry_index);
 }
 
+bool storage_db_entry_chunk_can_read_from_memory(
+        storage_db_t *db,
+        storage_db_chunk_info_t *chunk_info) {
+    if (db->config->backend_type == STORAGE_DB_BACKEND_TYPE_MEMORY) {
+        return true;
+    }
+
+    // TODO: with the storage backend the data can be read from the cache only if already available there
+    return false;
+}
+
+char* storage_db_entry_chunk_read_fast_from_memory(
+        storage_db_t *db,
+        storage_db_chunk_info_t *chunk_info) {
+    if (db->config->backend_type == STORAGE_DB_BACKEND_TYPE_MEMORY) {
+        return chunk_info->memory.chunk_data;
+    }
+
+    // This should never happen so if it does it is better to catch it
+    assert(false);
+    return NULL;
+}
+
 bool storage_db_entry_chunk_read(
         storage_db_t *db,
         storage_db_chunk_info_t *chunk_info,

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -668,7 +668,7 @@ storage_db_chunk_info_t *storage_db_entry_value_chunk_get(
     return entry_index->value_chunks_info + chunk_index;
 }
 
-void storage_db_entry_index_status_acquire_reader_lock(
+void storage_db_entry_index_status_increase_readers_counter(
         storage_db_entry_index_t* entry_index,
         storage_db_entry_index_status_t *old_status) {
     storage_db_entry_index_status_t old_status_internal;
@@ -700,7 +700,7 @@ void storage_db_entry_index_status_acquire_reader_lock(
     }
 }
 
-void storage_db_entry_index_status_free_reader_lock(
+void storage_db_entry_index_status_decrease_readers_counter(
         storage_db_entry_index_t* entry_index,
         storage_db_entry_index_status_t *old_status) {
     uint32_t old_cas_wrapper_ret = __sync_fetch_and_sub(

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -571,7 +571,7 @@ void *storage_db_entry_index_chunks_free(
         }
     }
 
-    if (entry_index->key_chunks_info) {
+    if (entry_index->value_chunks_info) {
         for (
                 storage_db_chunk_index_t chunk_index = 0;
                 chunk_index < entry_index->value_chunks_count;

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -218,11 +218,11 @@ storage_db_chunk_info_t *storage_db_entry_value_chunk_get(
         storage_db_entry_index_t* entry_index,
         storage_db_chunk_index_t chunk_index);
 
-void storage_db_entry_index_status_acquire_reader_lock(
+void storage_db_entry_index_status_increase_readers_counter(
         storage_db_entry_index_t* entry_index,
         storage_db_entry_index_status_t *old_status);
 
-void storage_db_entry_index_status_free_reader_lock(
+void storage_db_entry_index_status_decrease_readers_counter(
         storage_db_entry_index_t* entry_index,
         storage_db_entry_index_status_t *old_status);
 

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -200,6 +200,14 @@ void storage_db_entry_index_ring_buffer_free(
         storage_db_t *db,
         storage_db_entry_index_t *entry_index);
 
+bool storage_db_entry_chunk_can_read_from_memory(
+        storage_db_t *db,
+        storage_db_chunk_info_t *chunk_info);
+
+char* storage_db_entry_chunk_read_fast_from_memory(
+        storage_db_t *db,
+        storage_db_chunk_info_t *chunk_info);
+
 bool storage_db_entry_chunk_read(
         storage_db_t *db,
         storage_db_chunk_info_t *chunk_info,

--- a/tests/test-slab-allocator.cpp
+++ b/tests/test-slab-allocator.cpp
@@ -184,18 +184,20 @@ TEST_CASE("slab_allocator.c", "[slab_allocator]") {
         }
 
         SECTION("slab_index_by_object_size") {
-            REQUIRE(slab_index_by_object_size(20) == 0);
-            REQUIRE(slab_index_by_object_size(64) == 0);
-            REQUIRE(slab_index_by_object_size(128) == 1);
-            REQUIRE(slab_index_by_object_size(256) == 2);
-            REQUIRE(slab_index_by_object_size(512) == 3);
-            REQUIRE(slab_index_by_object_size(1024) == 4);
-            REQUIRE(slab_index_by_object_size(2048) == 5);
-            REQUIRE(slab_index_by_object_size(4096) == 6);
-            REQUIRE(slab_index_by_object_size(8192) == 7);
-            REQUIRE(slab_index_by_object_size(16384) == 8);
-            REQUIRE(slab_index_by_object_size(32768) == 9);
-            REQUIRE(slab_index_by_object_size(65536) == 10);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_16 - 1) == 0);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_16) == 0);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_32) == 1);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_64) == 2);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_128) == 3);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_256) == 4);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_512) == 5);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_1024) == 6);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_2048) == 7);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_4096) == 8);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_8192) == 9);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_16384) == 10);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_32768) == 11);
+            REQUIRE(slab_index_by_object_size(SLAB_OBJECT_SIZE_65536) == 12);
         }
 
         SECTION("sizeof(slab_slice_t)") {


### PR DESCRIPTION
This PR includes a number of small fixes and improvements in different areas covering the:
- storage db
- slab allocator
- the redis get operation

A memory leak has been fixed in the storage_db, because of a copy & paste memory wasn't being freed properly in storage_db_entry_index_chunks_free.

Also a new mechanism to determine if it's possible to get data from the storage db that are residing in memory can be read directly instead of copying them into a temporary buffer, this mechanism is currently used only by the redis get operation when the chunks of data to send are 64kb, this because using this mechanism introduce at least an extra fiber switch that would impact the latency much more than a memcpy but if the data are 64kb a context switch must be done anyway so in that case the performances are improved.

As last improvement, 2 additional sizes have been added to the slab allocator, 16 and 32 bytes, to reduce the memory waste when allocating small slabs. The tests and the benches have been updated accordingly.
In addition a magic const, that should have been changed because of the new slab allocator sizes, has been removed from slab_index_by_object_size and instead replaced with an expression that the compiler optimize away at compile time which will always resolve to the right value.