### PR TITLE
Improve performance of the redis get command avoiding fiber switches for small set of data

### DIFF
--- a/tools/cmake/build-types/build-types.cmake
+++ b/tools/cmake/build-types/build-types.cmake
@@ -24,8 +24,8 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 elseif (CMAKE_BUILD_TYPE MATCHES Release)
     add_definitions(-DNDEBUG=1)
 
-    add_compile_options($<$<COMPILE_LANGUAGE:C>:-O3>)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-O3>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-O2>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-O2>)
 
     message(STATUS "Release build")
 endif()


### PR DESCRIPTION
This PR fixes an optimisation that was broken in PR #99, it ensure that if the data to read from the storage are smaller than 64kb - 32 bytes everything gets sent without switching fiber context, dramatically reducing the latency.

The PR also include a non related fix that sets the build optimisation level to 2 as it's the one normally used for the packages in the distro.