### PR TITLE
Simplify slab allocator

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -17,7 +17,10 @@ extern "C" {
 
 #define HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT    14
 #define HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX          32
+
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
 #define HASHTABLE_KEY_INLINE_MAX_LENGTH                 22
+#endif
 
 typedef uint8_t hashtable_key_value_flags_t;
 typedef uint64_t hashtable_hash_t;
@@ -81,10 +84,12 @@ struct hashtable_key_value {
             hashtable_key_size_t size;          // 4 bytes
             hashtable_key_data_t* data;         // 8 bytes
         } __attribute__((packed)) external_key;
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         struct {
             uint8_t size;
             hashtable_key_data_t data[HASHTABLE_KEY_INLINE_MAX_LENGTH];
         } __attribute__((packed)) inline_key;
+#endif
     };
 
     hashtable_key_value_flags_t flags;

--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -10,7 +10,6 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <string.h>
-#include <stdatomic.h>
 
 #if __has_include(<valgrind/valgrind.h>)
 #include <valgrind/valgrind.h>
@@ -19,13 +18,11 @@
 
 #include "misc.h"
 #include "exttypes.h"
-#include "memory_fences.h"
 #include "spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "xalloc.h"
 #include "fatal.h"
 #include "utils_cpu.h"
-#include "utils_numa.h"
 #include "thread.h"
 #include "hugepages.h"
 #include "hugepage_cache.h"
