### PR TITLE
Minor build fixes and cleanup

### DIFF
--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -41,8 +41,7 @@ network:
           port: 6379
 
 database:
-  max_keys: 10000
-  shard_size_mb: 0
+  max_keys: 1000000
   backend: memory
 #  backend: file
 #  file:

--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -41,6 +41,10 @@ network:
           port: 6379
 
 database:
+  # Currently the internal cachegrand hashtable doesn't support the automatic resizing so if there isn't enough room
+  # the SET command will just fail with a generic error.
+  # For performance reason, the max amount of keys is always rounded up to the next power of 2 of max_keys, in this case
+  # 1000000 is rounded up to 1048576
   max_keys: 1000000
   backend: memory
 #  backend: file

--- a/src/pow2.c
+++ b/src/pow2.c
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-//https://jameshfisher.com/2018/03/30/round-up-power-2/
+// https://jameshfisher.com/2018/03/30/round-up-power-2/
 uint64_t pow2_next_pow2m1(
         uint64_t x) {
     x |= x>>1;
@@ -21,6 +21,7 @@ uint64_t pow2_next_pow2m1(
 
     return x;
 }
+
 uint64_t pow2_next(
         uint64_t x) {
     return pow2_next_pow2m1(x-1)+1;
@@ -28,5 +29,5 @@ uint64_t pow2_next(
 
 bool pow2_is(
         uint64_t x) {
-    return x && (!(x&(x-1)));
+    return x && (!(x & (x-1)));
 }

--- a/src/program.c
+++ b/src/program.c
@@ -569,9 +569,9 @@ int program_main(
 
     program_setup_sentry(program_context);
 
-    if (program_setup_pidfile(program_context) == false) {
-        goto fail;
-    }
+    // If it fails to create the pidfile reports an error and continues the execution, no need to check for the result
+    // of the operation
+    program_setup_pidfile(program_context);
 
     if (program_config_thread_affinity_set_selected_cpus(&program_context) == false) {
         LOG_E(TAG, "Unable to setup cpu affinity");

--- a/tests/test-fiber-scheduler.cpp
+++ b/tests/test-fiber-scheduler.cpp
@@ -254,8 +254,11 @@ TEST_CASE("fiber_scheduler.c", "[fiber_scheduler]") {
         REQUIRE(fiber_scheduler_stack.index == 0);
         REQUIRE(fiber_scheduler_stack.size == 2);
         REQUIRE(strcmp(fiber_scheduler_stack.list[0]->name, FIBER_SCHEDULER_FIBER_NAME) == 0);
+
+#if DEBUG == 1
         REQUIRE(strcmp(fiber->switched_back_on.file, CACHEGRAND_SRC_PATH) == 0);
         REQUIRE(strcmp(fiber->switched_back_on.func, "test_fiber_scheduler_fiber_switch_to_test_entrypoint") == 0);
+#endif
 
         fiber_free(fiber);
 

--- a/tests/test-pidfile.cpp
+++ b/tests/test-pidfile.cpp
@@ -36,7 +36,7 @@ bool test_pidfile_get_fnctl_lock(
 
         if ((fd = open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)) > -1) {
             if (fcntl(fd, F_GETLK, &child_lock) > -1) {
-                write(pipe_fd[1], &child_lock, sizeof(struct flock));
+                ssize_t ignore = write(pipe_fd[1], &child_lock, sizeof(struct flock));
                 fsync(pipe_fd[1]);
             }
         }

--- a/tools/cmake/options.cmake
+++ b/tools/cmake/options.cmake
@@ -1,4 +1,4 @@
-option(BUILD_TESTS "Build Tests" ON)
+option(BUILD_TESTS "Build Tests" OFF)
 option(BUILD_INTERNAL_BENCHES "Build Internal Benches" OFF)
 
 option(USE_HASH_ALGORITHM_XXH3 "Use xxh3 (xxHash) as hash algorithm for the hashtable" 0)


### PR DESCRIPTION
The PR contains a number of minor fixes and cleanups, for both the source code and the build system:

- the tests should be built only when requested not by default
- the fiber.switched_on fields file, line and func are available only in the debug builds
- in the skel config file, clarify some inner working behind max_keys and remove a non existing parameter
- fix a build warning for the tests for the pid file
- if cachegrand fails to create the pidfile at the startup don't terminate the execution