### PR TITLE
Honor socket keepalive settings

### DIFF
--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -39,11 +39,11 @@ modules:
         read_ms: -1
         write_ms: 10000
 
-      # Keep-alive parameters to keep the socket connected in case of no activity
-      keepalive:
-        time: 0
-        interval: 0
-        probes: 0
+#      # Keep-alive parameters to keep the socket connected in case of no activity
+#      keepalive:
+#        time: 0
+#        interval: 0
+#        probes: 0
 
 #      # TLS settings
 #      # If the configuration is missing or commented out, TLS is automatically disabled

--- a/src/network/channel/network_channel.c
+++ b/src/network/channel/network_channel.c
@@ -43,7 +43,6 @@ bool network_channel_client_setup(
     // majority of the cases in cachegrand, the data can be sent immediately
     error |= !network_io_common_socket_set_nodelay(fd, true);
     error |= !network_io_common_socket_set_linger(fd, true, 2);
-    error |= !network_io_common_socket_set_keepalive(fd, true);
     error |= !network_io_common_socket_set_receive_timeout(fd, 5, 0);
     error |= !network_io_common_socket_set_send_timeout(fd, 5, 0);
 

--- a/src/network/io/network_io_common.c
+++ b/src/network/io/network_io_common.c
@@ -106,11 +106,29 @@ bool network_io_common_socket_set_linger(
     return network_io_common_socket_set_option(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof(linger));
 }
 
-bool network_io_common_socket_set_keepalive(
+bool network_io_common_socket_enable_keepalive(
         network_io_common_fd_t fd,
         bool enable) {
     int val = enable ? 1 : 0;
     return network_io_common_socket_set_option(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
+}
+
+bool network_io_common_socket_set_keepalive_count(
+        network_io_common_fd_t fd,
+        uint32_t keepalive_count) {
+    return network_io_common_socket_set_option(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepalive_count, sizeof(keepalive_count));
+}
+
+bool network_io_common_socket_set_keepalive_idle(
+        network_io_common_fd_t fd,
+        uint32_t keepalive_idle) {
+    return network_io_common_socket_set_option(fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepalive_idle, sizeof(keepalive_idle));
+}
+
+bool network_io_common_socket_set_keepalive_interval(
+        network_io_common_fd_t fd,
+        uint32_t keepalive_interval) {
+    return network_io_common_socket_set_option(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepalive_interval, sizeof(keepalive_interval));
 }
 
 bool network_io_common_socket_set_incoming_cpu(

--- a/src/network/io/network_io_common.h
+++ b/src/network/io/network_io_common.h
@@ -44,9 +44,18 @@ bool network_io_common_socket_set_linger(
         network_io_common_fd_t fd,
         bool enable,
         int seconds);
-bool network_io_common_socket_set_keepalive(
+bool network_io_common_socket_enable_keepalive(
         network_io_common_fd_t fd,
         bool enable);
+bool network_io_common_socket_set_keepalive_count(
+        network_io_common_fd_t fd,
+        uint32_t keepalive_count);
+bool network_io_common_socket_set_keepalive_idle(
+        network_io_common_fd_t fd,
+        uint32_t keepalive_idle);
+bool network_io_common_socket_set_keepalive_interval(
+        network_io_common_fd_t fd,
+        uint32_t keepalive_interval);
 bool network_io_common_socket_set_incoming_cpu(
         network_io_common_fd_t fd,
         int cpu);

--- a/tests/network/io/test-network-io-common.cpp
+++ b/tests/network/io/test-network-io-common.cpp
@@ -236,14 +236,14 @@ TEST_CASE("network/io/network_io_common.c", "[network][network_io][network_io_co
         }
     }
 
-    SECTION("network_io_common_socket_set_keepalive") {
+    SECTION("network_io_common_socket_enable_keepalive") {
         SECTION("valid socket fd") {
             int val;
             socklen_t val_size = sizeof(val);
             int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
             REQUIRE(fd > 0);
-            REQUIRE(network_io_common_socket_set_keepalive(fd, true));
+            REQUIRE(network_io_common_socket_enable_keepalive(fd, true));
             REQUIRE(getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, &val_size) == 0);
             REQUIRE(val == 1);
 
@@ -251,7 +251,67 @@ TEST_CASE("network/io/network_io_common.c", "[network][network_io][network_io_co
         }
 
         SECTION("invalid socket fd") {
-            REQUIRE(!network_io_common_socket_set_keepalive(-1, true));
+            REQUIRE(!network_io_common_socket_enable_keepalive(-1, true));
+        }
+    }
+
+    SECTION("network_io_common_socket_enable_keepalive") {
+        SECTION("valid socket fd") {
+            int val;
+            socklen_t val_size = sizeof(val);
+            int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+            REQUIRE(fd > 0);
+            REQUIRE(network_io_common_socket_enable_keepalive(fd, true));
+            REQUIRE(network_io_common_socket_set_keepalive_count(fd, 3));
+            REQUIRE(getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, &val_size) == 0);
+            REQUIRE(val == 3);
+
+            close(fd);
+        }
+
+        SECTION("invalid socket fd") {
+            REQUIRE(!network_io_common_socket_set_keepalive_count(-1, true));
+        }
+    }
+
+    SECTION("network_io_common_socket_enable_keepalive") {
+        SECTION("valid socket fd") {
+            int val;
+            socklen_t val_size = sizeof(val);
+            int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+            REQUIRE(fd > 0);
+            REQUIRE(network_io_common_socket_enable_keepalive(fd, true));
+            REQUIRE(network_io_common_socket_set_keepalive_idle(fd, 6));
+            REQUIRE(getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, &val_size) == 0);
+            REQUIRE(val == 6);
+
+            close(fd);
+        }
+
+        SECTION("invalid socket fd") {
+            REQUIRE(!network_io_common_socket_set_keepalive_idle(-1, true));
+        }
+    }
+
+    SECTION("network_io_common_socket_enable_keepalive") {
+        SECTION("valid socket fd") {
+            int val;
+            socklen_t val_size = sizeof(val);
+            int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+            REQUIRE(fd > 0);
+            REQUIRE(network_io_common_socket_enable_keepalive(fd, true));
+            REQUIRE(network_io_common_socket_set_keepalive_interval(fd, 9));
+            REQUIRE(getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, &val_size) == 0);
+            REQUIRE(val == 9);
+
+            close(fd);
+        }
+
+        SECTION("invalid socket fd") {
+            REQUIRE(!network_io_common_socket_set_keepalive_interval(-1, true));
         }
     }
 


### PR DESCRIPTION
This PR implements 3 new network io functions to set the keepalive idel, interval and count and update the mechanism used to enable / disable the keepalive to:
- set the keepalive parameters only if the keepalive block is present in the configuration
- do not fail, only report a warning, if the keepalive parameters are for some reason refused

The PR closes #84