### PR TITLE
Fix memory leaks when set and shutdown

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -9,9 +9,9 @@ extern "C" {
 #define HASHTABLE_USE_UINT64    1
 #endif
 
-#define HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT     14
-#define HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX      32
-#define HASHTABLE_KEY_INLINE_MAX_LENGTH             22
+#define HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT    14
+#define HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX          32
+#define HASHTABLE_KEY_INLINE_MAX_LENGTH                 22
 
 typedef uint8_t hashtable_key_value_flags_t;
 typedef uint64_t hashtable_hash_t;

--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -42,11 +42,11 @@ enum {
 };
 
 #define HASHTABLE_KEY_VALUE_HAS_FLAG(flags, flag) \
-    ((flags & (hashtable_key_value_flags_t)flag) == (hashtable_key_value_flags_t)flag)
+    (((flags) & (hashtable_key_value_flags_t)(flag)) == (hashtable_key_value_flags_t)(flag))
 #define HASHTABLE_KEY_VALUE_SET_FLAG(flags, flag) \
     flags |= (hashtable_key_value_flags_t)flag
 #define HASHTABLE_KEY_VALUE_IS_EMPTY(flags) \
-    (flags == 0)
+    ((flags) == 0)
 
 
 /**

--- a/src/network/protocol/redis/command/network_protocol_redis_command_set.c
+++ b/src/network/protocol/redis/command/network_protocol_redis_command_set.c
@@ -174,7 +174,7 @@ NETWORK_PROTOCOL_REDIS_COMMAND_FUNCPTR_ARGUMENT_STREAM_DATA(set) {
         // (in debug mode)
         assert(set_command_context->key_offset + chunk_length <= set_command_context->key_length);
 
-        memcpy(set_command_context->key, chunk_data, chunk_length);
+        memcpy(set_command_context->key + set_command_context->key_offset, chunk_data, chunk_length);
         set_command_context->key_offset += chunk_length;
 
         // If the backend is in memory it's not necessary to write the key to the storage because it will never be used as

--- a/src/network/protocol/redis/command/network_protocol_redis_command_set.c
+++ b/src/network/protocol/redis/command/network_protocol_redis_command_set.c
@@ -352,6 +352,8 @@ NETWORK_PROTOCOL_REDIS_COMMAND_FUNCPTR_COMMAND_FREE(set) {
 
     if (!set_command_context->entry_index_saved) {
         storage_db_entry_index_free(db, set_command_context->entry_index);
+        slab_allocator_mem_free(set_command_context->key);
+        set_command_context->key = NULL;
     }
 
     slab_allocator_mem_free(protocol_context->command_context);

--- a/src/network/protocol/redis/command/network_protocol_redis_command_set.c
+++ b/src/network/protocol/redis/command/network_protocol_redis_command_set.c
@@ -120,7 +120,7 @@ NETWORK_PROTOCOL_REDIS_COMMAND_FUNCPTR_ARGUMENT_STREAM_BEGIN(set) {
 
         set_command_context->key_length = argument_length;
         set_command_context->key_offset = 0;
-        set_command_context->key = slab_allocator_mem_alloc(set_command_context->key_length);;
+        set_command_context->key = slab_allocator_mem_alloc(set_command_context->key_length);
 
         // If the backend is in memory it's not necessary to write the key to the storage because it will never be used as
         // the only case in which the keys are read from the storage is when the database gets loaded from the disk at the

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -446,7 +446,6 @@ void storage_db_free(
         double_linked_list_free(db->shards.opened_shards);
     }
 
-    // TODO: iterate over the hashtable to free up the memory
     for(uint64_t bucket_index = 0; bucket_index < db->hashtable->ht_current->buckets_count_real; bucket_index++) {
         hashtable_key_value_volatile_t *key_value = &db->hashtable->ht_current->keys_values[bucket_index];
 

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -750,7 +750,7 @@ void storage_db_entry_index_status_set_deleted(
             &entry_index->status._cas_wrapper,
             deleted ? 0x80000000 : 0);
 
-    if (likely(old_status)) {
+    if (likely(old_status != NULL)) {
         old_status->_cas_wrapper = cas_wrapper_ret;
     }
 }
@@ -863,16 +863,16 @@ bool storage_db_delete_entry_index(
         storage_db_t *db,
         char *key,
         size_t key_length) {
-    storage_db_entry_index_t *previous_entry_index = NULL;
+    storage_db_entry_index_t *current_entry_index = NULL;
 
     bool res = hashtable_mcmp_op_delete(
             db->hashtable,
             key,
             key_length,
-            (uintptr_t*)&previous_entry_index);
+            (uintptr_t*)&current_entry_index);
 
-    if (res && previous_entry_index != NULL) {
-        storage_db_worker_mark_deleted_or_deleting_previous_entry_index(db, previous_entry_index);
+    if (res && current_entry_index != NULL) {
+        storage_db_worker_mark_deleted_or_deleting_previous_entry_index(db, current_entry_index);
     }
 
     return res;

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -399,12 +399,6 @@ void* worker_thread_func(
             break;
         }
 
-        // The condition checked below is mostly for the tests, as there are some simple tests that should setup the
-        // storage_db otherwise
-        if (worker_context->db) {
-            storage_db_worker_garbage_collect_deleting_entry_index_when_no_readers(worker_context->db);
-        }
-
         if (worker_stats_should_publish(&worker_context->stats.shared)) {
             worker_stats_publish(
                     &worker_context->stats.internal,

--- a/src/worker/worker_op.c
+++ b/src/worker/worker_op.c
@@ -37,8 +37,14 @@ worker_op_timer_fp_t* worker_op_timer;
 
 void worker_timer_fiber_entrypoint(
         void *user_data) {
+    worker_context_t* worker_context = worker_context_get();
+
     while(worker_op_timer(0, WORKER_TIMER_LOOP_MS * 1000000l)) {
-        // TODO: process timeouts / garbage collector / etc
+        // The condition checked below is mostly for the tests, as there are some simple tests that should setup the
+        // storage_db otherwise
+        if (worker_context->db) {
+            storage_db_worker_garbage_collect_deleting_entry_index_when_no_readers(worker_context->db);
+        }
     }
 }
 

--- a/src/worker/worker_op.h
+++ b/src/worker/worker_op.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#define WORKER_TIMER_LOOP_MS 500l
+#define WORKER_TIMER_LOOP_MS 50l
 
 typedef bool (worker_op_timer_fp_t)(
         long seconds,

--- a/tests/hashtable/fixtures-hashtable.h
+++ b/tests/hashtable/fixtures-hashtable.h
@@ -35,7 +35,7 @@ char test_key_same_bucket_key_prefix_external[] = "same_bucket_key_not_inline_";
 char test_key_same_bucket_key_prefix_inline[] = "sb_key_inline_";
 
 char test_key_1[32] = "test key 1";
-hashtable_key_size_t test_key_1_len = 10;
+hashtable_key_size_t test_key_1_len = strlen(test_key_1);
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
     hashtable_hash_t test_key_1_hash = (hashtable_hash_t)t1ha2_atonce(test_key_1, test_key_1_len, HASHTABLE_SUPPORT_HASH_SEED);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
@@ -48,7 +48,7 @@ hashtable_hash_half_t test_key_1_hash_half = (test_key_1_hash >> 32u) | 0x800000
 hashtable_hash_quarter_t test_key_1_hash_quarter = test_key_1_hash_half & 0xFFFF;
 
 char test_key_2[32] = "test key 2";
-hashtable_key_size_t test_key_2_len = 10;
+hashtable_key_size_t test_key_2_len = strlen(test_key_2);
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
     hashtable_hash_t test_key_2_hash = (hashtable_hash_t)t1ha2_atonce(test_key_2, test_key_2_len, HASHTABLE_SUPPORT_HASH_SEED);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
@@ -59,6 +59,19 @@ hashtable_key_size_t test_key_2_len = 10;
 #endif
 hashtable_hash_half_t test_key_2_hash_half = (test_key_2_hash >> 32u) | 0x80000000u;
 hashtable_hash_quarter_t test_key_2_hash_quarter = test_key_2_hash_half & 0xFFFF;
+
+char test_key_long_1[] = "a very long test key that can't be inlined 1";
+hashtable_key_size_t test_key_long_1_len = strlen(test_key_long_1);
+#if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
+hashtable_hash_t test_key_long_1_hash = (hashtable_hash_t)t1ha2_atonce(test_key_long_1, test_key_long_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+#elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
+hashtable_hash_t test_key_long_1_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_long_1, test_key_long_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+#elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_CRC32 == 1
+uint32_t crc32 = hash_crc32c(test_key_long_1, test_key_long_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+hashtable_hash_t test_key_long_1_hash = ((uint64_t)hash_crc32c(test_key_long_1, test_key_long_1_len, crc32) << 32u) | crc32;
+#endif
+hashtable_hash_half_t test_key_long_1_hash_half = (test_key_long_1_hash >> 32u) | 0x80000000u;
+hashtable_hash_quarter_t test_key_long_1_hash_quarter = test_key_long_1_hash_half & 0xFFFF;
 
 #define HASHTABLE_DATA(buckets_count_v, ...) \
 { \

--- a/tests/hashtable/test-hashtable-op-delete.cpp
+++ b/tests/hashtable/test-hashtable-op-delete.cpp
@@ -41,9 +41,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 hashtable_key_value_volatile_t *key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
+                char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         NULL));
@@ -75,9 +78,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 hashtable_key_value_volatile_t *key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
+                char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         NULL));
@@ -109,9 +115,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 hashtable_key_value_volatile_t *key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
+                char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         NULL));
@@ -128,9 +137,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
+                test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         NULL));
@@ -160,9 +172,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         slots_to_fill);
 
                 for(hashtable_chunk_index_t i = 0; i < slots_to_fill; i++) {
+                    char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(test_key_same_bucket_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            (char *) test_key_same_bucket[i].key,
+                            test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
                             NULL));
@@ -203,9 +218,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         slots_to_fill);
 
                 for(hashtable_chunk_index_t i = 0; i < slots_to_fill - 1; i++) {
+                    char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(test_key_same_bucket_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            (char *) test_key_same_bucket[i].key,
+                            test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
                             NULL));
@@ -232,9 +250,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
                 REQUIRE(key_value->data == test_value_1 + random_slot_index);
 
+                char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[slots_to_fill - 1].key_len + 1);
+                strncpy(test_key_same_bucket_alloc, test_key_same_bucket[slots_to_fill - 1].key, test_key_same_bucket[slots_to_fill - 1].key_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        (char *) test_key_same_bucket[slots_to_fill - 1].key,
+                        test_key_same_bucket_alloc,
                         test_key_same_bucket[slots_to_fill - 1].key_len,
                         test_value_1 + slots_to_fill - 1,
                         NULL));

--- a/tests/hashtable/test-hashtable-op-set.cpp
+++ b/tests/hashtable/test-hashtable-op-set.cpp
@@ -31,9 +31,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                 hashtable_key_value_volatile_t * key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
+                char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         &prev_value));
@@ -75,16 +78,22 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                 hashtable_key_value_volatile_t * key_value =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
+                char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         &prev_value1));
 
+                test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1 + 1,
                         &prev_value2));
@@ -132,16 +141,22 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                 hashtable_key_value_volatile_t * key_value2 =
                         &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index2, chunk_slot_index2)];
 
+                char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_1,
+                        test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
                         NULL));
 
+                char *test_key_2_alloc = (char*)malloc(test_key_2_len + 1);
+                strncpy(test_key_2_alloc, test_key_2, test_key_2_len + 1);
+
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
-                        test_key_2,
+                        test_key_2_alloc,
                         test_key_2_len,
                         test_value_2,
                         NULL));
@@ -181,9 +196,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         slots_to_fill);
 
                 for(hashtable_chunk_index_t i = 0; i < slots_to_fill; i++) {
+                    char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(test_key_same_bucket_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            (char *) test_key_same_bucket[i].key,
+                            (char*)test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
                             NULL));
@@ -228,9 +246,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         slots_to_fill);
 
                 for(hashtable_chunk_slot_index_t i = 0; i < slots_to_fill; i++) {
+                    char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(test_key_same_bucket_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            (char *) test_key_same_bucket[i].key,
+                            test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
                             NULL));
@@ -281,9 +302,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         slots_to_fill);
 
                 for(hashtable_chunk_slot_index_t i = 0; i < slots_to_fill; i++) {
+                    char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(test_key_same_bucket_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            (char *) test_key_same_bucket[i].key,
+                            test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
                             NULL));
@@ -319,17 +343,23 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
 
                 uint32_t i = 0;
                 for(; i < slots_to_fill - 1; i++) {
+                    char *test_key_same_bucket_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(test_key_same_bucket_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            (char *) test_key_same_bucket[i].key,
+                            test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
                             NULL));
                 }
 
+                char *test_key_alloc = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                strncpy(test_key_alloc, test_key_same_bucket[i].key, test_key_same_bucket[i].key_len + 1);
+
                 REQUIRE(!hashtable_mcmp_op_set(
                         hashtable,
-                        (char *) test_key_same_bucket[i].key,
+                        test_key_alloc,
                         test_key_same_bucket[i].key_len,
                         test_value_1 + i,
                         NULL));
@@ -351,9 +381,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                     hashtable_key_value_volatile_t * key_value =
                             &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
 
+                    char *test_key_1_alloc = (char*)malloc(test_key_1_len + 1);
+                    strncpy(test_key_1_alloc, test_key_1, test_key_1_len + 1);
+
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
-                            test_key_1,
+                            test_key_1_alloc,
                             test_key_1_len,
                             test_value_1,
                             NULL));

--- a/tests/hashtable/test-hashtable-op-set.cpp
+++ b/tests/hashtable/test-hashtable-op-set.cpp
@@ -18,7 +18,7 @@
 
 TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashtable_mcmp_op_set]") {
     SECTION("hashtable_mcmp_op_set") {
-        SECTION("set 1 bucket") {
+        SECTION("set 1 bucket - inline key") {
             HASHTABLE(0x7FFF, false, {
                 uintptr_t prev_value = 0;
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
@@ -55,6 +55,50 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         (char*)key_value->inline_key.data,
                         test_key_1,
                         test_key_1_len) == 0);
+                REQUIRE(key_value->data == test_value_1);
+                REQUIRE(prev_value == 0);
+
+                // Check if the subsequent element has been affected by the changes
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index + 1].slot_id == 0);
+            })
+        }
+
+        SECTION("set 1 bucket - external key") {
+            HASHTABLE(0x7FFF, false, {
+                uintptr_t prev_value = 0;
+                hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
+                        hashtable->ht_current->buckets_count,
+                        test_key_long_1_hash));
+                hashtable_chunk_slot_index_t chunk_slot_index = 0;
+
+                hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk =
+                        &hashtable->ht_current->half_hashes_chunk[chunk_index];
+                hashtable_key_value_volatile_t * key_value =
+                        &hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)];
+
+                char *test_key_long_1_alloc = (char*)malloc(test_key_long_1_len + 1);
+                strncpy(test_key_long_1_alloc, test_key_long_1, test_key_long_1_len + 1);
+
+                REQUIRE(hashtable_mcmp_op_set(
+                        hashtable,
+                        test_key_long_1_alloc,
+                        test_key_long_1_len,
+                        test_value_1,
+                        &prev_value));
+
+                // Check if the write lock has been released
+                REQUIRE(!spinlock_is_locked(&half_hashes_chunk->write_lock));
+
+                // Check if the first slot of the chain ring contains the correct key/value
+                REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
+                REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_long_1_hash_quarter);
+                REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_FILLED);
+                REQUIRE(strncmp(
+                        (char*)key_value->external_key.data,
+                        test_key_long_1,
+                        test_key_long_1_len) == 0);
                 REQUIRE(key_value->data == test_value_1);
                 REQUIRE(prev_value == 0);
 


### PR DESCRIPTION
This PR fixes a couple of memory fixes:
- When the key is passed to the hashtable set, the hashtable code takes ownership of its management as the pointer will be stored in the hashtable to avoid copies, in some cases though, when the key is inlined or when an hashtable value is getting overwritten, the key isn't going to be used and should be, therefore freed.
- When the storage db is freed, the memory allocated for the keys and the storage db entries have to be freed up

The PR includes also:
- some minor style fixes
- some minor speed optimization, it's not necessary to GC the storage db entry index that are getting deleted on every internal loop, it's better to take advantage of the internal timer and run the procedure when it ticks, the tick interval has been reduced to 50ms
- some additional tests