@@ -114,40 +111,24 @@ slab_allocator_t* slab_allocator_init(
         size_t object_size) {
     assert(object_size <= SLAB_OBJECT_SIZE_MAX);
 
-    int numa_node_count = utils_numa_node_configured_count();
     int core_count = utils_cpu_count();
 
     slab_allocator_t* slab_allocator = (slab_allocator_t*)xalloc_alloc_zero(sizeof(slab_allocator_t));
 
-    spinlock_init(&slab_allocator->spinlock);
-
     slab_allocator->object_size = object_size;
-    slab_allocator->numa_node_count = numa_node_count;
     slab_allocator->core_count = core_count;
-    slab_allocator->numa_node_metadata = xalloc_alloc_zero(sizeof(slab_allocator_numa_node_metadata_t) * numa_node_count);
     slab_allocator->core_metadata = xalloc_alloc_zero(sizeof(slab_allocator_core_metadata_t) * core_count);
-    slab_allocator->metrics.total_slices_count = 0;
-    slab_allocator->metrics.free_slices_count = 0;
 
     for(int i = 0; i < slab_allocator->core_count; i++) {
         slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[i];
 
         core_metadata->slots = double_linked_list_init();
+        core_metadata->slices = double_linked_list_init();
+
         spinlock_init(&core_metadata->spinlock);
 
-        core_metadata->metrics.slices_free_count = 0;
-        core_metadata->metrics.slices_total_count = 0;
         core_metadata->metrics.slices_inuse_count = 0;
         core_metadata->metrics.objects_inuse_count = 0;
-    }
-
-    for(int i = 0; i < slab_allocator->numa_node_count; i++) {
-        slab_allocator_numa_node_metadata_t* numa_node_metadata = &slab_allocator->numa_node_metadata[i];
-
-        numa_node_metadata->slices = double_linked_list_init();
-
-        numa_node_metadata->metrics.free_slices_count = 0;
-        numa_node_metadata->metrics.total_slices_count = 0;
     }
 
     return slab_allocator;
@@ -155,12 +136,9 @@ slab_allocator_t* slab_allocator_init(
 
 void slab_allocator_free(
         slab_allocator_t* slab_allocator) {
-    // No need to deallocate the double linked list items of the slots as they are embedded within the hugepage and the
-    // hugepage is going to get freed below.
-
-    for(int i = 0; i < slab_allocator->numa_node_count; i++) {
-        slab_allocator_numa_node_metadata_t* numa_node_metadata = &slab_allocator->numa_node_metadata[i];
-        double_linked_list_item_t* item = numa_node_metadata->slices->head;
+    for(int i = 0; i < slab_allocator->core_count; i++) {
+        slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[i];
+        double_linked_list_item_t* item = core_metadata->slices->head;
 
         // Can't iterate using the normal double_linked_list_iter_next as the double_linked_list_item is embedded in the
         // hugepage and the hugepage is going to get freed
@@ -170,16 +148,11 @@ void slab_allocator_free(
             hugepage_cache_push(slab_slice->data.page_addr);
         }
 
-        double_linked_list_free(numa_node_metadata->slices);
-    }
-
-    for(int i = 0; i < slab_allocator->core_count; i++) {
-        slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[i];
+        double_linked_list_free(core_metadata->slices);
         double_linked_list_free(core_metadata->slots);
     }
 
     xalloc_free(slab_allocator->core_metadata);
-    xalloc_free(slab_allocator->numa_node_metadata);
     xalloc_free(slab_allocator);
 }
 
@@ -214,7 +187,6 @@ uint32_t slab_allocator_slice_calculate_slots_count(
 slab_slice_t* slab_allocator_slice_init(
         slab_allocator_t* slab_allocator,
         void* memptr,
-        uint8_t numa_node_index,
         uint16_t core_index) {
     slab_slice_t* slab_slice = (slab_slice_t*)memptr;
 
@@ -232,7 +204,6 @@ slab_slice_t* slab_allocator_slice_init(
     slab_slice->data.data_addr = (uintptr_t)memptr + data_offset;
     slab_slice->data.metrics.objects_total_count = slots_count;
     slab_slice->data.metrics.objects_inuse_count = 0;
-    slab_slice->data.numa_node_index = numa_node_index;
     slab_slice->data.core_index = core_index;
     slab_slice->data.available = true;
 
@@ -253,6 +224,11 @@ void slab_allocator_slice_add_slots_to_per_core_metadata_slots(
         slab_slot = &slab_slice->data.slots[index];
         slab_slot->data.available = true;
         slab_slot->data.memptr = (void*)(slab_slice->data.data_addr + (index * slab_allocator->object_size));
+
+#if DEBUG == 1
+        slab_slot->data.allocs = 0;
+        slab_slot->data.frees = 0;
+#endif
 
         double_linked_list_unshift_item(
                 core_metadata->slots,
@@ -281,46 +257,13 @@ void slab_allocator_slice_remove_slots_from_per_core_metadata_slots(
 slab_slice_t* slab_allocator_slice_from_memptr(
         void* memptr) {
     slab_slice_t* slab_slice = memptr - ((uintptr_t)memptr % HUGEPAGE_SIZE_2MB);
-
-#if DEBUG == 1
-    // This code try to match the memptr to a slab_allocator, the offset of the object from the beginning of the data
-    // address has to be divisible by the size of object_size associated with the slab_allocator.
-    // This check doesn't guarantee 100% certanty but it's simple enough to catch cases where a memory pointer passed
-    // hasn't been allocated with the slab allocator because if it would, the address should match at least 1 of the
-    // slab allocators
-    size_t usable_hugepage_size = slab_allocator_slice_calculate_usable_hugepage_size();
-
-    bool found = false;
-    for(int index = 0; index < SLAB_PREDEFINED_OBJECT_SIZES_COUNT; index++) {
-        slab_allocator_t *slab_allocator = predefined_slab_allocators[index];
-
-        uint32_t data_offset = slab_allocator_slice_calculate_data_offset(
-                usable_hugepage_size,
-                slab_allocator->object_size);
-        uintptr_t data_addr = (uintptr_t)slab_slice + data_offset;
-
-        size_t object_offset = (uintptr_t)memptr - data_addr;
-
-        if (object_offset % slab_allocator->object_size == 0) {
-            found = true;
-            break;
-        }
-    }
-
-    assert(found);
-#endif
-
     return slab_slice;
 }
 
 void slab_allocator_slice_make_available(
         slab_allocator_t* slab_allocator,
         slab_slice_t* slab_slice,
-        uint8_t numa_node_index,
-        uint16_t core_index,
-        bool* can_free_slice) {
-    *can_free_slice = false;
-    slab_allocator_numa_node_metadata_t* numa_node_metadata = &slab_allocator->numa_node_metadata[numa_node_index];
+        uint16_t core_index) {
     slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[core_index];
 
     slab_allocator_slice_remove_slots_from_per_core_metadata_slots(
@@ -331,70 +274,11 @@ void slab_allocator_slice_make_available(
     // The caller must ensure the lock
     assert(core_metadata->spinlock.lock != 0);
 
-    core_metadata->metrics.slices_total_count--;
-    core_metadata->metrics.slices_free_count--;
+    core_metadata->metrics.slices_inuse_count--;
 
-    spinlock_lock(&slab_allocator->spinlock, true);
-
-    if (slab_allocator->metrics.free_slices_count == 1) {
-        *can_free_slice = true;
-
-        slab_allocator->metrics.total_slices_count--;
-        numa_node_metadata->metrics.total_slices_count--;
-        double_linked_list_remove_item(
-                numa_node_metadata->slices,
-                &slab_slice->double_linked_list_item);
-    } else {
-        slab_allocator->metrics.free_slices_count++;
-        numa_node_metadata->metrics.free_slices_count++;
-        slab_slice->data.available = true;
-        double_linked_list_move_item_to_head(
-                numa_node_metadata->slices,
-                &slab_slice->double_linked_list_item);
-    }
-
-    spinlock_unlock(&slab_allocator->spinlock);
-}
-
-bool slab_allocator_slice_try_acquire(
-        slab_allocator_t* slab_allocator,
-        uint8_t numa_node_index,
-        uint16_t core_index) {
-    slab_allocator_numa_node_metadata_t* numa_node_metadata = &slab_allocator->numa_node_metadata[numa_node_index];
-    slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[core_index];
-
-    bool slab_slice_found = false;
-    double_linked_list_item_t* slab_slices_per_numa_node_head_item;
-    slab_slice_t* head_slab_slice;
-
-    // Check if an existing slices is available
-    spinlock_lock(&slab_allocator->spinlock, true);
-
-    slab_slices_per_numa_node_head_item =
-           numa_node_metadata->slices->head;
-    head_slab_slice = (slab_slice_t *)slab_slices_per_numa_node_head_item;
-
-    if (slab_slices_per_numa_node_head_item != NULL && head_slab_slice->data.available == true) {
-        slab_slice_found = true;
-        slab_allocator->metrics.free_slices_count--;
-        numa_node_metadata->metrics.free_slices_count--;
-        head_slab_slice->data.available = false;
-        double_linked_list_move_item_to_tail(
-               numa_node_metadata->slices,
-                slab_slices_per_numa_node_head_item);
-    }
-    spinlock_unlock(&slab_allocator->spinlock);
-
-    if (slab_slice_found) {
-        core_metadata->metrics.slices_inuse_count++;
-        core_metadata->metrics.slices_total_count++;
-        slab_allocator_slice_add_slots_to_per_core_metadata_slots(
-                slab_allocator,
-                head_slab_slice,
-                core_index);
-    }
-
-    return slab_slice_found;
+    double_linked_list_remove_item(
+            core_metadata->slices,
+            &slab_slice->double_linked_list_item);
 }
 
 slab_slot_t* slab_allocator_slot_from_memptr(
@@ -409,10 +293,8 @@ slab_slot_t* slab_allocator_slot_from_memptr(
 
 void slab_allocator_grow(
         slab_allocator_t* slab_allocator,
-        uint8_t numa_node_index,
         uint16_t core_index,
         void* memptr) {
-    slab_allocator_numa_node_metadata_t* numa_node_metadata = &slab_allocator->numa_node_metadata[numa_node_index];
     slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[core_index];
 
     // The caller must ensure the lock on core_metadata
@@ -422,7 +304,6 @@ void slab_allocator_grow(
     slab_slice_t* slab_slice = slab_allocator_slice_init(
             slab_allocator,
             memptr,
-            numa_node_index,
             core_index);
     slab_slice->data.available = false;
 
@@ -432,23 +313,14 @@ void slab_allocator_grow(
             slab_slice,
             core_index);
     core_metadata->metrics.slices_inuse_count++;
-    core_metadata->metrics.slices_total_count++;
 
-    // Add the slice to the ones initialized per core
-    spinlock_lock(&slab_allocator->spinlock, true);
-
-    slab_allocator->metrics.total_slices_count++;
-    numa_node_metadata->metrics.total_slices_count++;
     double_linked_list_push_item(
-            numa_node_metadata->slices,
+            core_metadata->slices,
             &slab_slice->double_linked_list_item);
-
-    spinlock_unlock(&slab_allocator->spinlock);
 }
 
 void* slab_allocator_mem_alloc_hugepages(
         size_t size,
-        uint8_t numa_node_index,
         uint16_t core_index) {
     slab_slot_t* slab_slot = NULL;
     slab_slice_t* slab_slice = NULL;
@@ -465,19 +337,16 @@ void* slab_allocator_mem_alloc_hugepages(
     slab_slot = (slab_slot_t*)slots_per_core_head_item;
 
     if (slots_per_core_head_item == NULL || slab_slot->data.available == false) {
-        if (slab_allocator_slice_try_acquire(slab_allocator, numa_node_index, core_index) == false) {
-            void* hugepage_addr = hugepage_cache_pop();
+        void* hugepage_addr = hugepage_cache_pop();
 
 #if defined(HAS_VALGRIND)
-            VALGRIND_CREATE_MEMPOOL(hugepage_addr, 0, false);
+        VALGRIND_CREATE_MEMPOOL(hugepage_addr, 0, false);
 #endif
 
-            slab_allocator_grow(
-                    slab_allocator,
-                    numa_node_index,
-                    core_index,
-                    hugepage_addr);
-        }
+        slab_allocator_grow(
+                slab_allocator,
+                core_index,
+                hugepage_addr);
 
         slots_per_core_head_item = slots_per_core_list->head;
         slab_slot = (slab_slot_t*)slots_per_core_head_item;
@@ -486,7 +355,12 @@ void* slab_allocator_mem_alloc_hugepages(
         assert(slab_slot->data.memptr != NULL);
     }
 
+    assert(slab_slot->data.allocs == slab_slot->data.frees);
+
     slab_slot->data.available = false;
+#if DEBUG == 1
+    slab_slot->data.allocs++;
+#endif
     double_linked_list_move_item_to_tail(slots_per_core_list, slots_per_core_head_item);
 
     slab_slice = slab_allocator_slice_from_memptr(slab_slot->data.memptr);
@@ -519,46 +393,40 @@ void slab_allocator_mem_free_hugepages(
     // the thread is running
     slab_slice_t* slab_slice = slab_allocator_slice_from_memptr(memptr);
     slab_allocator_t* slab_allocator = slab_slice->data.slab_allocator;
-    slab_slot_t* slot = slab_allocator_slot_from_memptr(
-            slab_allocator,
-            slab_slice,
-            memptr);
+    slab_slot_t* slab_slot = slab_allocator_slot_from_memptr(slab_allocator, slab_slice, memptr);
     slab_allocator_core_metadata_t* core_metadata = &slab_allocator->core_metadata[slab_slice->data.core_index];
 
-    // Debug test to catch double free
-    assert(slot->data.available == false);
+    // Test to catch double free
+    assert(slab_slot->data.available == false);
 
     spinlock_lock(&core_metadata->spinlock, true);
+
     // Update the availability and the metrics
     slab_slice->data.metrics.objects_inuse_count--;
     core_metadata->metrics.objects_inuse_count--;
-    slot->data.available = true;
+    slab_slot->data.available = true;
+
+#if DEBUG == 1
+    slab_slot->data.frees++;
+#endif
 
     // Move the slot back to the head because it's available
     double_linked_list_move_item_to_head(
             core_metadata->slots,
-            &slot->double_linked_list_item);
+            &slab_slot->double_linked_list_item);
 
     // If the slice is empty and for the currently core there is already another empty slice, make the current
     // slice available for other cores in the same numa node
     if (slab_slice->data.metrics.objects_inuse_count == 0) {
-        core_metadata->metrics.slices_free_count++;
-        core_metadata->metrics.slices_inuse_count--;
-
-        if (core_metadata->metrics.slices_free_count > 1) {
-            slab_allocator_slice_make_available(
-                    slab_allocator,
-                    slab_slice,
-                    slab_slice->data.numa_node_index,
-                    slab_slice->data.core_index,
-                    &can_free_slab_slice);
-        }
+        slab_allocator_slice_make_available(slab_allocator, slab_slice, slab_slice->data.core_index);
+        can_free_slab_slice = true;
     }
-    spinlock_unlock(&core_metadata->spinlock);
 
 #if defined(HAS_VALGRIND)
     VALGRIND_MEMPOOL_FREE(slab_slice->data.page_addr, memptr);
 #endif
+
+    spinlock_unlock(&core_metadata->spinlock);
 
     if (can_free_slab_slice) {
 #if defined(HAS_VALGRIND)
@@ -584,10 +452,7 @@ void* slab_allocator_mem_alloc(
     void* memptr;
 
     if (slab_allocator_enabled) {
-        memptr = slab_allocator_mem_alloc_hugepages(
-                size,
-                thread_get_current_numa_node_index(),
-                thread_get_current_core_index());
+        memptr = slab_allocator_mem_alloc_hugepages(size, thread_get_current_core_index());
     } else {
         memptr = slab_allocator_mem_alloc_xalloc(size);
     }


### PR DESCRIPTION
This PR simplifies the slab allocator removing the per numa-node hugepages cache as it was caching **only 1 hugepage** and this functionality is already provided by the hugepages cache.

This esemplification also gets rid of the numa-node spinlock reducing the amount of places where there can be contention.

The PR has also the side-effect of making the slab allocator slices free-up simpler and less flaky.