### PR TITLE
Implement expire and persist related commands

### DIFF
--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_expire"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
+    bool abort_rmw = false;
+    bool metadata_updated = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_expire_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        goto end;
+    }
+
+    int64_t milliseconds = context->seconds.value * 1000;
+
+    if (context->condition.value.nx_nx.has_token) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.xx_xx.has_token) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.gt_gt.has_token) {
+        if (milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.lt_lt.has_token) {
+        if (milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            abort_rmw = true;
+        }
+    }
+
+    if (abort_rmw) {
+        storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    } else {
+        current_entry_index->expiry_time_ms = clock_realtime_coarse_int64_ms() + milliseconds;
+        metadata_updated = true;
+
+        if (milliseconds <= 0) {
+            storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
+        } else {
+            storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+        }
+    }
+
+end:
+
+    return module_redis_connection_send_number(
+            connection_context,
+            metadata_updated ? 1 : 0);
+}

--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -80,12 +80,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
         }
     } else if (context->condition.value.gt_gt.has_token) {
         if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY ||
-            milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            milliseconds <= storage_db_entry_index_ttl_ms(current_entry_index)) {
             abort_rmw = true;
         }
     } else if (context->condition.value.lt_lt.has_token) {
         if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY &&
-            milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            milliseconds >= storage_db_entry_index_ttl_ms(current_entry_index)) {
             abort_rmw = true;
         }
     }

--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -79,11 +79,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
             abort_rmw = true;
         }
     } else if (context->condition.value.gt_gt.has_token) {
-        if (milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY ||
+            milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
             abort_rmw = true;
         }
     } else if (context->condition.value.lt_lt.has_token) {
-        if (milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY &&
+            milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
             abort_rmw = true;
         }
     }

--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -59,6 +59,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR expire failed");
+    }
+
+    if (!current_entry_index) {
         goto end;
     }
 
@@ -92,6 +98,9 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
             storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
         } else {
             storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+
+            context->key.value.key = NULL;
+            context->key.value.length = 0;
         }
     }
 

--- a/src/module/redis/command/module_redis_command_expireat.c
+++ b/src/module/redis/command/module_redis_command_expireat.c
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_expireat"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expireat) {
+    bool abort_rmw = false;
+    bool metadata_updated = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_expireat_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        goto end;
+    }
+
+    int64_t milliseconds = (int64_t)context->unix_time_seconds.value * 1000;
+
+    if (context->condition.value.nx_nx.has_token) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.xx_xx.has_token) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.gt_gt.has_token) {
+        if (milliseconds <= current_entry_index->expiry_time_ms) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.lt_lt.has_token) {
+        if (milliseconds >= current_entry_index->expiry_time_ms) {
+            abort_rmw = true;
+        }
+    }
+
+    if (abort_rmw) {
+        storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    } else {
+        current_entry_index->expiry_time_ms = milliseconds;
+        metadata_updated = true;
+
+        if (milliseconds <= 0) {
+            storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
+        } else {
+            storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+        }
+    }
+
+end:
+
+    return module_redis_connection_send_number(
+            connection_context,
+            metadata_updated ? 1 : 0);
+}

--- a/src/module/redis/command/module_redis_command_expireat.c
+++ b/src/module/redis/command/module_redis_command_expireat.c
@@ -79,11 +79,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expireat) {
             abort_rmw = true;
         }
     } else if (context->condition.value.gt_gt.has_token) {
-        if (milliseconds <= current_entry_index->expiry_time_ms) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY ||
+            milliseconds <= current_entry_index->expiry_time_ms) {
             abort_rmw = true;
         }
     } else if (context->condition.value.lt_lt.has_token) {
-        if (milliseconds >= current_entry_index->expiry_time_ms) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY &&
+            milliseconds >= current_entry_index->expiry_time_ms) {
             abort_rmw = true;
         }
     }

--- a/src/module/redis/command/module_redis_command_expireat.c
+++ b/src/module/redis/command/module_redis_command_expireat.c
@@ -59,6 +59,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expireat) {
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR expireat failed");
+    }
+
+    if (!current_entry_index) {
         goto end;
     }
 
