### PR TITLE
Implement hashtable op iter

### DIFF
--- a/benches/main.cpp
+++ b/benches/main.cpp
@@ -34,14 +34,6 @@ int main(int argc, char** argv) {
     // the main thread of the process
     thread_current_set_affinity(0);
 
-    fprintf(stdout, "Be aware, benchmarking is configured to:\n");
-    fprintf(stdout, "- spin up to 16 threads per core (with a limit to 2048 threads), pinning the threads to the cores\n");
-    fprintf(stdout, "- consume up to *120GB* of memory when testing the 2bln key hashtable size\n");
-    fprintf(stdout, "- the pre-generated keys are flushed from the cpu data cache at the beginning of each test,\n");
-    fprintf(stdout, "  although the test keyset by default contains 1610612736 (1.610bln) with a size of 46.5GB\n");
-    fprintf(stdout, "  so there is no chance to fit it in the cpu cache.\n");
-    fprintf(stdout, "\n");
-
     fprintf(stdout, "The benchmarks are running using the following hash algorithm:\n  %s\n",
             HASHTABLE_SUPPORT_HASH_NAME);
     fflush(stdout);

--- a/src/data_structures/hashtable/mcmp/hashtable.c
+++ b/src/data_structures/hashtable/mcmp/hashtable.c
@@ -19,6 +19,7 @@
 #include "hashtable.h"
 #include "hashtable_config.h"
 #include "hashtable_data.h"
+#include "hashtable_op_iter.h"
 
 hashtable_t* hashtable_mcmp_init(hashtable_config_t* hashtable_config) {
     hashtable_bucket_count_t buckets_count = pow2_next(hashtable_config->initial_size);
@@ -50,7 +51,7 @@ hashtable_t* hashtable_mcmp_init(hashtable_config_t* hashtable_config) {
 
 void hashtable_mcmp_free(hashtable_t* hashtable) {
     if (hashtable->ht_current) {
-        hashtable_mcmp_data_free((hashtable_data_t *) hashtable->ht_current);
+        hashtable_mcmp_data_free((hashtable_data_t *)hashtable->ht_current);
         hashtable->ht_current = NULL;
     }
 

--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -9,6 +9,12 @@ extern "C" {
 #define HASHTABLE_USE_UINT64    1
 #endif
 
+// By default, don't inline keys, although it might improve memory consumption it will hit hard to the memory allocator
+// which require currently some minimal locking wasting a lot of cycles just to save up to 32 bytes
+#ifndef HASHTABLE_FLAG_ALLOW_KEY_INLINE
+#define HASHTABLE_FLAG_ALLOW_KEY_INLINE 0
+#endif
+
 #define HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT    14
 #define HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX          32
 #define HASHTABLE_KEY_INLINE_MAX_LENGTH                 22

--- a/src/data_structures/hashtable/mcmp/hashtable_data.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.c
@@ -12,16 +12,21 @@
 #include <string.h>
 #include <errno.h>
 #include <numa.h>
+#include <assert.h>
 
 #include "exttypes.h"
 #include "spinlock.h"
 #include "xalloc.h"
 #include "pow2.h"
+#include "spinlock.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "slab_allocator.h"
 
 #include "hashtable.h"
 #include "hashtable_data.h"
 
-hashtable_data_t* hashtable_mcmp_data_init(hashtable_bucket_count_t buckets_count) {
+hashtable_data_t* hashtable_mcmp_data_init(
+        hashtable_bucket_count_t buckets_count) {
     if (pow2_is(buckets_count) == false) {
         return NULL;
     }

--- a/src/data_structures/hashtable/mcmp/hashtable_data.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.c
@@ -31,11 +31,14 @@ hashtable_data_t* hashtable_mcmp_data_init(hashtable_bucket_count_t buckets_coun
     hashtable_data->buckets_count =
             buckets_count;
     hashtable_data->buckets_count_real =
-            hashtable_data->buckets_count +
+            hashtable_data->buckets_count -
             (buckets_count % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) +
+            HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT +
             (HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
     hashtable_data->chunks_count =
             hashtable_data->buckets_count_real / HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
+
+    assert(hashtable_data->chunks_count * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT == hashtable_data->buckets_count_real);
 
     hashtable_data->half_hashes_chunk_size =
             sizeof(hashtable_half_hashes_chunk_volatile_t) * hashtable_data->chunks_count;

--- a/src/data_structures/hashtable/mcmp/hashtable_data.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.h
@@ -15,6 +15,9 @@ bool hashtable_mcmp_data_numa_interleave_memory(
 void hashtable_mcmp_data_free(
         hashtable_data_t* hashtable_data);
 
+void hashtable_mcmp_data_keys_free(
+        hashtable_data_t* hashtable_data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
@@ -110,7 +110,9 @@ bool hashtable_mcmp_op_delete(
 
             MEMORY_FENCE_STORE();
 
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
             if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value_flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
+#endif
                 // The get operation might be comparing the key while it gets freed because it doesn't use the lock, the
                 // scenario in which it might happen is that the code in the get operation has already checked the flags
                 // and therefore is now comparing the key.
@@ -123,7 +125,9 @@ bool hashtable_mcmp_op_delete(
                 slab_allocator_mem_free(key_value->external_key.data);
                 key_value->external_key.data = NULL;
                 key_value->external_key.size = 0;
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
             }
+#endif
 
             deleted = true;
         }

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -53,14 +53,16 @@ void *hashtable_mcmp_op_iter(
             }
 
             key_value = &hashtable->ht_current->keys_values[*bucket_index];
+            volatile void* data = (void*)key_value->data;
 
+            MEMORY_FENCE_LOAD();
             if (
                     HASHTABLE_KEY_VALUE_IS_EMPTY(key_value->flags) ||
                     HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED)) {
                 continue;
             }
 
-            return (void*)key_value->data;
+            return (void*)data;
         }
 
         chunk_slot_index = 0;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -23,7 +23,7 @@
 
 #include "hashtable_op_iter.h"
 
-void *hashtable_op_iter_next(
+void *hashtable_mcmp_op_iter(
         hashtable_t *hashtable,
         uint64_t *bucket_index) {
     hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdatomic.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "memory_fences.h"
+#include "spinlock.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "slab_allocator.h"
+#include "hashtable.h"
+#include "hashtable_data.h"
+
+#include "hashtable_op_iter.h"
+
+void *hashtable_op_iter_next(
+        hashtable_t *hashtable,
+        uint64_t *bucket_index) {
+    hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk;
+    hashtable_key_value_volatile_t *key_value;
+    hashtable_chunk_index_t chunk_index, chunk_index_start, chunk_index_end;
+    hashtable_chunk_slot_index_t chunk_slot_index;
+
+    chunk_index_start = *bucket_index / HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
+    chunk_index_end = hashtable->ht_current->chunks_count;
+    chunk_slot_index = *bucket_index % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
+
+    for(
+            chunk_index = chunk_index_start;
+            chunk_index < chunk_index_end;
+            chunk_index++) {
+        half_hashes_chunk = &hashtable->ht_current->half_hashes_chunk[chunk_index];
+
+        for(; chunk_slot_index < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; chunk_slot_index++) {
+            MEMORY_FENCE_LOAD();
+            *bucket_index = (chunk_index * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) + chunk_slot_index;
+
+            assert(*bucket_index < hashtable->ht_current->buckets_count_real);
+
+            // If there is no slot_id (hash plus other metadata) the bucket is empty and can be skipped
+            if (half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0) {
+                continue;
+            }
+
+            key_value = &hashtable->ht_current->keys_values[*bucket_index];
+
+            if (
+                    HASHTABLE_KEY_VALUE_IS_EMPTY(key_value->flags) ||
+                    HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED)) {
+                continue;
+            }
+
+            return (void*)key_value->data;
+        }
+
+        chunk_slot_index = 0;
+    }
+
+    return NULL;
+}

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
@@ -1,0 +1,16 @@
+#ifndef CACHEGRAND_HASHTABLE_OP_ITER_H
+#define CACHEGRAND_HASHTABLE_OP_ITER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *hashtable_op_iter_next(
+        hashtable_t *hashtable,
+        uint64_t *bucket_index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_HASHTABLE_OP_ITER_H

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void *hashtable_op_iter_next(
+void *hashtable_mcmp_op_iter(
         hashtable_t *hashtable,
         uint64_t *bucket_index);
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_set.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_set.c
@@ -46,6 +46,8 @@ bool hashtable_mcmp_op_set(
     LOG_DI("key (%d) = %s", key_size, key);
     LOG_DI("hash = 0x%016x", hash);
 
+    assert(*key != 0);
+
     // TODO: the resize logic has to be reviewed, the underlying hash search function has to be aware that it hasn't
     //       to create a new item if it's missing
     bool ret = hashtable_mcmp_support_op_search_key_or_create_new(

--- a/src/data_structures/hashtable/mcmp/hashtable_op_set.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_set.c
@@ -89,6 +89,7 @@ bool hashtable_mcmp_op_set(
 
         LOG_DI("copying the key onto the key_value structure");
 
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         // Get the destination pointer for the key
         if (key_size <= HASHTABLE_KEY_INLINE_MAX_LENGTH) {
             key_inlined = true;
@@ -102,10 +103,12 @@ bool hashtable_mcmp_op_set(
             key_value->inline_key.size = key_size;
         } else {
             LOG_DI("key can't be inline-ed, max length for inlining %d", HASHTABLE_KEY_INLINE_MAX_LENGTH);
-
+#endif
             key_value->external_key.data = key;
             key_value->external_key.size = key_size;
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         }
+#endif
 
         // Set the FILLED flag
         HASHTABLE_KEY_VALUE_SET_FLAG(flags, HASHTABLE_KEY_VALUE_FLAG_FILLED);

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -138,6 +138,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
 
             LOG_DI(">> checking key");
 
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
             // The key may potentially change if the item is first deleted and then recreated, if it's inline it
             // doesn't really matter because the key will mismatch and the execution will continue but if the key is
             // stored externally and the allocated memory is freed it may crash.
@@ -149,6 +150,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
                 found_key_compare_size = key_value->inline_key.size;
             } else {
                 LOG_DI(">> key_value->flags hasn't HASHTABLE_BUCKET_KEY_VALUE_FLAG_KEY_INLINE");
+#endif
 
                 found_key = key_value->external_key.data;
                 found_key_compare_size = key_value->external_key.size;
@@ -158,7 +160,9 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
                            key_size, key_value->external_key.size);
                     continue;
                 }
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
             }
+#endif
 
             // Ensure that the fresh-est flags value is going to be read to avoid that the deleted flag has
             // been set after they key pointer has been read
@@ -349,6 +353,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                 LOG_DI(">>> key_value->flags = 0x%08x", key_value->flags);
 
                 if (searching_or_creating == 0) {
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
                     if (HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags,
                             HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
                         LOG_DI(">>> key_value->flags has HASHTABLE_BUCKET_KEY_VALUE_FLAG_KEY_INLINE");
@@ -357,6 +362,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                         found_key_compare_size = key_value->inline_key.size;
                     } else {
                         LOG_DI(">>> key_value->flags hasn't HASHTABLE_BUCKET_KEY_VALUE_FLAG_KEY_INLINE");
+#endif
 
                         found_key = key_value->external_key.data;
                         found_key_compare_size = key_value->external_key.size;
@@ -366,8 +372,9 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                                      key_size, key_value->external_key.size);
                             continue;
                         }
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
                     }
-
+#endif
                     LOG_DI(">>> key fetched, comparing");
 
                     if (unlikely(utils_string_casecmp_eq_32(

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -41,13 +41,13 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
         hashtable_chunk_slot_index_t *found_chunk_slot_index,
         hashtable_key_value_volatile_t **found_key_value) {
     hashtable_hash_half_t hash_half;
-    hashtable_slot_id_wrapper_t slot_id_wrapper = {0};
+    hashtable_slot_id_wrapper_t slot_id_wrapper = { 0 };
     hashtable_bucket_index_t bucket_index;
     hashtable_chunk_index_t chunk_index, chunk_index_start_initial;
     hashtable_chunk_slot_index_t chunk_slot_index;
-    hashtable_half_hashes_chunk_volatile_t * half_hashes_chunk;
-    hashtable_key_value_volatile_t* key_value;
-    volatile hashtable_key_data_t* found_key;
+    hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk;
+    hashtable_key_value_volatile_t *key_value;
+    volatile hashtable_key_data_t *found_key;
     hashtable_key_size_t found_key_compare_size;
     uint32_t skip_indexes_mask;
     bool found = false;
@@ -164,9 +164,8 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
             // been set after they key pointer has been read
             MEMORY_FENCE_LOAD();
 
-            // Check the flags after it fetches the key, if DELETED is set the flag that specifies the
-            // inline of the key is not reliable anymore and therefore we may read from some memory not owned
-            // by the software.
+            // Check the flags after it fetches the key, if DELETED is set the flag that indicates that the key is
+            // inlined is not reliable anymore, therefore we may read from some memory not owned by the software.
             if (unlikely(HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags,
                     HASHTABLE_KEY_VALUE_FLAG_DELETED))) {
                 LOG_DI(">> key_value->flags has HASHTABLE_BUCKET_KEY_VALUE_FLAG_DELETED - continuing");
@@ -263,7 +262,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
             (searching_or_creating < (create_new_if_missing ? 2 : 1)) && found == false;
             searching_or_creating++) {
 
-        // Setup the search range
+        // Set up the search range
         if (searching_or_creating == 0) {
             // chunk_index_start has been calculated at the beginning of the function
             chunk_index_end = chunk_index_start + overflowed_chunks_counter + 1;
@@ -325,7 +324,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
 
             while (true) {
                 // It's not necessary to have a memory fence here, these data are not going to change because of the
-                // write lock and a full barrier is issued by the lock operation
+                // write-lock and a full barrier is issued by the lock operation
                 chunk_slot_index = HASHTABLE_MCMP_SUPPORT_HASH_SEARCH_FUNC(
                         searching_or_creating == 0 ? slot_id_wrapper.slot_id : 0,
                         (hashtable_hash_half_volatile_t *) half_hashes_chunk->half_hashes,
@@ -422,7 +421,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                     LOG_DI(">> can't find a free slot in current chunk, setting is_full to 1");
 
                     // Not needed to perform a memory store barrier here, the is_full metadata is used only by the
-                    // the thread holding the lock
+                    // thread holding the lock
                     half_hashes_chunk->metadata.is_full = 1;
                 }
             }

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -481,9 +481,9 @@ void storage_db_free(
     // Iterates over the hashtable to free up the entry index
     hashtable_bucket_index_t bucket_index = 0;
     for(
-            void *data = hashtable_op_iter_next(db->hashtable, &bucket_index);
+            void *data = hashtable_mcmp_op_iter(db->hashtable, &bucket_index);
             data;
-            ++bucket_index && (data = hashtable_op_iter_next(db->hashtable, &bucket_index))) {
+            ++bucket_index && (data = hashtable_mcmp_op_iter(db->hashtable, &bucket_index))) {
         storage_db_entry_index_free(db, data);
     }
 

--- a/tests/hashtable/test-hashtable-data.cpp
+++ b/tests/hashtable/test-hashtable-data.cpp
@@ -56,8 +56,9 @@ TEST_CASE("hashtable/hashtable_data.c", "[hashtable][hashtable_data]") {
     SECTION("hashtable_data->buckets_count_real") {
         HASHTABLE_DATA(0x80u, {
             uint64_t buckets_count_real_calc =
-                    hashtable_data->buckets_count +
+                    hashtable_data->buckets_count -
                     (hashtable_data->buckets_count % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) +
+                    HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT +
                     (HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
             REQUIRE(hashtable_data->buckets_count_real == buckets_count_real_calc);
         })

--- a/tests/hashtable/test-hashtable-op-get.cpp
+++ b/tests/hashtable/test-hashtable-op-get.cpp
@@ -11,9 +11,12 @@
 
 #include <string.h>
 
+#include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
 #include "xalloc.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "slab_allocator.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_config.h"
@@ -37,6 +40,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
             })
         }
 
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         SECTION("found - key inline") {
             HASHTABLE(0x7FFF, false, {
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
@@ -60,9 +64,14 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                 REQUIRE(value == test_value_1);
             })
         }
+#endif
 
         SECTION("found - key external") {
             HASHTABLE(0x7FFF, false, {
+                // Not necessary to free, the key is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
@@ -71,13 +80,13 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         chunk_index,
                         0,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         test_value_1);
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         &value));
 
@@ -87,6 +96,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
         SECTION("found - multiple chunks first slot") {
             HASHTABLE(0x7FFF, false, {
+                // Not necessary to free, the key(s) is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                char *test_key_2_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+                strcpy(test_key_2_copy, test_key_2);
+
                 hashtable_chunk_index_t chunk_index1 = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
@@ -94,25 +109,25 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         hashtable->ht_current->buckets_count,
                         test_key_2_hash));
 
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         chunk_index1,
                         0,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         test_value_1);
 
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         chunk_index2,
                         0,
                         test_key_2_hash,
-                        test_key_2,
+                        test_key_2_copy,
                         test_key_2_len,
                         test_value_2);
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         &value));
 
@@ -120,7 +135,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
-                        test_key_2,
+                        test_key_2_copy,
                         test_key_2_len,
                         &value));
 
@@ -130,21 +145,25 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
         SECTION("found - single chunk with first slot empty") {
             HASHTABLE(0x7FFF, false, {
+                // Not necessary to free, the key(s) is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         chunk_index,
                         1,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         test_value_1);
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         &value));
 
@@ -163,11 +182,18 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         test_key_same_bucket[0].key_hash % hashtable->ht_current->buckets_count;
 
                 for(hashtable_chunk_slot_index_t i = 0; i < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; i++) {
-                    HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                    // Not necessary to free, the key(s) is owned by the hashtable
+                    char *test_key_same_bucket_current_copy = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(
+                            test_key_same_bucket_current_copy,
+                            test_key_same_bucket[i].key,
+                            test_key_same_bucket[i].key_len + 1);
+
+                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                             HASHTABLE_TO_CHUNK_INDEX(bucket_index_base),
                             i,
                             test_key_same_bucket[i].key_hash,
-                            test_key_same_bucket[i].key,
+                            test_key_same_bucket_current_copy,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i);
                 }
@@ -202,18 +228,24 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                 hashtable->ht_current->half_hashes_chunk[chunk_index_base].metadata.overflowed_chunks_counter =
                         ceil((double)slots_to_fill / HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
 
-
                 for(hashtable_chunk_slot_index_t i = 0; i < slots_to_fill; i++) {
+                    // Not necessary to free, the key(s) is owned by the hashtable
+                    char *test_key_same_bucket_current_copy = (char*)malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(
+                            test_key_same_bucket_current_copy,
+                            test_key_same_bucket[i].key,
+                            test_key_same_bucket[i].key_len + 1);
+
                     hashtable_chunk_index_t chunk_index =
                             chunk_index_base + (int)(i / HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
                     hashtable_chunk_slot_index_t chunk_slot_index =
                             i % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
 
-                    HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                             chunk_index,
                             chunk_slot_index,
                             test_key_same_bucket[i].key_hash,
-                            test_key_same_bucket[i].key,
+                            test_key_same_bucket_current_copy,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i);
                     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].distance =
@@ -240,11 +272,15 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
         SECTION("not found - deleted flag") {
             HASHTABLE(0x7FFF, false, {
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                // Not necessary to free, the key(s) is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         HASHTABLE_TO_CHUNK_INDEX(test_key_1_hash & (0x8000 - 1)),
                         0,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         test_value_1);
 
@@ -261,15 +297,19 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
         SECTION("not found - hash set but key_value not (edge case because of parallelism)") {
             HASHTABLE(0x7FFF, false, {
+                // Not necessary to free, the key(s) is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         chunk_index,
                         0,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         test_value_1);
 
@@ -288,26 +328,32 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
         SECTION("found - single bucket - get key after delete with hash still in hash_half (edge case because of parallelism)") {
             HASHTABLE(0x7FFF, false, {
+                // Not necessary to free, the key(s) is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                char *test_key_2_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+                strcpy(test_key_2_copy, test_key_1);
+
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         chunk_index,
                         0,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_1_copy,
                         test_key_1_len,
                         test_value_1);
 
                 HASHTABLE_KEYS_VALUES(chunk_index, 0).flags =
                         HASHTABLE_KEY_VALUE_FLAG_DELETED;
 
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
                         chunk_index,
                         2,
                         test_key_1_hash,
-                        test_key_1,
+                        test_key_2_copy,
                         test_key_1_len,
                         test_value_1 + 10);
 

--- a/tests/hashtable/test-hashtable-op-iter.cpp
+++ b/tests/hashtable/test-hashtable-op-iter.cpp
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch.hpp>
+#include <numa.h>
+
+#include <string.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "spinlock.h"
+#include "xalloc.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "slab_allocator.h"
+
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_config.h"
+#include "data_structures/hashtable/mcmp/hashtable_support_index.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_iter.h"
+
+#include "../support.h"
+#include "fixtures-hashtable.h"
+
+TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hashtable_mcmp_op_iter]") {
+    SECTION("hashtable_mcmp_op_iter") {
+        SECTION("hashtable empty") {
+            hashtable_bucket_index_t bucket_index = 0;
+
+            HASHTABLE(0x7FFF, false, {
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
+            })
+        }
+
+        SECTION("one key") {
+            hashtable_bucket_index_t bucket_index = 0;
+
+            HASHTABLE(0x7FFF, false, {
+                // Not necessary to free, the key(s) is owned by the hashtable
+                char *test_key_1_copy = (char*)slab_allocator_mem_alloc(test_key_1_len + 1);
+                strcpy(test_key_1_copy, test_key_1);
+
+                hashtable_chunk_index_t chunk_index1 = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
+                        hashtable->ht_current->buckets_count,
+                        test_key_1_hash));
+                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                        chunk_index1,
+                        0,
+                        test_key_1_hash,
+                        test_key_1_copy,
+                        test_key_1_len,
+                        test_value_1);
+
+                REQUIRE((uintptr_t)hashtable_mcmp_op_iter(hashtable,&bucket_index) == test_value_1);
+                REQUIRE(bucket_index == HASHTABLE_TO_BUCKET_INDEX(chunk_index1, 0));
+
+                bucket_index++;
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
+            })
+        }
+
+        SECTION("single chunk multiple slots") {
+            hashtable_bucket_index_t bucket_index = 0;
+
+            HASHTABLE(0x7FFF, false, {
+                test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        hashtable->ht_current->buckets_count,
+                        test_key_same_bucket_key_prefix_external,
+                        HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+
+                hashtable_bucket_index_t bucket_index_base =
+                        test_key_same_bucket[0].key_hash % hashtable->ht_current->buckets_count;
+
+                for (hashtable_chunk_slot_index_t i = 0; i < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; i++) {
+                    // Not necessary to free, the key(s) is owned by the hashtable
+                    char *test_key_same_bucket_current_copy = (char *) malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(
+                            test_key_same_bucket_current_copy,
+                            test_key_same_bucket[i].key,
+                            test_key_same_bucket[i].key_len + 1);
+
+                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                            HASHTABLE_TO_CHUNK_INDEX(bucket_index_base),
+                            i,
+                            test_key_same_bucket[i].key_hash,
+                            test_key_same_bucket_current_copy,
+                            test_key_same_bucket[i].key_len,
+                            test_value_1 + i);
+                }
+
+                for (hashtable_chunk_slot_index_t i = 0; i < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; i++) {
+                    REQUIRE((uintptr_t)hashtable_mcmp_op_iter(hashtable, &bucket_index) == test_value_1 + i);
+                    REQUIRE(bucket_index == HASHTABLE_TO_BUCKET_INDEX(HASHTABLE_TO_CHUNK_INDEX(bucket_index_base), i));
+
+                    bucket_index++;
+                }
+
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
+            })
+        }
+
+        SECTION("single chunk multiple slots all deleted") {
+            hashtable_bucket_index_t bucket_index = 0;
+
+            HASHTABLE(0x7FFF, false, {
+                test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        hashtable->ht_current->buckets_count,
+                        test_key_same_bucket_key_prefix_external,
+                        HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+
+                hashtable_bucket_index_t bucket_index_base =
+                        test_key_same_bucket[0].key_hash % hashtable->ht_current->buckets_count;
+
+                for (hashtable_chunk_slot_index_t i = 0; i < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; i++) {
+                    // Not necessary to free, the key(s) is owned by the hashtable
+                    char *test_key_same_bucket_current_copy = (char *) malloc(test_key_same_bucket[i].key_len + 1);
+                    strncpy(
+                            test_key_same_bucket_current_copy,
+                            test_key_same_bucket[i].key,
+                            test_key_same_bucket[i].key_len + 1);
+
+                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                            HASHTABLE_TO_CHUNK_INDEX(bucket_index_base),
+                            i,
+                            test_key_same_bucket[i].key_hash,
+                            test_key_same_bucket_current_copy,
+                            test_key_same_bucket[i].key_len,
+                            test_value_1 + i);
+
+                    HASHTABLE_KEYS_VALUES(HASHTABLE_TO_CHUNK_INDEX(bucket_index_base), i).flags =
+                            HASHTABLE_KEY_VALUE_FLAG_DELETED;
+                }
+
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
+            })
+        }
+    }
+}

--- a/tests/hashtable/test-hashtable-op-set.cpp
+++ b/tests/hashtable/test-hashtable-op-set.cpp
@@ -498,7 +498,11 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                     REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_FILLED);
 #endif
                     REQUIRE(strncmp(
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
                             (char*)key_value->inline_key.data,
+#else
+                            key_value->external_key.data,
+#endif
                             test_key_1,
                             test_key_1_len) == 0);
                     REQUIRE(key_value->data == test_value_1);

--- a/tests/test-spinlock.cpp
+++ b/tests/test-spinlock.cpp
@@ -159,7 +159,7 @@ TEST_CASE("spinlock.c", "[spinlock]") {
 
 #if DEBUG == 1
             long thread_id = syscall(__NR_gettid);
-            lock.lock = (uint16_t)thread_id;
+            lock.lock = (uint32_t)thread_id;
 #else
             lock.lock = SPINLOCK_LOCKED;
 #endif


### PR DESCRIPTION
This PR implements a new internal operation for the hashtable that allows to iterate over the available keys and values to simplify the code that disposes the keys and the values at the shutdown but will be used as well for frontend commands that require iteration over the keys and the values.

Specifically the storage_db_free has been refactored to be more readable and splitted in logical units, one of these take advantage of the new operation to iterate over the hashtable and dispose all the entry indexes, and hashtable_mcmp_data_free uses the new function to cleanup the keys at the shutdown.

The usage pattern is really simple, the function taks the hashtable and a bucket index as pointer which value has initially be set to 0, after each invocation, if the function doesn't return null, bucket_index has to be increased otherwise the current element will be found again.
```
    hashtable_bucket_index_t bucket_index = 0;
    for(
            void *data = hashtable_mcmp_op_iter(db->hashtable, &bucket_index);
            data;
            ++bucket_index && (data = hashtable_mcmp_op_iter(db->hashtable, &bucket_index))) {
        storage_db_entry_index_free(db, data);
    }
```

The PR contains also some general style cleanups, the tests for the new command and a minor bugfix in a test for the spinlocks.