### PR TITLE
Add libatomic to requirements

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -20,13 +20,17 @@ Example output
 | pkg-config |              | **mandatory** |
 | libnuma    | \>= 1.1      | **mandatory** |
 | libyaml    | \>= 1.1      | **mandatory** |
+| libmbedtls | \>= 2.28     | **mandatory** |
+| libatomic1 |              | **mandatory** |
 | openssl    | \>= 2.0      | **mandatory** |
 | curl       | \>= 7.0      | **mandatory** |
-| libmbedtls | \>= 2.28     | **mandatory** |
 
 ## Install the required packages
 
 ### Ubuntu 22.04
+
+`libatomic1` is not included directly as it's as dependency of `libatomic` which is a dependency itself of 
+`build-essential`.
 
 ```shell
 sudo apt install \
@@ -39,6 +43,9 @@ sudo apt install \
 
 ### Ubuntu 20.04
 
+`libatomic1` is not included directly as it's as dependency of `libatomic` which is a dependency itself of
+`build-essential`.
+
 ```shell
 sudo apt install \
     build-essential cmake pkg-config git \
@@ -49,6 +56,9 @@ sudo apt install \
 ```
 
 ### Debian 11
+
+`libatomic1` is not included directly as it's as dependency of `libatomic` which is a dependency itself of
+`build-essential`.
 
 ```shell
 sudo apt install \
@@ -68,7 +78,8 @@ sudo dnf install \
     numactl-libs numactl-devel \
     libcurl libcurl-devel \
     libyaml libyaml-devel \
-    mbedtls mbedtls-devel
+    mbedtls mbedtls-devel \
+    libatomic libatomic-devel
 ```
 
 ## How to build it

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         apt-utils \
     && apt-get install -y --no-install-recommends \
-        libnuma1 libyaml-0-2 libcurl4 libmbedtls14 \
+        libnuma1 libyaml-0-2 libcurl4 libmbedtls14 libatomic1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR simply add libatomic to the Dockerfile used for release container and mention the package in the build from sources documentation.