@@ -92,6 +98,9 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expireat) {
             storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
         } else {
             storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+
+            context->key.value.key = NULL;
+            context->key.value.length = 0;
         }
     }
 

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -58,6 +58,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR expiretime failed");
+    }
+
+    if (!current_entry_index) {
         return module_redis_connection_send_number(
                 connection_context,
                 -2);

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -73,7 +73,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
             connection_context,
             current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
             ? -1
-            : (current_entry_index->expiry_time_ms - clock_realtime_coarse_int64_ms()) / 1000);
+            : current_entry_index->expiry_time_ms / 1000);
 
     storage_db_op_rmw_abort(connection_context->db, &rmw_status);
 

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_expiretime"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
+    bool return_res = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_expiretime_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        return module_redis_connection_send_number(
+                connection_context,
+                -2);
+    }
+
+    return_res = module_redis_connection_send_number(
+            connection_context,
+            current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
+            ? -1
+            : (current_entry_index->expiry_time_ms - clock_realtime_coarse_int64_ms()) / 1000);
+
+    storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+
+    return return_res;
+}

--- a/src/module/redis/command/module_redis_command_persist.c
+++ b/src/module/redis/command/module_redis_command_persist.c
@@ -59,6 +59,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR persist failed");
+    }
+
+    if (!current_entry_index) {
         goto end;
     }
 
@@ -72,6 +78,9 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
         current_entry_index->expiry_time_ms = STORAGE_DB_ENTRY_NO_EXPIRY;
         metadata_updated = true;
         storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+
+        context->key.value.key = NULL;
+        context->key.value.length = 0;
     }
 
 end:

--- a/src/module/redis/command/module_redis_command_persist.c
+++ b/src/module/redis/command/module_redis_command_persist.c
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_persist"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
+    bool abort_rmw = false;
+    bool metadata_updated = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_expire_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        goto end;
+    }
+
+    if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+        abort_rmw = true;
+    }
+
+    if (abort_rmw) {
+        storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    } else {
+        current_entry_index->expiry_time_ms = STORAGE_DB_ENTRY_NO_EXPIRY;
+        metadata_updated = true;
+        storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+    }
+
+end:
+
+    return module_redis_connection_send_number(
+            connection_context,
+            metadata_updated ? 1 : 0);
+}

--- a/src/module/redis/command/module_redis_command_pexpire.c
+++ b/src/module/redis/command/module_redis_command_pexpire.c
@@ -79,11 +79,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
             abort_rmw = true;
         }
     } else if (context->condition.value.gt_gt.has_token) {
-        if (milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY ||
+            milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
             abort_rmw = true;
         }
     } else if (context->condition.value.lt_lt.has_token) {
-        if (milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY &&
+            milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
             abort_rmw = true;
         }
     }

--- a/src/module/redis/command/module_redis_command_pexpire.c
+++ b/src/module/redis/command/module_redis_command_pexpire.c
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_pexpire"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
+    bool abort_rmw = false;
+    bool metadata_updated = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_pexpire_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        goto end;
+    }
+
+    int64_t milliseconds = context->milliseconds.value;
+
+    if (context->condition.value.nx_nx.has_token) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.xx_xx.has_token) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.gt_gt.has_token) {
+        if (milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.lt_lt.has_token) {
+        if (milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            abort_rmw = true;
+        }
+    }
+
+    if (abort_rmw) {
+        storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    } else {
+        current_entry_index->expiry_time_ms =
+                clock_realtime_coarse_int64_ms() + context->milliseconds.value;
+
+        storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+        metadata_updated = true;
+    }
+
+end:
+
+    return module_redis_connection_send_number(
+            connection_context,
+            metadata_updated ? 1 : 0);
+}

--- a/src/module/redis/command/module_redis_command_pexpire.c
+++ b/src/module/redis/command/module_redis_command_pexpire.c
@@ -80,12 +80,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
         }
     } else if (context->condition.value.gt_gt.has_token) {
         if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY ||
-            milliseconds <= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            milliseconds <= storage_db_entry_index_ttl_ms(current_entry_index)) {
             abort_rmw = true;
         }
     } else if (context->condition.value.lt_lt.has_token) {
         if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY &&
-            milliseconds >= storage_db_entry_index_expires_in_ms(current_entry_index)) {
+            milliseconds >= storage_db_entry_index_ttl_ms(current_entry_index)) {
             abort_rmw = true;
         }
     }

