### PR TITLE
Update the README.md with a new (functional) SLoC badge and add a new COCOMO badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build & Test](https://github.com/danielealbano/cachegrand/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/danielealbano/cachegrand/actions/workflows/build_and_test.yml)
 [![codecov](https://codecov.io/gh/danielealbano/cachegrand/branch/main/graph/badge.svg?token=H4W0N0F7MT)](https://codecov.io/gh/danielealbano/cachegrand)
-[![Last Commit](https://img.shields.io/github/commit-activity/m/danielealbano/cachegrand/main)](https://github.com/danielealbano/cachegrand/commits/main)
 [![LGTM Grade](https://img.shields.io/lgtm/grade/cpp/github/danielealbano/cachegrand?label=lgtm%20code%20quality)](https://lgtm.com/projects/g/danielealbano/cachegrand/context:cpp)
-![Lines of code](https://img.shields.io/tokei/lines/github/danielealbano/cachegrand)
+![Lines of code](https://sloc.xyz/github/danielealbano/cachegrand)
+[![COCOMO](https://sloc.xyz/github/danielealbano/cachegrand?category=cocomo)](https://en.wikipedia.org/wiki/COCOMO)
 
 cachegrand
 ==========


### PR DESCRIPTION
This PR updated the README.md with a new (functional) SLoC badge and add a new COCOMO badge.

The current SLoC badge uses token which, way too often, reports 0 or unknown lines of code. On top of this, the current "commits per month" badge doesn't make sense anymore as merges are now getting squashed together to reduce the chaos on the hsitory.

The new SLoC badge works very well.