### PR TITLE
Implement storage db flush sync

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <string.h>
+#include <numa.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "memory_fences.h"
+#include "spinlock.h"
+#include "log/log.h"
+
+#include "hashtable.h"
+
+bool hashtable_mcmp_op_get_key(
+        hashtable_t *hashtable,
+        hashtable_bucket_index_t bucket_index,
+        hashtable_key_data_t **key,
+        hashtable_key_size_t *key_size) {
+    MEMORY_FENCE_LOAD();
+
+    hashtable_data_volatile_t* hashtable_data = hashtable->ht_current;
+    hashtable_key_value_volatile_t *key_value = &hashtable_data->keys_values[bucket_index];
+
+    if (
+            unlikely(HASHTABLE_KEY_VALUE_IS_EMPTY(key_value->flags)) ||
+            unlikely(HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED))) {
+        return false;
+    }
+
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
+    // The key may potentially change if the item is first deleted and then recreated, if it's inline it
+    // doesn't really matter because the key will mismatch and the execution will continue but if the key is
+    // stored externally and the allocated memory is freed it may crash.
+    if (HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
+        *key = key_value->inline_key.data;
+        *key_size = key_value->inline_key.size;
+    } else {
+#endif
+        *key = key_value->external_key.data;
+        *key_size = key_value->external_key.size;
+#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
+    }
+#endif
+
+    return true;
+}

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.h
@@ -1,0 +1,18 @@
+#ifndef CACHEGRAND_HASHTABLE_OP_GET_KEY_H
+#define CACHEGRAND_HASHTABLE_OP_GET_KEY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool hashtable_mcmp_op_get_key(
+        hashtable_t *hashtable,
+        hashtable_bucket_index_t bucket_index,
+        hashtable_key_data_t **key,
+        hashtable_key_size_t *key_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_HASHTABLE_OP_GET_KEY_H

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1246,8 +1246,12 @@ bool storage_db_op_flush_sync(
             hashtable_key_data_t *key;
             hashtable_key_size_t key_size;
 
-            hashtable_mcmp_op_get_key(db->hashtable, bucket_index, &key, &key_size);
-            storage_db_op_delete(db, key, key_size);
+            // The bucket might have been deleted in the meantime so get_key has to return true
+            if (hashtable_mcmp_op_get_key(db->hashtable, bucket_index, &key, &key_size)) {
+                storage_db_op_delete(db, key, key_size);
+            }
         }
     }
+
+    return true;
 }

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1217,6 +1217,16 @@ bool storage_db_op_delete(
     return res;
 }
 
+int64_t storage_db_op_get_size(
+        storage_db_t *db) {
+    int64_t size = 0;
+    hashtable_counters_t *counters_sum = hashtable_mcmp_thread_counters_sum_fetch(db->hashtable);
+    size = counters_sum->size;
+    hashtable_mcmp_thread_counters_sum_free(counters_sum);
+
+    return size;
+}
+
 bool storage_db_op_flush_sync(
         storage_db_t *db) {
     // As the resizing has to be taken into account but not yet implemented, the assert will catch if the resizing is

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -322,6 +322,9 @@ bool storage_db_op_delete(
         char *key,
         size_t key_length);
 
+int64_t storage_db_op_get_size(
+        storage_db_t *db);
+
 bool storage_db_op_flush_sync(
         storage_db_t *db);
 

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -22,6 +22,7 @@ typedef uint16_t storage_db_chunk_index_t;
 typedef uint16_t storage_db_chunk_length_t;
 typedef uint32_t storage_db_chunk_offset_t;
 typedef uint32_t storage_db_shard_index_t;
+typedef uint64_t storage_db_create_time_ms_t;
 typedef int64_t storage_db_expiry_time_ms_t;
 
 enum storage_db_backend_type {
@@ -111,6 +112,7 @@ struct storage_db_chunk_sequence {
 typedef struct storage_db_entry_index storage_db_entry_index_t;
 struct storage_db_entry_index {
     storage_db_entry_index_status_t status;
+    storage_db_create_time_ms_t created_time_ms;
     storage_db_expiry_time_ms_t expiry_time_ms;
     storage_db_chunk_sequence_t *key;
     storage_db_chunk_sequence_t *value;
@@ -319,6 +321,9 @@ bool storage_db_op_delete(
         storage_db_t *db,
         char *key,
         size_t key_length);
+
+bool storage_db_op_flush_sync(
+        storage_db_t *db);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR implements a mechanism to flush the storage db synchronously.

It also includes some code of a previous PR to calculate the size of the DB as it wasn't initially included.

The mechanism is required by the redis command FLUSH [SYNC].