### PR TITLE
Report clock resolution during the bootstrap

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -7,3 +7,19 @@
  **/
 
 #include "clock.h"
+
+int64_t clock_realtime_coarse_get_resolution_ms() {
+    timespec_t res;
+    clock_getres(CLOCK_REALTIME_COARSE, &res);
+    int64_t res_ms = clock_timespec_to_int64_ms(&res);
+
+    return res_ms;
+}
+
+int64_t clock_monotonic_coarse_get_resolution_ms() {
+    timespec_t res;
+    clock_getres(CLOCK_MONOTONIC_COARSE, &res);
+    int64_t res_ms = clock_timespec_to_int64_ms(&res);
+
+    return res_ms;
+}

--- a/src/clock.h
+++ b/src/clock.h
@@ -22,6 +22,9 @@ extern "C" {
 
 typedef struct timespec timespec_t;
 
+int64_t clock_monotonic_coarse_get_resolution_ms();
+int64_t clock_realtime_coarse_get_resolution_ms();
+
 static inline __attribute__((always_inline)) int64_t clock_timespec_to_int64_ms(
         timespec_t *timespec) {
     time_t s = timespec->tv_sec * 1000;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_set.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_set.c
@@ -126,7 +126,7 @@ bool hashtable_mcmp_op_set(
 
     LOG_DI("unlocking half_hashes_chunk 0x%016x", half_hashes_chunk);
 
-    // Validate if the passed key can be freed because unused or beacuse inlined
+    // Validate if the passed key can be freed because unused or because inlined
     if (!created_new || key_inlined) {
         slab_allocator_mem_free(key);
     }

--- a/src/program.c
+++ b/src/program.c
@@ -671,6 +671,11 @@ int program_main(
                 CACHEGRAND_CMAKE_CONFIG_NAME);
     }
 
+    LOG_I(
+            TAG,
+            "> Clock resolution: %ld ms",
+            clock_realtime_coarse_get_resolution_ms());
+
     // Initialize the log sinks defined in the configuration, if any is defined. The function will take care of dropping
     // the temporary log sink defined initially
     program_config_setup_log_sinks(program_context->config);

--- a/tests/test-clock.cpp
+++ b/tests/test-clock.cpp
@@ -126,12 +126,11 @@ TEST_CASE("clock.c", "[clock]") {
     }
 
     SECTION("clock_monotonic_coarse_int64_ms") {
-        timespec_t a, res;
+        timespec_t a;
         clock_monotonic_coarse(&a);
         int64_t b = clock_monotonic_coarse_int64_ms();
 
-        clock_getres(CLOCK_MONOTONIC_COARSE, &res);
-        int64_t res_ms = clock_timespec_to_int64_ms(&res);
+        int64_t res_ms = clock_monotonic_coarse_get_resolution_ms();
 
         // Allow up to res in ms of difference
         int64_t diff = (b - clock_timespec_to_int64_ms(&a)) + res_ms;
@@ -139,12 +138,11 @@ TEST_CASE("clock.c", "[clock]") {
     }
 
     SECTION("clock_realtime_coarse_int64_ms") {
-        timespec_t a, res;
+        timespec_t a;
         clock_realtime_coarse(&a);
         int64_t b = clock_realtime_coarse_int64_ms();
 
-        clock_getres(CLOCK_REALTIME_COARSE, &res);
-        int64_t res_ms = clock_timespec_to_int64_ms(&res);
+        int64_t res_ms = clock_realtime_coarse_get_resolution_ms();
 
         // Allow up to res in ms of difference
         int64_t diff = (b - clock_timespec_to_int64_ms(&a)) + res_ms;


### PR DESCRIPTION
This PR introduces two new functions to report the clock resolution for CLOCK_MONOTONIC_COARSE and CLOCK_REALTIME_COARSE, which are used for the storage db entries expirations, and add a log line to report the resolution at the boostrap.

Tests are also updated within the PR to use these functions instead of fetching the resolution via clock_getres.