--- a/src/module/redis/command/module_redis_command_pexpireat.c
+++ b/src/module/redis/command/module_redis_command_pexpireat.c
@@ -79,11 +79,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
             abort_rmw = true;
         }
     } else if (context->condition.value.gt_gt.has_token) {
-        if (milliseconds <= current_entry_index->expiry_time_ms) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY ||
+            milliseconds <= current_entry_index->expiry_time_ms) {
             abort_rmw = true;
         }
     } else if (context->condition.value.lt_lt.has_token) {
-        if (milliseconds >= current_entry_index->expiry_time_ms) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY &&
+            milliseconds >= current_entry_index->expiry_time_ms) {
             abort_rmw = true;
         }
     }

--- a/src/module/redis/command/module_redis_command_pexpireat.c
+++ b/src/module/redis/command/module_redis_command_pexpireat.c
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_pexpireat"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
+    bool abort_rmw = false;
+    bool metadata_updated = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_pexpireat_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        goto end;
+    }
+
+    int64_t milliseconds = (int64_t)context->unix_time_milliseconds.value;
+
+    if (context->condition.value.nx_nx.has_token) {
+        if (current_entry_index->expiry_time_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.xx_xx.has_token) {
+        if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.gt_gt.has_token) {
+        if (milliseconds <= current_entry_index->expiry_time_ms) {
+            abort_rmw = true;
+        }
+    } else if (context->condition.value.lt_lt.has_token) {
+        if (milliseconds >= current_entry_index->expiry_time_ms) {
+            abort_rmw = true;
+        }
+    }
+
+    if (abort_rmw) {
+        storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    } else {
+        current_entry_index->expiry_time_ms = milliseconds;
+        metadata_updated = true;
+
+        if (milliseconds <= 0) {
+            storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
+        } else {
+            storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+        }
+    }
+
+end:
+
+    return module_redis_connection_send_number(
+            connection_context,
+            metadata_updated ? 1 : 0);
+}

--- a/src/module/redis/command/module_redis_command_pexpireat.c
+++ b/src/module/redis/command/module_redis_command_pexpireat.c
@@ -59,6 +59,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR pexpireat failed");
+    }
+
+    if (!current_entry_index) {
         goto end;
     }
 
@@ -92,6 +98,9 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
             storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
         } else {
             storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);
+
+            context->key.value.key = NULL;
+            context->key.value.length = 0;
         }
     }
 

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_delete.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_pexpiretime"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
+    bool return_res = false;
+    storage_db_entry_index_t *current_entry_index = NULL;
+    module_redis_command_expiretime_context_t *context = connection_context->command.context;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        return module_redis_connection_send_number(
+                connection_context,
+                -2);
+    }
+
+    return_res = module_redis_connection_send_number(
+            connection_context,
+            current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
+            ? -1
+            : current_entry_index->expiry_time_ms - clock_realtime_coarse_int64_ms());
+
+    storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+
+    return return_res;
+}

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -58,6 +58,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR pexpiretime failed");
+    }
+
+    if (!current_entry_index) {
         return module_redis_connection_send_number(
                 connection_context,
                 -2);

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -73,7 +73,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
             connection_context,
             current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
             ? -1
-            : current_entry_index->expiry_time_ms - clock_realtime_coarse_int64_ms());
+            : current_entry_index->expiry_time_ms);
 
     storage_db_op_rmw_abort(connection_context->db, &rmw_status);
 

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -949,7 +949,7 @@ bool storage_db_entry_index_is_expired(
     return false;
 }
 
