### PR TITLE
Improve benchmarks

### DIFF
--- a/benches/bench-hashtable-op-get.cpp
+++ b/benches/bench-hashtable-op-get.cpp
@@ -74,6 +74,7 @@ static void hashtable_op_get_not_found_key(benchmark::State& state) {
     }
 }
 
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
 static void hashtable_op_get_single_key_inline(benchmark::State& state) {
     static hashtable_t* hashtable;
     static hashtable_bucket_index_t bucket_index;
@@ -126,6 +127,7 @@ static void hashtable_op_get_single_key_inline(benchmark::State& state) {
         hashtable_mcmp_free(hashtable);
     }
 }
+#endif
 
 static void hashtable_op_get_single_key_external(benchmark::State& state) {
     static hashtable_t* hashtable;
@@ -181,5 +183,9 @@ static void hashtable_op_get_single_key_external(benchmark::State& state) {
 }
 
 BENCHMARK(hashtable_op_get_not_found_key)->HASHTABLE_OP_GET_BENCHS_ARGS;
+
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
 BENCHMARK(hashtable_op_get_single_key_inline)->HASHTABLE_OP_GET_BENCHS_ARGS;
+#endif
+
 BENCHMARK(hashtable_op_get_single_key_external)->HASHTABLE_OP_GET_BENCHS_ARGS;

--- a/benches/bench-hashtable-op-set.cpp
+++ b/benches/bench-hashtable-op-set.cpp
@@ -6,9 +6,7 @@
  * of the BSD license.  See the LICENSE file for details.
  **/
 
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
 #include <numa.h>
 
 #include <benchmark/benchmark.h>
@@ -16,229 +14,383 @@
 #include "exttypes.h"
 #include "spinlock.h"
 #include "log/log.h"
+#include "memory_fences.h"
+#include "utils_cpu.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_set.h"
-#include "data_structures/hashtable/mcmp/hashtable_op_get.h"
 
 #include "../tests/support.h"
-#include "../tests/hashtable/fixtures-hashtable.h"
 
 #include "bench-support.h"
 
-#define KEYSET_MAX_SIZE             (double)0x7FFFFFFFu * (double)0.75
-#define KEYSET_GENERATOR_METHOD     TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_RANDOM_LENGTH
+// Set the generator to use
+#define KEYSET_GENERATOR_METHOD     TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_MAX_LENGTH
 
-#define SET_BENCH_ARGS_HT_SIZE_AND_KEYS() \
-    Args({0x0000FFFFu, 75})-> \
-    Args({0x000FFFFFu, 75})-> \
-    Args({0x001FFFFFu, 75})-> \
-    Args({0x007FFFFFu, 75})-> \
-    Args({0x00FFFFFFu, 75})-> \
-    Args({0x01FFFFFFu, 50})-> \
-    Args({0x01FFFFFFu, 75})-> \
-    Args({0x07FFFFFFu, 50})-> \
-    Args({0x07FFFFFFu, 75})-> \
-    Args({0x0FFFFFFFu, 50})-> \
-    Args({0x0FFFFFFFu, 75})-> \
-    Args({0x1FFFFFFFu, 50})-> \
-    Args({0x1FFFFFFFu, 75})-> \
-    Args({0x3FFFFFFFu, 50})-> \
-    Args({0x3FFFFFFFu, 75})-> \
-    Args({0x7FFFFFFFu, 50})-> \
-    Args({0x7FFFFFFFu, 75})
+// These two are kept static and external because
+// - Google Benchmark invokes the setup multiple times, once per thread, but it doesn't have an entry point invoked
+//   only once to setup non-shared elements for the test
+// - the order of the threads started by Google Benchmark is undefined and therefore the code relies on the first thread
+//   to setup the keyset and the db and then on having these two static pointers set to NULL to understand when they
+//   have been configured by the thread 0. The other threads will wait for these allocations to be made.
+volatile static hashtable_t *static_hashtable = nullptr;
+volatile static test_support_keyset_slot_t *static_keyset_slots = nullptr;
+volatile static bool static_storage_db_populated = false;
 
-#define SET_BENCH_THREADS \
-    Threads(1)-> \
-    Threads(2)-> \
-    Threads(4)-> \
-    Threads(8)-> \
-    Threads(16)-> \
-    Threads(32)-> \
-    Threads(64)-> \
-    Threads(128)-> \
-    Threads(256)-> \
-    Threads(512)-> \
-    Threads(1024)-> \
-    Threads(2048)
+class HashtableOpSetInsertFixture : public benchmark::Fixture {
+private:
+    hashtable_t *_hashtable = nullptr;
+    test_support_keyset_slot_t *_keyset_slots = nullptr;
+    uint64_t _requested_keyset_size = 0;
 
-#define SET_BENCH_ITERATIONS \
-    Iterations(1)->\
-    Repetitions(25)->\
-    DisplayAggregatesOnly(true)
-
-#define CONFIGURE_BENCH_MT_HT_SIZE_AND_KEYS() \
-    UseRealTime()-> \
-    SET_BENCH_ARGS_HT_SIZE_AND_KEYS()-> \
-    SET_BENCH_ITERATIONS-> \
-    SET_BENCH_THREADS
-
-
-static char* keyset = NULL;
-static uint64_t keyset_size = 0;
-
-static void hashtable_op_set_keyset_init_notatest(benchmark::State& state) {
-    keyset_size = KEYSET_MAX_SIZE + 1;
-
-    keyset = test_support_init_keys(
-            keyset_size,
-            KEYSET_GENERATOR_METHOD,
-            544498304);
-
-    state.SkipWithError("Not a test, skipping");
-}
-
-static void hashtable_op_set_keyset_cleanup_notatest(benchmark::State& state) {
-    test_support_free_keys(keyset, keyset_size);
-
-    keyset = NULL;
-    keyset_size = 0;
-
-    state.SkipWithError("Not a test, skipping");
-}
-
-static void hashtable_op_set_new(benchmark::State& state) {
-    static hashtable_t* hashtable;
-    static uint64_t requested_keyset_size;
-    bool result;
-    char error_message[150] = {0};
-
-    if (bench_support_check_if_too_many_threads_per_core(state.threads(), BENCHES_MAX_THREADS_PER_CORE)) {
-        sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
-        state.SkipWithError(error_message);
-        return;
+public:
+    hashtable_t *GetHashtable() {
+        return this->_hashtable;
     }
 
-    if (state.thread_index() == 0) {
-        hashtable = test_support_init_hashtable(state.range(0));
+    test_support_keyset_slot_t *GetKeysetSlots() {
+        return this->_keyset_slots;
+    }
 
-        double requested_load_factor = (double)state.range(1) / 100;
-        requested_keyset_size = (double)hashtable->ht_current->buckets_count * requested_load_factor;
-        if (requested_keyset_size > keyset_size) {
-            sprintf(
-                    error_message,
-                    "The requested keyset size of <%lu> is greater than the one available of <%lu>, can't continue",
-                    requested_keyset_size,
-                    keyset_size);
-            state.SkipWithError(error_message);
+    [[nodiscard]] uint64_t GetRequestedKeysetSize() const {
+        return this->_requested_keyset_size;
+    }
+
+    void SetUp(const ::benchmark::State& state) override {
+        char error_message[150] = {0};
+
+        test_support_set_thread_affinity(state.thread_index());
+
+        // Calculate the requested keyset size
+        double requested_load_factor = (double) state.range(1) / 100.0f;
+        this->_requested_keyset_size = (uint64_t) (((double) state.range(0)) * requested_load_factor);
+
+        if (state.thread_index() == 0) {
+            if (bench_support_check_if_too_many_threads_per_core(
+                    state.threads(),
+                    BENCHES_MAX_THREADS_PER_CORE)) {
+                sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
+                ((::benchmark::State &) state).SkipWithError(error_message);
+
+                return;
+            }
+
+            // Initialize the key set
+            static_keyset_slots = test_support_init_keyset_slots(
+                    this->_requested_keyset_size,
+                    KEYSET_GENERATOR_METHOD,
+                    544498304);
+
+            // Setup the hashtable
+            static_hashtable = test_support_init_hashtable(state.range(0));
+
+            if (!static_hashtable) {
+                sprintf(
+                        error_message,
+                        "Failed to allocate the hashtable, unable to continue");
+                ((::benchmark::State &) state).SkipWithError(error_message);
+                return;
+            }
+
+            MEMORY_FENCE_STORE();
+        }
+
+        if (state.thread_index() != 0) {
+            while (!static_hashtable) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+
+            while (!static_keyset_slots) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+        }
+
+        this->_hashtable = (hashtable_t *)static_hashtable;
+        this->_keyset_slots = (test_support_keyset_slot_t *)static_keyset_slots;
+    }
+
+    void TearDown(const ::benchmark::State& state) override {
+        if (state.thread_index() != 0) {
             return;
         }
 
-        // Flush the cpu DCACHE related to the portion of the keyset used by the bench before starting the test
-        test_support_flush_data_cache(keyset, TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * requested_keyset_size);
+        if (this->_hashtable != nullptr) {
+            bench_support_collect_hashtable_stats_and_update_state(
+                    (benchmark::State&)state, this->_hashtable);
+
+            // Free the stoarge
+            hashtable_mcmp_free(this->_hashtable);
+        }
+
+        if (this->_keyset_slots != nullptr) {
+            // Free the keys
+            test_support_free_keyset_slots(this->_keyset_slots);
+        }
+
+        this->_hashtable = nullptr;
+        this->_keyset_slots = nullptr;
+        this->_requested_keyset_size = 0;
+
+        static_hashtable = nullptr;
+        static_keyset_slots = nullptr;
     }
+};
+
+BENCHMARK_DEFINE_F(HashtableOpSetInsertFixture, hashtable_op_set_insert)(benchmark::State& state) {
+    bool result;
+    hashtable_t *hashtable;
+    uint64_t requested_keyset_size;
+    test_support_keyset_slot_t *keyset_slots;
+    char error_message[150] = {0};
 
     test_support_set_thread_affinity(state.thread_index());
 
-    for (auto _ : state) {
-        for(long int i = state.thread_index(); i < requested_keyset_size; i += state.threads()) {
-            uint64_t keyset_offset = TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * i;
-            char* key = keyset + keyset_offset;
+    // Fetch the information from the fixtures needed for the test
+    hashtable = this->GetHashtable();
+    keyset_slots = this->GetKeysetSlots();
+    requested_keyset_size = this->GetRequestedKeysetSize();
 
+    for (auto _ : state) {
+        for(
+                uint64_t key_index = state.thread_index();
+                key_index < requested_keyset_size;
+                key_index += state.threads()) {
             benchmark::DoNotOptimize((result = hashtable_mcmp_op_set(
                     hashtable,
-                    key,
-                    strlen(key),
-                    i,
-                    NULL)));
+                    keyset_slots[key_index].key,
+                    keyset_slots[key_index].key_length,
+                    key_index,
+                    nullptr)));
 
             if (!result) {
                 sprintf(
                         error_message,
                         "Unable to set the key <%s> with index <%ld> for the thread <%d>",
-                        key,
-                        i,
+                        keyset_slots[key_index].key,
+                        key_index,
                         state.thread_index());
                 state.SkipWithError(error_message);
                 break;
             }
         }
     }
-
-    if (state.thread_index() == 0) {
-        bench_support_collect_hashtable_stats_and_update_state(state, hashtable);
-        hashtable_mcmp_free(hashtable);
-    }
 }
 
-static void hashtable_op_set_update(benchmark::State& state) {
-    static hashtable_t* hashtable;
-    static uint64_t requested_keyset_size;
+class HashtableOpSetUpdateFixture : public benchmark::Fixture {
+private:
+    hashtable_t *_hashtable = nullptr;
+    test_support_keyset_slot_t *_keyset_slots = nullptr;
+    uint64_t _requested_keyset_size = 0;
+
+public:
+    hashtable_t *GetHashtable() {
+        return this->_hashtable;
+    }
+
+    test_support_keyset_slot_t *GetKeysetSlots() {
+        return this->_keyset_slots;
+    }
+
+    [[nodiscard]] uint64_t GetRequestedKeysetSize() const {
+        return this->_requested_keyset_size;
+    }
+
+    void SetUp(const ::benchmark::State& state) override {
+        char error_message[150] = {0};
+
+        test_support_set_thread_affinity(state.thread_index());
+
+        // Calculate the requested keyset size
+        double requested_load_factor = (double) state.range(1) / 100.0f;
+        this->_requested_keyset_size = (uint64_t) (((double) state.range(0)) * requested_load_factor);
+
+        if (state.thread_index() == 0) {
+            if (bench_support_check_if_too_many_threads_per_core(
+                    state.threads(),
+                    BENCHES_MAX_THREADS_PER_CORE)) {
+                sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
+                ((::benchmark::State &) state).SkipWithError(error_message);
+
+                return;
+            }
+
+            // Initialize the key set
+            static_keyset_slots = test_support_init_keyset_slots(
+                    this->_requested_keyset_size,
+                    KEYSET_GENERATOR_METHOD,
+                    544498304);
+
+            // Setup the hashtable
+            static_hashtable = test_support_init_hashtable(state.range(0));
+
+            if (!static_hashtable) {
+                sprintf(
+                        error_message,
+                        "Failed to allocate the hashtable, unable to continue");
+                ((::benchmark::State &) state).SkipWithError(error_message);
+                return;
+            }
+
+            MEMORY_FENCE_STORE();
+        }
+
+        if (state.thread_index() != 0) {
+            while (!static_hashtable) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+
+            while (!static_keyset_slots) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+        }
+
+        for(
+                uint64_t key_index = state.thread_index();
+                key_index < this->_requested_keyset_size;
+                key_index += state.threads()) {
+            bool result = hashtable_mcmp_op_set(
+                    (hashtable_t*)static_hashtable,
+                    static_keyset_slots[key_index].key,
+                    static_keyset_slots[key_index].key_length,
+                    key_index,
+                    nullptr);
+
+            if (!result) {
+                sprintf(
+                        error_message,
+                        "Unable to set the key <%s (%d)> with index <%ld> for the thread <%d>",
+                        static_keyset_slots[key_index].key,
+                        static_keyset_slots[key_index].key_length,
+                        key_index,
+                        state.thread_index());
+
+                ((::benchmark::State &) state).SkipWithError(error_message);
+                break;
+            }
+        }
+
+        if (state.thread_index() == 0) {
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
+            // Free up the memory allocated for the first keyset slots generated
+            test_support_free_keyset_slots(static_keyset_slots);
+
+            fprintf(stdout, "> Setup (%d) - second keyset slots generation\n", state.thread_index());
+            fflush(stdout);
+
+            // Re-initialize the keyset, the random generator in use will re-generate exactly the same set as we are
+            // using the same random seed (although the generator will not generate them in the same order because
+            // threads are used but that's doesn't matter)
+            static_keyset_slots = test_support_init_keyset_slots(
+                    this->_requested_keyset_size,
+                    KEYSET_GENERATOR_METHOD,
+                    544498304);
+#endif
+
+            static_storage_db_populated = true;
+            MEMORY_FENCE_STORE();
+        }
+
+        if (state.thread_index() != 0) {
+            while (!static_storage_db_populated) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+        }
+
+        this->_hashtable = (hashtable_t *)static_hashtable;
+        this->_keyset_slots = (test_support_keyset_slot_t *)static_keyset_slots;
+    }
+
+    void TearDown(const ::benchmark::State& state) override {
+        if (state.thread_index() != 0) {
+            return;
+        }
+
+        if (this->_hashtable != nullptr) {
+            bench_support_collect_hashtable_stats_and_update_state(
+                    (benchmark::State&)state, this->_hashtable);
+
+            // Free the stoarge
+            hashtable_mcmp_free(this->_hashtable);
+        }
+
+        if (this->_keyset_slots != nullptr) {
+            // Free the keys
+            test_support_free_keyset_slots(this->_keyset_slots);
+        }
+
+        this->_hashtable = nullptr;
+        this->_keyset_slots = nullptr;
+        this->_requested_keyset_size = 0;
+
+        static_hashtable = nullptr;
+        static_keyset_slots = nullptr;
+        static_storage_db_populated = false;
+    }
+};
+
+BENCHMARK_DEFINE_F(HashtableOpSetUpdateFixture, hashtable_op_set_update)(benchmark::State& state) {
     bool result;
+    hashtable_t *hashtable;
+    uint64_t requested_keyset_size;
+    test_support_keyset_slot_t *keyset_slots;
     char error_message[150] = {0};
-
-    if (bench_support_check_if_too_many_threads_per_core(state.threads(), BENCHES_MAX_THREADS_PER_CORE)) {
-        sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
-        state.SkipWithError(error_message);
-        return;
-    }
-
-    if (state.thread_index() == 0) {
-        hashtable = test_support_init_hashtable(state.range(0));
-
-        double requested_load_factor = (double)state.range(1) / 100;
-        requested_keyset_size = (double)hashtable->ht_current->buckets_count * requested_load_factor;
-        if (requested_keyset_size > keyset_size) {
-            sprintf(
-                    error_message,
-                    "The requested keyset size of <%lu> is greater than the one available of <%lu>, can't continue",
-                    requested_keyset_size,
-                    keyset_size);
-            state.SkipWithError(error_message);
-            return;
-        }
-
-        bool result = test_support_hashtable_prefill(hashtable, keyset, test_value_1, requested_keyset_size);
-
-        if (!result) {
-            hashtable_mcmp_free(hashtable);
-
-            sprintf(error_message, "Unable to prefill the hashtable with <%lu> keys", requested_keyset_size);
-            state.SkipWithError(error_message);
-            return;
-        }
-
-        // Flush the cpu DCACHE related to the portion of the keyset used by the bench before starting the test
-        test_support_flush_data_cache(keyset, TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * requested_keyset_size);
-    }
 
     test_support_set_thread_affinity(state.thread_index());
 
-    for (auto _ : state) {
-        for(long int i = state.thread_index(); i < requested_keyset_size; i += state.threads()) {
-            char* key = keyset + (TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL * i);
+    // Fetch the information from the fixtures needed for the test
+    hashtable = this->GetHashtable();
+    keyset_slots = this->GetKeysetSlots();
+    requested_keyset_size = this->GetRequestedKeysetSize();
 
+    for (auto _ : state) {
+        for(
+                uint64_t key_index = state.thread_index();
+                key_index < requested_keyset_size;
+                key_index += state.threads()) {
             benchmark::DoNotOptimize((result = hashtable_mcmp_op_set(
                     hashtable,
-                    key,
-                    strlen(key),
-                    i,
-                    NULL)));
+                    keyset_slots[key_index].key,
+                    keyset_slots[key_index].key_length,
+                    key_index,
+                    nullptr)));
 
             if (!result) {
                 sprintf(
                         error_message,
                         "Unable to set the key <%s> with index <%ld> for the thread <%d>",
-                        key,
-                        i,
+                        keyset_slots[key_index].key,
+                        key_index,
                         state.thread_index());
                 state.SkipWithError(error_message);
                 break;
             }
         }
     }
-
-    if (state.thread_index() == 0) {
-        bench_support_collect_hashtable_stats_and_update_state(state, hashtable);
-        hashtable_mcmp_free(hashtable);
-    }
 }
 
-BENCHMARK(hashtable_op_set_keyset_init_notatest)->Iterations(1)->Threads(1)->Repetitions(1);
+BENCHMARK_REGISTER_F(HashtableOpSetInsertFixture, hashtable_op_set_insert)
+        ->ArgsProduct({
+                              { 0x0000FFFFu, 0x000FFFFFu, 0x001FFFFFu, 0x007FFFFFu, 0x00FFFFFFu, 0x01FFFFFFu, 0x07FFFFFFu,
+                                0x0FFFFFFFu, 0x1FFFFFFFu, 0x3FFFFFFFu, 0x7FFFFFFFu, 0x7FFFFFFFu },
+                              { 50, 75 },
+                      })
+        ->ThreadRange(1, utils_cpu_count())
+        ->Iterations(1)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly(true);
 
-BENCHMARK(hashtable_op_set_new)
-    ->CONFIGURE_BENCH_MT_HT_SIZE_AND_KEYS();
-BENCHMARK(hashtable_op_set_update)
-    ->CONFIGURE_BENCH_MT_HT_SIZE_AND_KEYS();
-
-BENCHMARK(hashtable_op_set_keyset_cleanup_notatest)->Iterations(1)->Threads(1)->Repetitions(1);
+BENCHMARK_REGISTER_F(HashtableOpSetUpdateFixture, hashtable_op_set_update)
+        ->ArgsProduct({
+                              { 0x0000FFFFu, 0x000FFFFFu, 0x001FFFFFu, 0x007FFFFFu, 0x00FFFFFFu, 0x01FFFFFFu, 0x07FFFFFFu,
+                                0x0FFFFFFFu, 0x1FFFFFFFu, 0x3FFFFFFFu, 0x7FFFFFFFu, 0x7FFFFFFFu },
+                              { 50, 75 },
+                      })
+        ->ThreadRange(1, utils_cpu_count())
+        ->Iterations(1)
+        ->Repetitions(25)
+        ->DisplayAggregatesOnly(true);

--- a/benches/bench-storage-db-op-get.cpp
+++ b/benches/bench-storage-db-op-get.cpp
@@ -1,0 +1,385 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <cstdint>
+#include <cstring>
+#include <numa.h>
+
+#include <benchmark/benchmark.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "spinlock.h"
+#include "log/log.h"
+#include "clock.h"
+#include "memory_fences.h"
+#include "config.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "slab_allocator.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "utils_cpu.h"
+#include "fiber.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#include "../tests/support.h"
+
+#include "bench-support.h"
+
+// Set the generator to use
+#define KEYSET_GENERATOR_METHOD     TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_MAX_LENGTH
+
+// These two are kept static and external because
+// - Google Benchmark invokes the setup multiple times, once per thread, but it doesn't have an entry point invoked
+//   only once to setup non-shared elements for the test
+// - the order of the threads started by Google Benchmark is undefined and therefore the code relies on the first thread
+//   to setup the keyset and the db and then on having these two static pointers set to NULL to understand when they
+//   have been configured by the thread 0. The other threads will wait for these allocations to be made.
+volatile static storage_db *static_db = nullptr;
+volatile static test_support_keyset_slot_t *static_keyset_slots = nullptr;
+volatile static bool static_storage_db_populated = false;
+
+class StorageDbOpGetFixture : public benchmark::Fixture {
+private:
+    storage_db *_db = nullptr;
+    uint32_t _workers_count = 0;
+    char _value_buffer[100] = { 0 };
+    size_t _value_buffer_length = sizeof(_value_buffer);
+    test_support_keyset_slot_t *_keyset_slots = nullptr;
+    uint64_t _requested_keyset_size = 0;
+
+public:
+    storage_db *GetDb() {
+        return this->_db;
+    }
+
+    [[nodiscard]] uint32_t GetWorkersCount() const {
+        return this->_workers_count;
+    }
+
+    char *GetValueBuffer() {
+        return this->_value_buffer;
+    }
+
+    [[nodiscard]] size_t GetValueBufferLength() const {
+        return this->_value_buffer_length;
+    }
+
+    test_support_keyset_slot_t *GetKeysetSlots() {
+        return this->_keyset_slots;
+    }
+
+    [[nodiscard]] uint64_t GetRequestedKeysetSize() const {
+        return this->_requested_keyset_size;
+    }
+
+    void SetUp(const ::benchmark::State& state) override {
+        char error_message[150] = {0};
+
+        test_support_set_thread_affinity(state.thread_index());
+
+        fprintf(stdout, "> Setup (%d) - started\n", state.thread_index());
+        fflush(stdout);
+
+        // Calculate the requested keyset size
+        double requested_load_factor = (double) state.range(1) / 100.0f;
+        this->_requested_keyset_size = (uint64_t) (((double) state.range(0)) * requested_load_factor);
+
+        if (state.thread_index() == 0) {
+            if (bench_support_check_if_too_many_threads_per_core(
+                    state.threads(),
+                    BENCHES_MAX_THREADS_PER_CORE)) {
+                sprintf(error_message, "Too many threads per core, max allowed <%d>", BENCHES_MAX_THREADS_PER_CORE);
+                ((::benchmark::State &) state).SkipWithError(error_message);
+
+                return;
+            }
+
+            char charset[] = {TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_REPEATED_LIST};
+            // Generate the value (just some data from the charset)
+            for (int i = 0; i < this->_value_buffer_length; i++) {
+                this->_value_buffer[i] = charset[i % sizeof(charset)];
+            }
+
+            fprintf(stdout, "> Setup (%d) - setting up storage_db\n", state.thread_index());
+            fflush(stdout);
+
+            // Setup the storage db
+            storage_db_config_t *db_config = storage_db_config_new();
+            db_config->max_keys = state.range(0);
+            db_config->backend_type = STORAGE_DB_BACKEND_TYPE_MEMORY;
+            static_db = storage_db_new(db_config, state.threads());
+            if (!static_db) {
+                storage_db_config_free(db_config);
+
+                sprintf(
+                        error_message,
+                        "Failed to allocate the storage db, unable to continue");
+
+                ((::benchmark::State &) state).SkipWithError(error_message);
+                return;
+            }
+
+            fprintf(stdout, "> Setup (%d) - initial keyset slots generation\n", state.thread_index());
+            fflush(stdout);
+
+            // Initialize the key set
+            static_keyset_slots = test_support_init_keyset_slots(
+                    this->_requested_keyset_size,
+                    KEYSET_GENERATOR_METHOD,
+                    544498304);
+
+            MEMORY_FENCE_STORE();
+        }
+
+        if (state.thread_index() != 0) {
+            while (!static_db) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+
+            while (!static_keyset_slots) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+        }
+
+        fprintf(stdout, "> Setup (%d) - setting up worker thread\n", state.thread_index());
+        fflush(stdout);
+
+        // Set up the worker context, as it's required by the storage db, this has to be done here as the worker_context
+        // is stored in a thread variable an the threads are managed internally by the benchmarking library and therefore
+        // they can be recycled or re-created.
+        worker_context_t *worker_context;
+        if ((worker_context = worker_context_get()) == nullptr) {
+            // This assigned memory will be lost but this is a benchmark and we don't care
+            worker_context = (worker_context_t *) slab_allocator_mem_alloc(sizeof(worker_context_t));
+            worker_context_set(worker_context);
+        }
+
+        // Setup the worker as needed
+        worker_context->worker_index = state.thread_index();
+        worker_context->workers_count = this->GetWorkersCount();
+        worker_context->db = (storage_db *) static_db;
+
+        fprintf(stdout, "> Setup (%d) - populating storage_db\n", state.thread_index());
+        fflush(stdout);
+
+        for(
+                uint64_t key_index = state.thread_index();
+                key_index < this->_requested_keyset_size;
+                key_index += state.threads()) {
+            bool result = storage_db_set_small_value(
+                    (storage_db*)static_db,
+                    static_keyset_slots[key_index].key,
+                    static_keyset_slots[key_index].key_length,
+                    this->_value_buffer,
+                    this->_value_buffer_length);
+
+            if (!result) {
+                sprintf(
+                        error_message,
+                        "Unable to set the key <%s (%d)> with index <%ld> for the thread <%d>",
+                        static_keyset_slots[key_index].key,
+                        static_keyset_slots[key_index].key_length,
+                        key_index,
+                        state.thread_index());
+
+                ((::benchmark::State &) state).SkipWithError(error_message);
+                break;
+            }
+        }
+
+        if (state.thread_index() == 0) {
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
+            // Free up the memory allocated for the first keyset slots generated
+            test_support_free_keyset_slots(this->_keyset_slots);
+
+            fprintf(stdout, "> Setup (%d) - second keyset slots generation\n", state.thread_index());
+            fflush(stdout);
+
+            // Re-initialize the keyset, the random generator in use will re-generate exactly the same set as we are
+            // using the same random seed (although the generator will not generate them in the same order because
+            // threads are used but that's doesn't matter)
+            static_keyset_slots = test_support_init_keyset_slots(
+                    this->_requested_keyset_size,
+                    KEYSET_GENERATOR_METHOD,
+                    544498304);
+#endif
+
+            static_storage_db_populated = true;
+            MEMORY_FENCE_STORE();
+        }
+
+        if (state.thread_index() != 0) {
+            while (!static_storage_db_populated) {
+                MEMORY_FENCE_LOAD();
+                sched_yield();
+            }
+        }
+
+        this->_db = (storage_db*)static_db;
+        this->_workers_count = state.threads();
+        this->_keyset_slots = (test_support_keyset_slot_t *)static_keyset_slots;
+
+        fprintf(stdout, "> Setup (%d) - completed\n", state.thread_index());
+        fflush(stdout);
+    }
+
+    void TearDown(const ::benchmark::State& state) override {
+        fprintf(stdout, "< Teardown (%d) - started\n", state.thread_index());
+        fflush(stdout);
+
+        if (state.thread_index() != 0) {
+            fprintf(stdout, "< Teardown (%d) - completed\n", state.thread_index());
+            fflush(stdout);
+            return;
+        }
+
+        if (this->_db != nullptr) {
+            fprintf(stdout, "< Teardown (%d) - collecting hashtable statistics\n", state.thread_index());
+            fflush(stdout);
+
+            bench_support_collect_hashtable_stats_and_update_state(
+                    (benchmark::State&)state, this->_db->hashtable);
+
+            fprintf(stdout, "< Teardown (%d) - cleaning up storage_db\n", state.thread_index());
+            fflush(stdout);
+
+            // Free the storage
+            storage_db_free(this->_db, this->_workers_count);
+        }
+
+        if (this->_keyset_slots != nullptr) {
+            fprintf(stdout, "< Teardown (%d) - free-ing up the keyset slots\n", state.thread_index());
+            fflush(stdout);
+
+            // Free the keys
+            test_support_free_keyset_slots(this->_keyset_slots);
+        }
+
+        this->_db = nullptr;
+        this->_workers_count = 0;
+        this->_keyset_slots = nullptr;
+        this->_requested_keyset_size = 0;
+
+        static_db = nullptr;
+        static_keyset_slots = nullptr;
+        static_storage_db_populated = false;
+
+        fprintf(stdout, "< Teardown (%d) - completed\n", state.thread_index());
+        fflush(stdout);
+    }
+};
+
+BENCHMARK_DEFINE_F(StorageDbOpGetFixture, storage_db_op_get)(benchmark::State& state) {
+    uint64_t requested_keyset_size;
+    test_support_keyset_slot_t *keyset_slots;
+    worker_context_t *worker_context;
+    char error_message[150] = { 0 };
+
+    test_support_set_thread_affinity(state.thread_index());
+
+    // Set up the worker context, as it's required by the storage db, this has to be done here as the worker_context
+    // is stored in a thread variable an the threads are managed internally by the benchmarking library and therefore
+    // they can be recycled or re-created.
+    if ((worker_context = worker_context_get()) == nullptr) {
+        // This assigned memory will be lost but this is a benchmark and we don't care
+        worker_context = (worker_context_t *)slab_allocator_mem_alloc(sizeof(worker_context_t));
+        worker_context_set(worker_context);
+    }
+
+    // Setup the worker as needed
+    worker_context->worker_index = state.thread_index();
+    worker_context->workers_count = this->GetWorkersCount();
+    worker_context->db = this->GetDb();
+
+    // Fetch the information from the fixtures needed for the test
+    keyset_slots = this->GetKeysetSlots();
+    requested_keyset_size = this->GetRequestedKeysetSize();
+
+    for (auto _ : state) {
+        for(
+                uint64_t key_index = state.thread_index();
+                key_index < requested_keyset_size;
+                key_index += state.threads()) {
+            storage_db_entry_index_t *entry_index = storage_db_get_entry_index(
+                    worker_context->db,
+                    keyset_slots[key_index].key,
+                    keyset_slots[key_index].key_length);
+
+            if (unlikely(!entry_index)) {
+                sprintf(
+                        error_message,
+                        "Can't find the key <%s (%d)> with index <%ld> for the thread <%d>",
+                        keyset_slots[key_index].key,
+                        keyset_slots[key_index].key_length,
+                        key_index,
+                        state.thread_index());
+                state.SkipWithError(error_message);
+                break;
+            }
+
+            if (likely(entry_index)) {
+                storage_db_entry_index_status_t old_status;
+
+                // Try to acquire a reader lock until it's successful or the entry index has been marked as deleted
+                storage_db_entry_index_status_increase_readers_counter(
+                        entry_index,
+                        &old_status);
+
+                if (unlikely(old_status.deleted)) {
+                    sprintf(
+                            error_message,
+                            "The key <%s (%d)> with index <%ld> for the thread <%d> has been deleted but it's not possible!",
+                            keyset_slots[key_index].key,
+                            keyset_slots[key_index].key_length,
+                            key_index,
+                            state.thread_index());
+                    state.SkipWithError(error_message);
+                    break;
+                }
+            }
+
+            // Only <= 64kb values so no need to iterate over the chunks
+            storage_db_chunk_info_t *chunk_info = storage_db_entry_value_chunk_get(entry_index, 0);
+
+            char *buffer;
+
+            if (likely(storage_db_entry_chunk_can_read_from_memory(worker_context->db, chunk_info))) {
+                benchmark::DoNotOptimize((buffer = storage_db_entry_chunk_read_fast_from_memory(worker_context->db, chunk_info)));
+            } else {
+                sprintf(
+                        error_message,
+                        "Can't perform fast read from memory for key <%s (%d)> with index <%ld> for the thread <%d>",
+                        keyset_slots[key_index].key,
+                        keyset_slots[key_index].key_length,
+                        key_index,
+                        state.thread_index());
+                state.SkipWithError(error_message);
+                break;
+            }
+
+            storage_db_entry_index_status_decrease_readers_counter(entry_index, NULL);
+        }
+    }
+}
+
+BENCHMARK_REGISTER_F(StorageDbOpGetFixture, storage_db_op_get)
+    ->ArgsProduct({
+                          { 340000000 },
+                          { 75 },
+    })
+    ->ThreadRange(4, utils_cpu_count())
+    ->Iterations(1)
+    ->Repetitions(3)
+    ->DisplayAggregatesOnly(true);

--- a/benches/bench-storage-db-op-get.cpp
+++ b/benches/bench-storage-db-op-get.cpp
@@ -202,7 +202,7 @@ public:
         if (state.thread_index() == 0) {
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
             // Free up the memory allocated for the first keyset slots generated
-            test_support_free_keyset_slots(this->_keyset_slots);
+            test_support_free_keyset_slots(static_keyset_slots);
 
             fprintf(stdout, "> Setup (%d) - second keyset slots generation\n", state.thread_index());
             fflush(stdout);
@@ -376,10 +376,11 @@ BENCHMARK_DEFINE_F(StorageDbOpGetFixture, storage_db_op_get)(benchmark::State& s
 
 BENCHMARK_REGISTER_F(StorageDbOpGetFixture, storage_db_op_get)
     ->ArgsProduct({
-                          { 340000000 },
-                          { 75 },
+                          { 0x0000FFFFu, 0x000FFFFFu, 0x001FFFFFu, 0x007FFFFFu, 0x00FFFFFFu, 0x01FFFFFFu, 0x07FFFFFFu,
+                            0x0FFFFFFFu, 0x1FFFFFFFu, 0x3FFFFFFFu, 0x7FFFFFFFu, 0x7FFFFFFFu },
+                          { 50, 75 },
     })
-    ->ThreadRange(4, utils_cpu_count())
+    ->ThreadRange(1, utils_cpu_count())
     ->Iterations(1)
-    ->Repetitions(3)
+    ->Repetitions(25)
     ->DisplayAggregatesOnly(true);

--- a/benches/bench-support.cpp
+++ b/benches/bench-support.cpp
@@ -91,8 +91,7 @@ void bench_support_collect_hashtable_stats_and_update_state(benchmark::State& st
             &longest_half_hashes_chunk);
 
     state.counters["total_buckets"] = hashtable->ht_current->buckets_count;
-    state.counters["keys_to_insert"] = keys_count;
-    state.counters["keys_inserted_per_second"] = keys_count;
+    state.counters["inserted_keys"] = keys_count;
     state.counters["requested_load_factor"] = requested_load_factor;
     state.counters["total_chunks"] = hashtable->ht_current->chunks_count;
     state.counters["used_chunks"] = used_chunks;

--- a/tests/hashtable/fixtures-hashtable.h
+++ b/tests/hashtable/fixtures-hashtable.h
@@ -136,12 +136,14 @@ hashtable_hash_quarter_t test_key_long_1_hash_quarter = test_key_long_1_hash_hal
     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].filled = true; \
     HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).data = value;
 
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
 #define HASHTABLE_SET_KEY_INLINE_BY_INDEX(chunk_index, chunk_slot_index, hash, key, key_size, value) \
     HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value); \
     HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).flags = \
         HASHTABLE_KEY_VALUE_FLAG_FILLED | HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE; \
     strncpy((char*)&HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).inline_key.data, key, HASHTABLE_KEY_INLINE_MAX_LENGTH); \
     HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).inline_key.size = key_size;
