### PR TITLE
Fix LCS behaviour when non existant keys are provided

### DIFF
--- a/src/module/redis/command/module_redis_command_lcs.c
+++ b/src/module/redis/command/module_redis_command_lcs.c
@@ -221,10 +221,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(lcs) {
         goto end;
     }
 
-    if (entry_index_1->value->size >= UINT32_MAX || entry_index_1->value->size >= UINT32_MAX) {
-        return_res = module_redis_connection_error_message_printf_noncritical(
-                connection_context,
-                "String too long for LCS");
+    if (entry_index_1->value->size == 0 || entry_index_2->value->size == 0) {
         goto end;
     }
 

--- a/src/module/redis/module_redis_connection.c
+++ b/src/module/redis/module_redis_connection.c
@@ -353,7 +353,7 @@ bool module_redis_connection_send_string(
             return false;
         }
 
-        send_buffer_start = protocol_redis_writer_write_simple_string(
+        send_buffer_start = protocol_redis_writer_write_blob_string(
                 send_buffer_start,
                 slice_length,
                 string,

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -1633,7 +1633,50 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
     }
 
     SECTION("Redis - command - LCS") {
+        SECTION("Missing keys - String") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"LCS", "a_key", "b_key"},
+                    "$0\r\n\r\n"));
+        }
+
+        SECTION("Missing keys - Length") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Empty keys - String") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"MSET", "a_key", "", "b_key", ""},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"LCS", "a_key", "b_key"},
+                    "$0\r\n\r\n"));
+        }
+
+        SECTION("Empty keys - Length") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"MSET", "a_key", "", "b_key", ""},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
+                    ":0\r\n"));
+        }
+
         SECTION("No common substrings - String") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"MSET", "a_key", "qwertyuiop", "b_key", "asdfghjkl"},
+                    "+OK\r\n"));
+
             REQUIRE(send_recv_resp_command_text(
                     client_fd,
                     std::vector<std::string>{"LCS", "a_key", "b_key"},
@@ -1641,6 +1684,11 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         }
 
         SECTION("No common substrings - Length") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"MSET", "a_key", "qwertyuiop", "b_key", "asdfghjkl"},
+                    "+OK\r\n"));
+
             REQUIRE(send_recv_resp_command_text(
                     client_fd,
                     std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},


### PR DESCRIPTION
This PR fixes the behaviour of the LCS command when non existant keys are provided and also handle errors. The PR also expand the tests done for the LCS command to better cover the possible cases.