-int64_t storage_db_entry_index_expires_in_ms(
+int64_t storage_db_entry_index_ttl_ms(
         storage_db_entry_index_t *entry_index) {
     if (entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
         return -1;

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -955,7 +955,7 @@ int64_t storage_db_entry_index_expires_in_ms(
         return -1;
     }
 
-    return clock_realtime_coarse_int64_ms() - entry_index->expiry_time_ms;
+    return entry_index->expiry_time_ms - clock_realtime_coarse_int64_ms();
 }
 
 storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -949,6 +949,15 @@ bool storage_db_entry_index_is_expired(
     return false;
 }
 
+int64_t storage_db_entry_index_expires_in_ms(
+        storage_db_entry_index_t *entry_index) {
+    if (entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+        return -1;
+    }
+
+    return clock_realtime_coarse_int64_ms() - entry_index->expiry_time_ms;
+}
+
 storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(
         storage_db_t *db,
         char *key,
@@ -1143,6 +1152,16 @@ storage_db_entry_index_t *storage_db_op_rmw_current_entry_index_prep_for_read(
     return entry_index;
 }
 
+bool storage_db_op_rmw_commit_metadata(
+        storage_db_t *db,
+        storage_db_op_rmw_status_t *rmw_status) {
+    hashtable_mcmp_op_rmw_commit_update(
+            &rmw_status->hashtable,
+            rmw_status->current_entry_index);
+
+    return true;
+}
+
 bool storage_db_op_rmw_commit_update(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status,
@@ -1198,7 +1217,7 @@ bool storage_db_op_rmw_commit_update(
 
     result_res = true;
 
-end:
+    end:
 
     if (!result_res) {
         if (entry_index) {

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -272,6 +272,9 @@ storage_db_entry_index_t *storage_db_get_entry_index(
 bool storage_db_entry_index_is_expired(
         storage_db_entry_index_t *entry_index);
 
+int64_t storage_db_entry_index_expires_in_ms(
+        storage_db_entry_index_t *entry_index);
+
 storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(
         storage_db_t *db,
         char *key,
@@ -307,6 +310,10 @@ storage_db_entry_index_t *storage_db_op_rmw_current_entry_index_prep_for_read(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status,
         storage_db_entry_index_t *entry_index);
+
+bool storage_db_op_rmw_commit_metadata(
+        storage_db_t *db,
+        storage_db_op_rmw_status_t *rmw_status);
 
 bool storage_db_op_rmw_commit_update(
         storage_db_t *db,

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -272,7 +272,7 @@ storage_db_entry_index_t *storage_db_get_entry_index(
 bool storage_db_entry_index_is_expired(
         storage_db_entry_index_t *entry_index);
 
-int64_t storage_db_entry_index_expires_in_ms(
+int64_t storage_db_entry_index_ttl_ms(
         storage_db_entry_index_t *entry_index);
 
 storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(

--- a/tests/integration_tests/redis_server/bootstrap.sh
+++ b/tests/integration_tests/redis_server/bootstrap.sh
@@ -212,7 +212,7 @@ do
 		TOTAL_TESTS_COUNT=$(($TOTAL_TESTS_COUNT + 1))
 		TEST_NAME_GREP=$(printf '%q' "$TEST_NAME")
 
-		TEST_RESULT=$($CAT $TESTS_RESULTS_PATH | $GREP -v "\->" | $EGREP -e "\]: ${TEST_NAME_GREP} (\(|in ${TEMP_FOLDER}/tests)" | $CUT -d"[" -f 2 | $CUT -d"]" -f 1)
+		TEST_RESULT=$($CAT $TESTS_RESULTS_PATH | $GREP -v "\->" | $EGREP -e "\]: ${TEST_NAME_GREP} (\([0-9]+ ms\)|in ${TEMP_FOLDER}/tests)" | $CUT -d"[" -f 2 | $CUT -d"]" -f 1)
 
 		# Check that something was found and map it to success or failure
 		if [ -z "${TEST_RESULT}" ]
@@ -220,7 +220,7 @@ do
 			echo "Failed to fetch the test result for '${TEST_NAME}' in '${TEST_FILE_PATH}'" >&2
 			echo $TEST_RESULT
 			exit 1
-		elif [ $TEST_RESULT != "ok" ] && [ $TEST_RESULT != "err" ]
+		elif [ "${TEST_RESULT}" != "ok" ] && [ "${TEST_RESULT}" != "err" ]
 		then
 			echo "The test result '${TEST_RESULT}' fetched for '${TEST_NAME}' in '${TEST_FILE_PATH}' doesn\'t match the expected 'ok' or 'err' values" >&2
 			exit 1

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -2358,6 +2358,76 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         }
     }
 
+    SECTION("Redis - command - EXPIRETIME") {
+        SECTION("No key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIRETIME", "a_key"},
+                    ":-2\r\n"));
+        }
+
+        SECTION("Existing key - no expiration") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIRETIME", "a_key"},
+                    ":-1\r\n"));
+        }
+
+        SECTION("Existing key - expiration") {
+            int64_t unixtime_plus_5s = (clock_realtime_coarse_int64_ms() / 1000) + 5;
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIRETIME", "a_key"},
+                    (char*)string_format(":%ld\r\n", unixtime_plus_5s).c_str()));
+        }
+    }
+
+    SECTION("Redis - command - PEXPIRETIME") {
+        SECTION("No key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIRETIME", "a_key"},
+                    ":-2\r\n"));
+        }
+
+        SECTION("Existing key - no expiration") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIRETIME", "a_key"},
+                    ":-1\r\n"));
+        }
+
+        SECTION("Existing key - expiration") {
+            int64_t unixtime_ms_plus_5s = clock_realtime_coarse_int64_ms() + 5000;
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIRETIME", "a_key"},
+                    (char*)string_format(":%ld\r\n", unixtime_ms_plus_5s).c_str()));
+        }
+    }
+
     SECTION("Redis - command - LCS") {
         SECTION("Missing keys - String") {
             REQUIRE(send_recv_resp_command_text(

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -1927,6 +1927,151 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         }
     }
 
+    SECTION("Redis - command - EXPIREAT") {
+        char unixtime_plus_5s_str[32] = { 0 };
+        int64_t unixtime_plus_5 = (clock_realtime_coarse_int64_ms() / 1000) + 5;
+        snprintf(unixtime_plus_5s_str, sizeof(unixtime_plus_5s_str), "%ld", unixtime_plus_5);
+
+        SECTION("No key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - NX - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "NX"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - NX - key with expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "NX"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - XX - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "XX"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - XX - key with expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "XX"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - GT - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - GT - key with expiry - lower than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - GT - key with expiry - greater than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - LT - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - LT - key with expiry - lower than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - LT - key with expiry - greater than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
+                    ":0\r\n"));
+        }
+    }
+
     SECTION("Redis - command - PEXPIRE") {
         SECTION("No key") {
             REQUIRE(send_recv_resp_command_text(
@@ -2064,6 +2209,151 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             REQUIRE(send_recv_resp_command_text(
                     client_fd,
                     std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
+                    ":0\r\n"));
+        }
+    }
+
+    SECTION("Redis - command - PEXPIREAT") {
+        char unixtime_ms_plus_5s_str[32] = {0 };
+        int64_t unixtime_ms_plus_5s = clock_realtime_coarse_int64_ms() + 5000;
+        snprintf(unixtime_ms_plus_5s_str, sizeof(unixtime_ms_plus_5s_str), "%ld", unixtime_ms_plus_5s);
+
+        SECTION("No key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - NX - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "NX"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - NX - key with expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "NX"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - XX - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "XX"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - XX - key with expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "XX"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - GT - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "GT"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - GT - key with expiry - lower than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "GT"},
+                    ":0\r\n"));
+        }
+
+        SECTION("Existing key - GT - key with expiry - greater than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "GT"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - LT - key without expiry") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "LT"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - LT - key with expiry - lower than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "LT"},
+                    ":1\r\n"));
+        }
+
+        SECTION("Existing key - LT - key with expiry - greater than") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
+                    "+OK\r\n"));
+
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "LT"},
                     ":0\r\n"));
         }
     }


### PR DESCRIPTION
This PR implements a bunch of new commands related to keys expiration:
- EXPIRE
- EXPIREAT
- EXPIRETIME
- PEXPIRE
- PEXPIREAT
- PEXPIRETIME
- PERSIST

On a side, there is also a minor fix for the redis tests included in this PR