+#endif
 
 #define HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(chunk_index, chunk_slot_index, hash, key, key_size, value) \
     HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value); \

--- a/tests/support.h
+++ b/tests/support.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
-#define TEST_SUPPORT_RANDOM_KEYS_MIN_LENGTH             11
-#define TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH             19
+#define TEST_SUPPORT_RANDOM_KEYS_MIN_LENGTH             7
+#define TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH             8
 #define TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL   (TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH + 1)
 #define TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_REPEATED_LIST \
     'q','w','e','r','t','y','u','i','o','p','a','s','d','f','g','h','j','k', 'l','z','x','c','v','b','n','m', \
@@ -16,18 +16,8 @@ extern "C" {
     '1','2','3','4','5','6','7','8','9','0', '1','2','3','4','5','6','7','8','9','0', \
     '.',',','/','|','\'',';',']','[','<','>','?',':','"','{','}','!','@','$','%','^','&','*','(',')','_','-','=','+','#'
 
-#define TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_UNIQUE_LIST \
-    'q','w','e','r','t','y','u','i','o','p','a','s','d','f','g','h','j','k', 'l','z','x','c','v','b','n','m', \
-    'Q','W','E','R','T','Y','U','I','O','P','A','S','D','F','G','H','J','K', 'L','Z','X','C','V','B','N','M', \
-    '1','2','3','4','5','6','7','8','9','0', \
-    '.',',','/','|','\'',';',']','[','<','>','?',':','"','{','}','!','@','$','%','^','&','*','(',')','_','-','=','+','#'
-
-#define TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_REPEATED_SIZE  sizeof((char[]){TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_REPEATED_LIST})
-#define TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_UNIQUE_SIZE  sizeof((char[]){TEST_SUPPORT_RANDOM_KEYS_CHARACTER_SET_UNIQUE_LIST})
-
 #define TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_MAX_LENGTH                 1
 #define TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_RANDOM_LENGTH              2
-// #define TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_REPETIBLE_STR_ALTERNATEMINMAX_LENGTH  3
 
 #define TEST_SUPPORT_FIXTURE_FILE_FROM_DATA(DATA, DATA_LEN, FIXTURE_PATH, ...) { \
     { \
@@ -38,6 +28,12 @@ extern "C" {
         test_support_fixture_file_from_data_cleanup(FIXTURE_PATH); \
     } \
 }
+
+typedef struct test_support_keyset_slot test_support_keyset_slot_t;
+struct test_support_keyset_slot {
+    uint32_t key_length;
+    char *key;
+};
 
 // We don't really want to import the hashtable stuff in all the tests
 typedef struct hashtable hashtable_t;
@@ -79,8 +75,8 @@ struct keyset_generator_thread_info {
     pthread_t thread_id;
     uint16_t thread_num;
     uint16_t threads_count;
-    uint64_t keyset_size;
-    char* keyset;
+    uint64_t keyset_slots_count;
+    test_support_keyset_slot_t *keyset_slots;
     uint64_t start;
     uint64_t end;
 };
@@ -100,11 +96,10 @@ void test_support_same_hash_mod_fixtures_free(
 void test_support_set_thread_affinity(
         int thread_index);
 
-void test_support_free_keys(
-        char* keys,
-        uint64_t count);
+void test_support_free_keyset_slots(
+        test_support_keyset_slot_t* keyset_slots);
 
-char* test_support_init_keys(
+test_support_keyset_slot_t* test_support_init_keyset_slots(
         uint64_t keys_count,
         uint8_t keys_generator_method,
         uint64_t random_seed_base);


### PR DESCRIPTION
This PR includes a new benchmark for the storage_op_get operation, cleanup the storage_op_set and hashtable_op_set  benchmarks to properly use the setup & teardown mechanisms provided by google benchmark and a few more minor fixes.

It also update some support code used by the tests to properly generate the keys now that the hashtable owns the key.