### PR TITLE
Implement getrange and setrange

### DIFF
--- a/src/data_structures/hashtable/spsc/hashtable_spsc.h
+++ b/src/data_structures/hashtable/spsc/hashtable_spsc.h
@@ -78,7 +78,7 @@ static inline __attribute__((always_inline)) hashtable_spsc_bucket_index_t hasht
     return -1;
 }
 
-static inline __attribute__((always_inline)) hashtable_spsc_bucket_index_t hashtable_spsc_find_bucket_index_by_key(
+static inline __attribute__((always_inline)) hashtable_spsc_bucket_index_t hashtable_spsc_find_bucket_index_by_key_ci(
         hashtable_spsc_t *hashtable,
         uint32_t hash,
         const char* key,
@@ -127,13 +127,81 @@ static inline __attribute__((always_inline)) hashtable_spsc_bucket_index_t hasht
     return -1;
 }
 
-static inline __attribute__((always_inline)) void *hashtable_spsc_op_get(
+static inline __attribute__((always_inline)) void *hashtable_spsc_op_get_ci(
+        hashtable_spsc_t *hashtable,
+        const char* key_ci,
+        hashtable_spsc_key_length_t key_ci_length) {
+    uint32_t hash = fnv_32_hash_ci((void *)key_ci, key_ci_length);
+
+    hashtable_spsc_bucket_index_t bucket_index = hashtable_spsc_find_bucket_index_by_key_ci(
+            hashtable,
+            hash,
+            key_ci,
+            key_ci_length);
+
+    if (unlikely(bucket_index == -1)) {
+        return NULL;
+    }
+
+    return hashtable_spsc_get_buckets(hashtable)[bucket_index].value;
+}
+
+static inline __attribute__((always_inline)) hashtable_spsc_bucket_index_t hashtable_spsc_find_bucket_index_by_key_cs(
+        hashtable_spsc_t *hashtable,
+        uint32_t hash,
+        const char* key,
+        hashtable_spsc_key_length_t key_length) {
+    hashtable_spsc_bucket_index_t bucket_index;
+    hashtable_spsc_bucket_count_t bucket_index_max;
+
+    assert(key_length < UINT16_MAX);
+
+    hashtable_spsc_cmp_hash_t cmp_hash = hash & 0x7FFF;
+
+    bucket_index = hashtable_spsc_bucket_index_from_hash(hashtable, hash);
+    bucket_index_max = bucket_index + hashtable->max_range;
+
+    do {
+        bucket_index = hashtable_spsc_find_set_bucket(
+                hashtable,
+                bucket_index,
+                bucket_index_max);
+
+        if (unlikely(bucket_index == -1)) {
+            if (hashtable->stop_on_not_set) {
+                break;
+            }
+
+            continue;
+        }
+
+        if (hashtable->hashes[bucket_index].cmp_hash != cmp_hash) {
+            continue;
+        }
+
+        hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
+
+        if (unlikely(buckets[bucket_index].key_length != key_length)) {
+            continue;
+        }
+
+        if (unlikely(strncmp(buckets[bucket_index].key, key, key_length) != 0)) {
+            continue;
+        }
+
+        return bucket_index;
+    } while(++bucket_index);
+
+    return -1;
+}
+
+static inline __attribute__((always_inline)) void *hashtable_spsc_op_get_cs(
         hashtable_spsc_t *hashtable,
         const char* key,
         hashtable_spsc_key_length_t key_length) {
-    uint32_t hash = fnv_32_hash_ci((void *)key, key_length);
+    uint32_t hash = fnv_32_hash((void *)key, key_length);
 
-    hashtable_spsc_bucket_index_t bucket_index = hashtable_spsc_find_bucket_index_by_key(
+    hashtable_spsc_bucket_index_t bucket_index = hashtable_spsc_find_bucket_index_by_key_cs(
             hashtable,
             hash,
             key,
@@ -155,13 +223,24 @@ hashtable_spsc_t *hashtable_spsc_new(
 void hashtable_spsc_free(
         hashtable_spsc_t *hashtable);
 
-bool hashtable_spsc_op_try_set(
+bool hashtable_spsc_op_try_set_ci(
         hashtable_spsc_t *hashtable,
         const char *key,
         hashtable_spsc_key_length_t key_length,
         void* value);
 
-bool hashtable_spsc_op_delete(
+bool hashtable_spsc_op_delete_ci(
+        hashtable_spsc_t *hashtable,
+        const char* key,
+        hashtable_spsc_key_length_t key_length);
+
+bool hashtable_spsc_op_try_set_cs(
+        hashtable_spsc_t *hashtable,
+        const char *key,
+        hashtable_spsc_key_length_t key_length,
+        void* value);
+
+bool hashtable_spsc_op_delete_cs(
         hashtable_spsc_t *hashtable,
         const char* key,
         hashtable_spsc_key_length_t key_length);

--- a/src/hash/hash_fnv1.h
+++ b/src/hash/hash_fnv1.h
@@ -32,7 +32,7 @@ static inline __attribute__((always_inline)) uint32_t fnv_32_hash_ci_internal(
     char *cp = (char*)buf;
     while (len > 0) {
         char c = *cp++;
-        c = c >= 'A' && c <= 'Z' ? c | (char) 32 : c;
+        c = c >= 'A' && c <= 'Z' ? (char)(c | 32) : c;
 
         hval += (hval<<1) + (hval<<4) + (hval<<7) + (hval<<8) + (hval<<24);
         hval ^= (uint32_t)c;

--- a/src/module/redis/command/module_redis_command_getrange.c
+++ b/src/module/redis/command/module_redis_command_getrange.c
@@ -79,6 +79,10 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getrange) {
         goto end;
     }
 
+    if (unlikely(range_start + range_length > entry_index->value->size)) {
+        range_length = entry_index->value->size = range_start;
+    }
+
     return_res = module_redis_command_stream_entry_range(
             connection_context->network_channel,
             connection_context->db,

--- a/src/module/redis/command/module_redis_command_getrange.c
+++ b/src/module/redis/command/module_redis_command_getrange.c
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_get.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_getrange"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getrange) {
+    bool return_res = false;
+    storage_db_entry_index_t *entry_index = NULL;
+    module_redis_command_getrange_context_t *context = connection_context->command.context;
+
+    entry_index = storage_db_get_entry_index_for_read(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length);
+
+    if (unlikely(!entry_index)) {
+        return_res = module_redis_connection_send_string_null(connection_context);
+        goto end;
+    }
+
+    off_t range_start = context->start.value;
+    off_t range_end = context->end.value;
+
+    if (range_start < 0) {
+        range_start += (off_t)entry_index->value->size;
+    }
+
+    if (range_end < 0) {
+        range_end += (off_t)entry_index->value->size;
+    }
+
+    size_t range_length = range_end - range_start + 1;
+
+    if (unlikely(range_start > entry_index->value->size || range_length <= 0)) {
+        return_res = module_redis_connection_send_string(connection_context, "", 0);
+        goto end;
+    }
+
+    return_res = module_redis_command_stream_entry_range(
+            connection_context->network_channel,
+            connection_context->db,
+            entry_index,
+            range_start,
+            range_length);
+
+end:
+
+    if (likely(entry_index)) {
+        storage_db_entry_index_status_decrease_readers_counter(entry_index, NULL);
+        entry_index = NULL;
+    }
+
+    return return_res;
+}

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -51,7 +51,8 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
     bool abort_rmw = true;
     storage_db_op_rmw_status_t rmw_status = { 0 };
     storage_db_entry_index_t *current_entry_index = NULL;
-    storage_db_chunk_sequence_t *new_chunk_sequence = NULL;
+    storage_db_chunk_sequence_t *destination_chunk_sequence = NULL, *current_chunk_sequence = NULL;
+    char *padding_memory_zeroed = NULL;
     module_redis_command_setrange_context_t *context = connection_context->command.context;
 
     if (context->offset.value < 0) {
@@ -73,23 +74,198 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
         goto end;
     }
 
+    if (likely(current_entry_index)) {
+        current_entry_index = storage_db_op_rmw_current_entry_index_prep_for_read(
+                connection_context->db,
+                &rmw_status,
+                current_entry_index);
+    }
+
+    if (likely(current_entry_index)) {
+        current_chunk_sequence = current_entry_index->value;
+    }
+
     size_t requested_total_length = context->offset.value + context->value.value.chunk_sequence->size;
     size_t chunk_sequence_required_length =  requested_total_length > current_entry_index->value->size
             ? requested_total_length
             : current_entry_index->value->size;
 
-    if (unlikely(!new_chunk_sequence = storage_db_chunk_sequence_allocate(
+    if (unlikely((destination_chunk_sequence = storage_db_chunk_sequence_allocate(
             connection_context->db,
-            chunk_sequence_required_length))) {
+            chunk_sequence_required_length)) == NULL)) {
         return_res = module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR setrange failed");
         goto end;
     }
 
-    // TODO
+    // Copy the data from the original chunk sequence or the new one for the range using a 3-way scrolling window
+    storage_db_chunk_index_t destination_chunk_index = 0, current_chunk_index = 0, range_value_chunk_index = 0;
+    storage_db_chunk_info_t *destination_chunk_info = NULL, *current_chunk_info = NULL, *range_value_chunk_info = NULL;
+    size_t destination_offset = 0, destination_chunk_offset = 0, range_value_chunk_offset = 0;
 
-    new_chunk_sequence = NULL;
+    destination_chunk_info = storage_db_chunk_sequence_get(
+            destination_chunk_sequence,
+            destination_chunk_index);
+    current_chunk_info = storage_db_chunk_sequence_get(
+            current_chunk_sequence,
+            current_chunk_index);
+    range_value_chunk_info = storage_db_chunk_sequence_get(
+            context->value.value.chunk_sequence,
+            range_value_chunk_index);
+
+    do {
+        assert(destination_chunk_info != NULL);
+
+        size_t data_to_write_length;
+        char *data_to_write_buffer = NULL;
+        char *allocated_buffer = NULL;
+        bool allocated_new_buffer = false;
+
+        if (destination_offset >= context->offset.value && destination_offset < requested_total_length) {
+            // This assert will be triggered if this branch will be accessed after all the data have been copied as
+            // the last storage_db_chunk_sequence_get will return NULL;
+            assert(range_value_chunk_info != NULL);
+
+            size_t can_write_length = range_value_chunk_info->chunk_length - range_value_chunk_offset;
+            size_t available_space_in_chunk_length = destination_chunk_info->chunk_length - destination_chunk_offset;
+
+            if (unlikely((allocated_buffer = storage_db_get_chunk_data(
+                    connection_context->db,
+                    range_value_chunk_info,
+                    &allocated_new_buffer)) == NULL)) {
+                return_res = module_redis_connection_error_message_printf_noncritical(
+                        connection_context,
+                        "ERR setrange failed");
+                goto end;
+            }
+
+            data_to_write_length = can_write_length > available_space_in_chunk_length
+                    ? available_space_in_chunk_length
+                    : can_write_length;
+            data_to_write_buffer = allocated_buffer + range_value_chunk_offset;
+
+            range_value_chunk_offset += data_to_write_length;
+
+            assert(range_value_chunk_offset <= range_value_chunk_info->chunk_length);
+
+            if (range_value_chunk_offset == range_value_chunk_info->chunk_length) {
+                // Destination and current chunks are fetched always together as the data have to copied from there is
+                // the current offset doesn't fall within the range of the data to copy
+                range_value_chunk_index++;
+
+                range_value_chunk_info = storage_db_chunk_sequence_get(
+                        context->value.value.chunk_sequence,
+                        range_value_chunk_index);
+
+                range_value_chunk_offset = 0;
+            }
+        } else {
+            // If source_chunk_info is NULL, then it means that current_chunk_info was selected and it's empty so it's not
+            // necessary to try to identify again the source_chunk_info until the range requested to be set is reached.
+            if (unlikely(current_chunk_info == NULL)) {
+                // When the source is null, an empty chunk of memory has to be written
+                if (unlikely(padding_memory_zeroed == NULL)) {
+                    padding_memory_zeroed = slab_allocator_mem_alloc_zero(STORAGE_DB_CHUNK_MAX_SIZE);
+                }
+
+                // Calculate how much has to be written, if current_chunk_info is NULL there will be nothing to write
+                // after the value passed in setrange is set, so the logic can be fairly simple and can be checked only
+                // with an assert via testing
+                size_t needed_padding = context->offset.value - destination_offset;
+                assert(needed_padding >= 0);
+
+                data_to_write_length = needed_padding > STORAGE_DB_CHUNK_MAX_SIZE
+                                       ? STORAGE_DB_CHUNK_MAX_SIZE
+                                       : needed_padding;
+
+                data_to_write_buffer = padding_memory_zeroed;
+            } else {
+                size_t can_write_length = current_chunk_info->chunk_length - destination_chunk_offset;
+                size_t destination_offset_after_write = destination_offset + can_write_length;
+
+                if (destination_offset < requested_total_length &&
+                    destination_offset_after_write > context->offset.value) {
+                    can_write_length = context->offset.value - destination_offset;
+                }
+
+                if (unlikely((allocated_buffer = storage_db_get_chunk_data(
+                        connection_context->db,
+                        current_chunk_info,
+                        &allocated_new_buffer)) == NULL)) {
+                    return_res = module_redis_connection_error_message_printf_noncritical(
+                            connection_context,
+                            "ERR setrange failed");
+                    goto end;
+                }
+
+                data_to_write_length = can_write_length;
+                data_to_write_buffer = allocated_buffer + destination_chunk_offset;
+            }
+        }
+
+        if (unlikely(!storage_db_chunk_write(
+                connection_context->db,
+                destination_chunk_info,
+                destination_chunk_offset,
+                data_to_write_buffer,
+                data_to_write_length))) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR setrange failed");
+            goto end;
+        }
+
+        if (allocated_new_buffer) {
+            slab_allocator_mem_free(allocated_buffer);
+            allocated_buffer = NULL;
+            allocated_new_buffer = false;
+        }
+
+        destination_offset += data_to_write_length;
+        destination_chunk_offset += data_to_write_length;
+
+        if (destination_chunk_offset == destination_chunk_info->chunk_length) {
+            // Destination and current chunks are fetched always together as the data have to copied from there is
+            // the current offset doesn't fall within the range of the data to copy
+            destination_chunk_index++;
+            current_chunk_index++;
+
+            destination_chunk_info = storage_db_chunk_sequence_get(
+                    destination_chunk_sequence,
+                    destination_chunk_index);
+            current_chunk_info = storage_db_chunk_sequence_get(
+                    current_chunk_sequence,
+                    current_chunk_index);
+
+            destination_chunk_offset = 0;
+        } else if (unlikely(current_chunk_info && destination_chunk_offset == current_chunk_info->chunk_length)) {
+            // If this branch is hit, it means that the setrange is trying to write after the end of the existing data
+            // so current_chunk_info will be basically set to NULL.
+            current_chunk_index++;
+            current_chunk_info = storage_db_chunk_sequence_get(
+                    current_chunk_sequence,
+                    current_chunk_index);
+        }
+    } while(destination_chunk_index < destination_chunk_sequence->count);
+
+    module_redis_connection_send_number(connection_context, (int64_t)destination_chunk_sequence->size);
+
+    if (unlikely(!storage_db_op_rmw_commit_update(
+            connection_context->db,
+            &rmw_status,
+            destination_chunk_sequence,
+            STORAGE_DB_ENTRY_NO_EXPIRY))) {
+        return_res = module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR setrange failed");
+        goto end;
+    }
+
+    // Set the key null as now it's owned by the storage_db / hashtable
+    context->key.value.key = NULL;
+
+    destination_chunk_sequence = NULL;
     abort_rmw = false;
     return_res = true;
 
@@ -99,8 +275,12 @@ end:
         storage_db_op_rmw_abort(connection_context->db, &rmw_status);
     }
 
-    if (new_chunk_sequence) {
-        storage_db_chunk_sequence_free(connection_context->db, new_chunk_sequence):
+    if (current_entry_index) {
+        storage_db_entry_index_status_decrease_readers_counter(current_entry_index, NULL);
+    }
+
+    if (destination_chunk_sequence) {
+        storage_db_chunk_sequence_free(connection_context->db, destination_chunk_sequence);
     }
 
     return return_res;

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -164,7 +164,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
                 range_value_chunk_offset = 0;
             }
         } else {
-            // If source_chunk_info is NULL, then it means that current_chunk_info was selected and it's empty so it's not
+            // If source_chunk_info is NULL it means that current_chunk_info was selected and it's empty, it's not
             // necessary to try to identify again the source_chunk_info until the range requested to be set is reached.
             if (unlikely(current_chunk_info == NULL)) {
                 // When the source is null, an empty chunk of memory has to be written
@@ -175,7 +175,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
                 // Calculate how much has to be written, if current_chunk_info is NULL there will be nothing to write
                 // after the value passed in setrange is set, so the logic can be fairly simple and can be checked only
                 // with an assert via testing
-                size_t needed_padding = context->offset.value - destination_offset;
+                off_t needed_padding = context->offset.value - (off_t)destination_offset;
                 assert(needed_padding >= 0);
 
                 data_to_write_length = needed_padding > STORAGE_DB_CHUNK_MAX_SIZE

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -54,6 +54,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
     storage_db_chunk_sequence_t *new_chunk_sequence = NULL;
     module_redis_command_setrange_context_t *context = connection_context->command.context;
 
+    if (context->offset.value < 0) {
+        return_res = module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR offset is out of range");
+        goto end;
+    }
+
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             context->key.value.key,
@@ -63,13 +70,6 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
         return_res = module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR setrange failed");
-        goto end;
-    }
-
-    if (context->offset.value < 0) {
-        return_res = module_redis_connection_error_message_printf_noncritical(
-                connection_context,
-                "ERR offset is out of range");
         goto end;
     }
 

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_get.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "fiber.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
+#include "network/network.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+
+#define TAG "module_redis_command_setrange"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
+    bool return_res = false;
+    bool abort_rmw = true;
+    storage_db_op_rmw_status_t rmw_status = { 0 };
+    storage_db_entry_index_t *current_entry_index = NULL;
+    storage_db_chunk_sequence_t *new_chunk_sequence = NULL;
+    module_redis_command_setrange_context_t *context = connection_context->command.context;
+
+    if (unlikely(!storage_db_op_rmw_begin(
+            connection_context->db,
+            context->key.value.key,
+            context->key.value.length,
+            &rmw_status,
+            &current_entry_index))) {
+        return_res = module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR setrange failed");
+        goto end;
+    }
+
+    if (context->offset.value < 0) {
+        return_res = module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR offset is out of range");
+        goto end;
+    }
+
+    size_t requested_total_length = context->offset.value + context->value.value.chunk_sequence->size;
+    size_t chunk_sequence_required_length =  requested_total_length > current_entry_index->value->size
+            ? requested_total_length
+            : current_entry_index->value->size;
+
+    if (unlikely(!new_chunk_sequence = storage_db_chunk_sequence_allocate(
+            connection_context->db,
+            chunk_sequence_required_length))) {
+        return_res = module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR setrange failed");
+        goto end;
+    }
+
+    // TODO
+
+    new_chunk_sequence = NULL;
+    abort_rmw = false;
+    return_res = true;
+
+end:
+
+    if (current_entry_index && abort_rmw) {
+        storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    }
+
+    if (new_chunk_sequence) {
+        storage_db_chunk_sequence_free(connection_context->db, new_chunk_sequence):
+    }
+
+    return return_res;
+}

--- a/src/module/redis/module_redis.c
+++ b/src/module/redis/module_redis.c
@@ -232,7 +232,7 @@ bool module_redis_process_data(
                     char *command_data = read_buffer_data_start + connection_context->current_argument_token_data_offset;
 
                     // Set the current command to UNKNOWN
-                    connection_context->command.info = hashtable_spsc_op_get(
+                    connection_context->command.info = hashtable_spsc_op_get_ci(
                             module_redis_commands_hashtable,
                             command_data,
                             command_length);

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -761,18 +761,23 @@ bool module_redis_command_acquire_slice_and_write_blob_start(
     return true;
 }
 
-bool module_redis_command_stream_entry_with_one_chunk(
+bool module_redis_command_stream_entry_range_with_one_chunk(
         network_channel_t *network_channel,
         storage_db_t *db,
-        storage_db_entry_index_t *entry_index) {
+        storage_db_entry_index_t *entry_index,
+        size_t range_start,
+        size_t range_length) {
     bool result_res = false;
     network_channel_buffer_data_t *send_buffer = NULL, *send_buffer_start = NULL, *send_buffer_end = NULL;
     storage_db_chunk_info_t *chunk_info;
 
+    assert(entry_index->value->count == 1 && range_length + 32 <= NETWORK_CHANNEL_MAX_PACKET_SIZE);
+
+    // Acquires a slice long enough to stream the data and the protocol bits
     if (unlikely(!module_redis_command_acquire_slice_and_write_blob_start(
             network_channel,
-            MIN(entry_index->value->size + 32, STORAGE_DB_CHUNK_MAX_SIZE),
-            entry_index->value->size,
+            range_length + 32,
+            range_length,
             &send_buffer,
             &send_buffer_start,
             &send_buffer_end))) {
@@ -786,12 +791,9 @@ bool module_redis_command_stream_entry_with_one_chunk(
     if (unlikely(!storage_db_chunk_read(
             db,
             chunk_info,
-            send_buffer_start))) {
-        LOG_E(
-                TAG,
-                "[REDIS][GET] Critical error, unable to read chunk <%u> long <%u> bytes",
-                0,
-                chunk_info->chunk_length);
+            send_buffer_start,
+            range_start,
+            range_length))) {
         return false;
     }
 
@@ -813,7 +815,7 @@ bool module_redis_command_stream_entry_with_one_chunk(
     send_buffer = NULL;
     result_res = true;
 
-end:
+    end:
 
     if (unlikely(send_buffer != NULL && !result_res)) {
         network_send_buffer_release_slice(
@@ -824,19 +826,23 @@ end:
     return result_res;
 }
 
-bool module_redis_command_stream_entry_with_multiple_chunks(
+bool module_redis_command_stream_entry_range_with_multiple_chunks(
         network_channel_t *network_channel,
         storage_db_t *db,
-        storage_db_entry_index_t *entry_index) {
+        storage_db_entry_index_t *entry_index,
+        size_t range_start,
+        size_t range_length) {
     bool res;
     network_channel_buffer_data_t *send_buffer = NULL, *send_buffer_start = NULL, *send_buffer_end = NULL;
     storage_db_chunk_info_t *chunk_info = NULL;
     size_t slice_length = 32;
 
+    assert(entry_index->value->count > 1 || range_length + 32 > NETWORK_CHANNEL_MAX_PACKET_SIZE);
+
     if (unlikely(!module_redis_command_acquire_slice_and_write_blob_start(
             network_channel,
             32,
-            entry_index->value->size,
+            range_length,
             &send_buffer,
             &send_buffer_start,
             &send_buffer_end))) {
@@ -847,14 +853,29 @@ bool module_redis_command_stream_entry_with_multiple_chunks(
             network_channel,
             send_buffer_start ? send_buffer_start - send_buffer : 0);
 
+    size_t sent_data;
+    storage_db_chunk_index_t chunk_index = 0;
+
+    // Skip the chunks until it reaches one containing range_start
+    for (; chunk_index < entry_index->value->count; chunk_index++) {
+        chunk_info = storage_db_chunk_sequence_get(entry_index->value, chunk_index);
+
+        if (range_start < chunk_info->chunk_length) {
+            break;
+        }
+
+        range_start -= chunk_info->chunk_length;
+    }
+
+    // Set sent_data to the value of range_start to skip the initial part of the first chunk selected to be sent
+    sent_data = range_start;
+
     // Build the chunks for the value
-    for (storage_db_chunk_index_t chunk_index = 0; chunk_index < entry_index->value->count; chunk_index++) {
+    for (; chunk_index < entry_index->value->count && range_length > 0; chunk_index++) {
         char *buffer_to_send;
-        size_t buffer_to_send_length;
         bool allocated_new_buffer = false;
         chunk_info = storage_db_chunk_sequence_get(entry_index->value, chunk_index);
 
-        buffer_to_send_length = chunk_info->chunk_length;
         if (unlikely((buffer_to_send = storage_db_get_chunk_data(
                 db,
                 chunk_info,
@@ -862,9 +883,11 @@ bool module_redis_command_stream_entry_with_multiple_chunks(
             return false;
         }
 
-        size_t sent_data = 0;
+        size_t chunk_length_to_send = range_length > chunk_info->chunk_length
+                ? chunk_info->chunk_length
+                : range_length;
         do {
-            size_t data_available_to_send_length = buffer_to_send_length - sent_data;
+            size_t data_available_to_send_length = chunk_length_to_send - sent_data;
             size_t data_to_send_length =
                     data_available_to_send_length > NETWORK_CHANNEL_MAX_PACKET_SIZE
                     ? NETWORK_CHANNEL_MAX_PACKET_SIZE
@@ -880,13 +903,17 @@ bool module_redis_command_stream_entry_with_multiple_chunks(
             }
 
             sent_data += data_to_send_length;
-        } while (sent_data < buffer_to_send_length);
+            range_length -= data_to_send_length;
+        } while (sent_data < chunk_length_to_send);
 
-        assert(sent_data == buffer_to_send_length);
+        assert(sent_data == chunk_length_to_send);
 
         if (allocated_new_buffer) {
             slab_allocator_mem_free(buffer_to_send);
         }
+
+        // Resets sent data at the end of the loop
+        sent_data = 0;
     }
 
     send_buffer = send_buffer_start = network_send_buffer_acquire_slice(

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -884,7 +884,7 @@ bool module_redis_command_stream_entry_range_with_multiple_chunks(
 
         size_t chunk_length_to_send = length > chunk_info->chunk_length
                 ? chunk_info->chunk_length
-                : length;
+                : length + sent_data;
         do {
             size_t data_available_to_send_length = chunk_length_to_send - sent_data;
             size_t data_to_send_length =

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -444,7 +444,7 @@ bool module_redis_command_process_argument_full(
     }
 
     if (check_tokens && connection_context->command.info->tokens_hashtable) {
-        module_redis_command_parser_context_argument_token_entry_t *token_entry = hashtable_spsc_op_get(
+        module_redis_command_parser_context_argument_token_entry_t *token_entry = hashtable_spsc_op_get_ci(
                 connection_context->command.info->tokens_hashtable,
                 chunk_data,
                 chunk_length);
@@ -456,7 +456,7 @@ bool module_redis_command_process_argument_full(
                 module_redis_command_argument_t *stopped_at_list_argument, *stopped_at_list_resume_from_argument;
 
                 for(int index = 0; index < token_entry->one_of_token_count; index++) {
-                    module_redis_command_parser_context_argument_token_entry_t *oneof_token_entry = hashtable_spsc_op_get(
+                    module_redis_command_parser_context_argument_token_entry_t *oneof_token_entry = hashtable_spsc_op_get_ci(
                             connection_context->command.info->tokens_hashtable,
                             token_entry->one_of_tokens[index],
                             strlen(token_entry->one_of_tokens[index]));

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -781,7 +781,7 @@ bool module_redis_command_stream_entry_range_with_one_chunk(
             &send_buffer,
             &send_buffer_start,
             &send_buffer_end))) {
-        return false;
+        goto end;
     }
 
     chunk_info = storage_db_chunk_sequence_get(
@@ -794,10 +794,10 @@ bool module_redis_command_stream_entry_range_with_one_chunk(
             send_buffer_start,
             offset,
             length))) {
-        return false;
+        goto end;
     }
 
-    send_buffer_start += chunk_info->chunk_length;
+    send_buffer_start += length;
 
     send_buffer_start = protocol_redis_writer_write_argument_blob_end(
             send_buffer_start,
@@ -815,7 +815,7 @@ bool module_redis_command_stream_entry_range_with_one_chunk(
     send_buffer = NULL;
     result_res = true;
 
-    end:
+end:
 
     if (unlikely(send_buffer != NULL && !result_res)) {
         network_send_buffer_release_slice(
@@ -832,7 +832,6 @@ bool module_redis_command_stream_entry_range_with_multiple_chunks(
         storage_db_entry_index_t *entry_index,
         off_t offset,
         size_t length) {
-    bool res;
     network_channel_buffer_data_t *send_buffer = NULL, *send_buffer_start = NULL, *send_buffer_end = NULL;
     storage_db_chunk_info_t *chunk_info = NULL;
     size_t slice_length = 32;

--- a/src/module/redis/module_redis_command.h
+++ b/src/module/redis/module_redis_command.h
@@ -50,15 +50,15 @@ bool module_redis_command_stream_entry_range_with_one_chunk(
         network_channel_t *network_channel,
         storage_db_t *db,
         storage_db_entry_index_t *entry_index,
-        size_t range_start,
-        size_t range_length);
+        off_t offset,
+        size_t length);
 
 bool module_redis_command_stream_entry_range_with_multiple_chunks(
         network_channel_t *network_channel,
         storage_db_t *db,
         storage_db_entry_index_t *entry_index,
-        size_t range_start,
-        size_t range_length);
+        off_t offset,
+        size_t length);
 
 static inline __attribute__((always_inline)) bool module_redis_command_process_end(
         module_redis_connection_context_t *connection_context) {
@@ -231,9 +231,9 @@ static inline __attribute__((always_inline)) bool module_redis_command_stream_en
         network_channel_t *network_channel,
         storage_db_t *db,
         storage_db_entry_index_t *entry_index,
-        size_t range_start,
-        size_t range_length) {
-    if (unlikely(range_start + range_length > entry_index->value->size)) {
+        off_t offset,
+        size_t length) {
+    if (unlikely(offset + length > entry_index->value->size)) {
         return false;
     }
 
@@ -245,15 +245,15 @@ static inline __attribute__((always_inline)) bool module_redis_command_stream_en
                 network_channel,
                 db,
                 entry_index,
-                range_start,
-                range_length);
+                offset,
+                length);
     } else {
         return module_redis_command_stream_entry_range_with_multiple_chunks(
                 network_channel,
                 db,
                 entry_index,
-                range_start,
-                range_length);
+                offset,
+                length);
     }
 }
 

--- a/src/module/redis/module_redis_commands.c
+++ b/src/module/redis/module_redis_commands.c
@@ -53,7 +53,7 @@ hashtable_spsc_t *module_redis_commands_build_commands_hashtables(
             command_info_index++) {
         module_redis_command_info_t *command_info = &command_infos[command_info_index];
 
-        if (!hashtable_spsc_op_try_set(
+        if (!hashtable_spsc_op_try_set_ci(
                 commands_hashtable,
                 command_info->string,
                 command_info->string_len,
@@ -154,7 +154,7 @@ bool module_redis_commands_build_command_arguments_token_entries_hashtable(
         }
 
         // These are fixed hashtable generated at the start, if the set fails the software must stop
-        if (!hashtable_spsc_op_try_set(
+        if (!hashtable_spsc_op_try_set_ci(
                 hashtable,
                 argument->token,
                 strlen(argument->token),

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -702,7 +702,7 @@ bool storage_db_chunk_read(
         char *buffer,
         off_t offset,
         size_t length) {
-    assert(offset + length < chunk_info->chunk_length);
+    assert(offset + length <= chunk_info->chunk_length);
 
     if (db->config->backend_type == STORAGE_DB_BACKEND_TYPE_MEMORY) {
         if (!memcpy(buffer, chunk_info->memory.chunk_data + offset, length)) {

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -768,7 +768,7 @@ bool storage_db_chunk_write(
 storage_db_chunk_info_t *storage_db_chunk_sequence_get(
         storage_db_chunk_sequence_t *chunk_sequence,
         storage_db_chunk_index_t chunk_index) {
-    if (unlikely(chunk_index >= chunk_sequence->count)) {
+    if (unlikely(chunk_sequence == NULL || chunk_index >= chunk_sequence->count)) {
         return NULL;
     }
 

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -583,6 +583,9 @@ storage_db_chunk_sequence_t *storage_db_chunk_sequence_allocate(
     storage_db_chunk_sequence_t *chunk_sequence = slab_allocator_mem_alloc(sizeof(storage_db_chunk_sequence_t));
 
     if (unlikely(!chunk_sequence)) {
+        LOG_E(
+                TAG,
+                "Failed to allocate a chunk sequence");
         goto end;
     }
 

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -222,7 +222,9 @@ char* storage_db_entry_chunk_read_fast_from_memory(
 bool storage_db_chunk_read(
         storage_db_t *db,
         storage_db_chunk_info_t *chunk_info,
-        char *buffer);
+        char *buffer,
+        off_t offset,
+        size_t length);
 
 bool storage_db_chunk_write(
         storage_db_t *db,

--- a/tests/unit_tests/data_structures/test-hashtable-spsc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-spsc.cpp
@@ -14,13 +14,19 @@
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
 TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][hashtable][hashtable_spsc]") {
-    char *key = "this is a key";
+    char *key = "This Is A Key";
+    char *key_different_case = "THIS IS A KEY";
     hashtable_spsc_key_length_t key_length = strlen(key);
-    uint32_t key_hash = fnv_32_hash_ci(key, key_length);
+    uint32_t key_hash = fnv_32_hash(key, key_length);
+    uint32_t key_different_case_hash = fnv_32_hash(key_different_case, key_length);
+    uint32_t key_ci_hash = fnv_32_hash_ci(key, key_length);
+    uint32_t key_different_case_ci_hash = fnv_32_hash_ci(key, key_length);
 
-    char *key2 = "this is a another key";
+    char *key2 = "This Is Another Key";
+    char *key2_different_case = "THIS IS ANOTHER KEY";
     hashtable_spsc_key_length_t key2_length = strlen(key2);
-    uint32_t key2_hash = fnv_32_hash_ci(key2, key2_length);
+    uint32_t key2_hash = fnv_32_hash(key2, key2_length);
+    uint32_t key2_ci_hash = fnv_32_hash_ci(key2, key2_length);
 
     SECTION("hashtable_spsc_new") {
         SECTION("valid buckets_count, default max range, stop_on_not_set true, free_keys_on_deallocation false") {
@@ -87,7 +93,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
         hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
 
-        REQUIRE(buckets == (void*)(hashtable->hashes + hashtable->buckets_count_real));
+        REQUIRE(buckets == (void *) (hashtable->hashes + hashtable->buckets_count_real));
 
         hashtable_spsc_free(hashtable);
     }
@@ -98,8 +104,9 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
                 false,
                 false);
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index_max = hashtable_key_bucket_index + hashtable->max_range;
+        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_ci_hash & (hashtable->buckets_count_pow2 - 1);
+        hashtable_spsc_bucket_count_t hashtable_key_bucket_index_max =
+                hashtable_key_bucket_index + hashtable->max_range;
 
         SECTION("bucket found") {
             hashtable->hashes[hashtable_key_bucket_index].set = true;
@@ -135,8 +142,9 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
                 false,
                 false);
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index_max = hashtable_key_bucket_index + hashtable->max_range;
+        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_ci_hash & (hashtable->buckets_count_pow2 - 1);
+        hashtable_spsc_bucket_count_t hashtable_key_bucket_index_max =
+                hashtable_key_bucket_index + hashtable->max_range;
 
         SECTION("bucket found") {
             REQUIRE(hashtable_spsc_find_empty_bucket(
@@ -146,7 +154,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         }
 
         SECTION("bucket not found - nothing in range") {
-            for(int index = hashtable_key_bucket_index; index < hashtable_key_bucket_index_max; index++) {
+            for (int index = hashtable_key_bucket_index; index < hashtable_key_bucket_index_max; index++) {
                 hashtable->hashes[index].set = true;
             }
 
@@ -157,7 +165,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         }
 
         SECTION("bucket not found - hashtable full") {
-            for(int index = 0; index < hashtable->buckets_count_real; index++) {
+            for (int index = 0; index < hashtable->buckets_count_real; index++) {
                 hashtable->hashes[index].set = true;
             }
 
@@ -177,232 +185,580 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 false,
                 false);
 
-        // TODO
+        REQUIRE((key_hash & (hashtable->buckets_count_pow2 - 1)) == 15);
 
         hashtable_spsc_free(hashtable);
     }
 
-    SECTION("hashtable_spsc_find_bucket_index_by_key") {
-        hashtable_spsc_t *hashtable = hashtable_spsc_new(
-                16,
-                HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
-                false);
-        hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+    SECTION("Case Insensitive interface") {
+        SECTION("hashtable_spsc_find_bucket_index_by_key_ci") {
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index =
+                    key_ci_hash & (hashtable->buckets_count_pow2 - 1);
 
-        hashtable_spsc_t *hashtable2 = hashtable_spsc_new(
-                16,
-                HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                true,
-                false);
-        hashtable_spsc_bucket_t *hashtable2_buckets = hashtable_spsc_get_buckets(hashtable2);
-        hashtable_spsc_bucket_count_t hashtable2_key_bucket_index = key_hash & (hashtable2->buckets_count_pow2 - 1);
+            hashtable_spsc_t *hashtable2 = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    true,
+                    false);
+            hashtable_spsc_bucket_t *hashtable2_buckets = hashtable_spsc_get_buckets(hashtable2);
+            hashtable_spsc_bucket_count_t hashtable2_key_bucket_index =
+                    key_ci_hash & (hashtable2->buckets_count_pow2 - 1);
 
-        SECTION("bucket found - key exists") {
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index].key = key;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+            SECTION("bucket found - key exists") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable, key_hash, key, key_length) == hashtable_key_bucket_index);
-        }
-
-        SECTION("bucket found - same hash but different key_length and key") {
-            hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
-            hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
-            hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
-
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash;
-            hashtable_buckets[hashtable_key_bucket_index].key = key2;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key2_length;
-
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable, key_hash, key, key_length) == hashtable_key_bucket_index + 1);
-        }
-
-        SECTION("bucket found - same hash and same key_length but different key") {
-            hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
-            hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
-            hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
-
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash;
-            hashtable_buckets[hashtable_key_bucket_index].key = key2;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = hashtable_buckets[hashtable_key_bucket_index + 1].key_length;
-
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable, key_hash, key, key_length) == hashtable_key_bucket_index + 1);
-        }
-
-        SECTION("bucket found - key exists, not first bucket") {
-            int extra_slots = 6;
-
-            for(int index = 0; index < extra_slots; index++) {
-                hashtable->hashes[hashtable_key_bucket_index + index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = (key_hash & 0x7FFF) + 1 + index;
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable, key_ci_hash, key, key_length) == hashtable_key_bucket_index);
             }
 
-            hashtable->hashes[hashtable_key_bucket_index + extra_slots].set = true;
-            hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index + extra_slots].key = key;
-            hashtable_buckets[hashtable_key_bucket_index + extra_slots].key_length = key_length;
+            SECTION("bucket found - same hash but different key_length and key") {
+                hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
 
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(
-                    hashtable, key_hash, key, key_length) == hashtable_key_bucket_index + extra_slots);
-        }
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash =
+                        hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash;
+                hashtable_buckets[hashtable_key_bucket_index].key = key2;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key2_length;
 
-        SECTION("bucket found - key exists, last bucket within max range") {
-            hashtable_key_bucket_index += hashtable->max_range - 1;
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index].key = key;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
-
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable, key_hash, key, key_length) == hashtable_key_bucket_index);
-        }
-
-        SECTION("bucket not found - key not-existent") {
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index].key = key;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
-
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable, key2_hash, key2, key2_length) == -1);
-        }
-
-        SECTION("bucket not found - key outside max range") {
-            hashtable_key_bucket_index += hashtable->max_range;
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index].key = key;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
-
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable, key_hash, key, key_length) == -1);
-        }
-
-        SECTION("bucket not found - key exists but not set buckets on the way") {
-            hashtable2_key_bucket_index += hashtable2->max_range;
-            hashtable2->hashes[hashtable2_key_bucket_index].set = true;
-            hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable2_buckets[hashtable2_key_bucket_index].key = key;
-            hashtable2_buckets[hashtable2_key_bucket_index].key_length = key_length;
-
-            REQUIRE(hashtable_spsc_find_bucket_index_by_key(hashtable2, key_hash, key, key_length) == -1);
-        }
-
-        hashtable_spsc_free(hashtable);
-        hashtable_spsc_free(hashtable2);
-    }
-
-    SECTION("hashtable_spsc_op_try_set") {
-        char *value1 = "first value";
-        char *value2 = "second value";
-        hashtable_spsc_t *hashtable = hashtable_spsc_new(
-                16,
-                HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
-                false);
-        hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
-
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
-
-        SECTION("value set - insert") {
-            REQUIRE(hashtable_spsc_op_try_set(hashtable, key, key_length, value1));
-
-            REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-            REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
-            REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
-            REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
-            REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
-        }
-
-        SECTION("value set - update") {
-            REQUIRE(hashtable_spsc_op_try_set(hashtable, key, key_length, value1));
-            REQUIRE(hashtable_spsc_op_try_set(hashtable, key, key_length, value2));
-
-            REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-            REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
-            REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
-            REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
-            REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
-        }
-
-        SECTION("value not set - no free buckets in range") {
-            for(int index = 0; index < hashtable->max_range; index++) {
-                hashtable->hashes[hashtable_key_bucket_index + index].set = true;
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable, key_ci_hash, key, key_length) == hashtable_key_bucket_index + 1);
             }
 
-            REQUIRE(!hashtable_spsc_op_try_set(hashtable, key, key_length, &value1));
-        }
+            SECTION("bucket found - same hash and same key_length but different key") {
+                hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
 
-        SECTION("value not set - hashtable full") {
-            for(int index = 0; index < hashtable->buckets_count_real; index++) {
-                hashtable->hashes[index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash =
+                        hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash;
+                hashtable_buckets[hashtable_key_bucket_index].key = key2;
+                hashtable_buckets[hashtable_key_bucket_index].key_length =
+                        hashtable_buckets[hashtable_key_bucket_index + 1].key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable, key_ci_hash, key, key_length) == hashtable_key_bucket_index + 1);
             }
 
-            REQUIRE(!hashtable_spsc_op_try_set(hashtable, key, key_length, &value1));
+            SECTION("bucket found - key exists, not first bucket") {
+                int extra_slots = 6;
+
+                for (int index = 0; index < extra_slots; index++) {
+                    hashtable->hashes[hashtable_key_bucket_index + index].set = true;
+                    hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = (key_ci_hash & 0x7FFF) + 1 + index;
+                }
+
+                hashtable->hashes[hashtable_key_bucket_index + extra_slots].set = true;
+                hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index + extra_slots].key = key;
+                hashtable_buckets[hashtable_key_bucket_index + extra_slots].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable, key_ci_hash, key, key_length) == hashtable_key_bucket_index + extra_slots);
+            }
+
+            SECTION("bucket found - key exists, last bucket within max range") {
+                hashtable_key_bucket_index += hashtable->max_range - 1;
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(hashtable, key_ci_hash, key, key_length) ==
+                        hashtable_key_bucket_index);
+            }
+
+            SECTION("bucket found - key with different case") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable, key_hash, key_different_case, key_length) == hashtable_key_bucket_index);
+            }
+
+            SECTION("bucket not found - key not-existent") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable, key2_ci_hash, key2, key2_length) == -1);
+            }
+
+            SECTION("bucket not found - key outside max range") {
+                hashtable_key_bucket_index += hashtable->max_range;
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(hashtable, key_ci_hash, key, key_length) == -1);
+            }
+
+            SECTION("bucket not found - key exists but not set buckets on the way") {
+                hashtable2_key_bucket_index += hashtable2->max_range;
+                hashtable2->hashes[hashtable2_key_bucket_index].set = true;
+                hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable2_buckets[hashtable2_key_bucket_index].key = key;
+                hashtable2_buckets[hashtable2_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_ci(
+                        hashtable2, key_ci_hash, key, key_length) == -1);
+            }
+
+            hashtable_spsc_free(hashtable);
+            hashtable_spsc_free(hashtable2);
         }
 
-        hashtable_spsc_free(hashtable);
+        SECTION("hashtable_spsc_op_try_set_ci") {
+            char *value1 = "first value";
+            char *value2 = "second value";
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index =
+                    key_ci_hash & (hashtable->buckets_count_pow2 - 1);
+
+            SECTION("value set - insert") {
+                REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key, key_length, value1));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_ci_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
+            }
+
+            SECTION("value set - update") {
+                REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key, key_length, value1));
+                REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key, key_length, value2));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_ci_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
+            }
+
+            SECTION("value set - update - key with different key") {
+                REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key, key_length, value1));
+                REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key_different_case, key_length, value2));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_ci_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key_different_case);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
+            }
+
+            SECTION("value not set - no free buckets in range") {
+                for (int index = 0; index < hashtable->max_range; index++) {
+                    hashtable->hashes[hashtable_key_bucket_index + index].set = true;
+                }
+
+                REQUIRE(!hashtable_spsc_op_try_set_ci(hashtable, key, key_length, &value1));
+            }
+
+            SECTION("value not set - hashtable full") {
+                for (int index = 0; index < hashtable->buckets_count_real; index++) {
+                    hashtable->hashes[index].set = true;
+                }
+
+                REQUIRE(!hashtable_spsc_op_try_set_ci(hashtable, key, key_length, &value1));
+            }
+
+            hashtable_spsc_free(hashtable);
+        }
+
+
+
+        SECTION("hashtable_spsc_op_get_ci") {
+            char *value1 = "first value";
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_ci_hash & (hashtable->buckets_count_pow2 - 1);
+
+            SECTION("value found - existing key") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+                hashtable_buckets[hashtable_key_bucket_index].value = value1;
+
+                REQUIRE(hashtable_spsc_op_get_ci(hashtable, key, key_length) == value1);
+            }
+
+            SECTION("value found - existing key with different case") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+                hashtable_buckets[hashtable_key_bucket_index].value = value1;
+
+                REQUIRE(hashtable_spsc_op_get_ci(hashtable, key_different_case, key_length) == value1);
+            }
+
+            SECTION("value not found - non-existent key") {
+                REQUIRE(hashtable_spsc_op_get_ci(hashtable, key, key_length) == NULL);
+            }
+
+            hashtable_spsc_free(hashtable);
+        }
+
+        SECTION("hashtable_spsc_op_delete_ci") {
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_ci_hash & (hashtable->buckets_count_pow2 - 1);
+
+            SECTION("value deleted - existing key") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_op_delete_ci(hashtable, key, key_length));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set == false);
+            }
+
+            SECTION("value deleted - existing key with different case") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_op_delete_ci(hashtable, key_different_case, key_length));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set == false);
+            }
+
+            SECTION("value not deleted - non-existent key") {
+                REQUIRE(!hashtable_spsc_op_delete_ci(hashtable, key, key_length));
+            }
+
+            hashtable_spsc_free(hashtable);
+        }
     }
 
-    SECTION("hashtable_spsc_op_get") {
-        char *value1 = "first value";
-        hashtable_spsc_t *hashtable = hashtable_spsc_new(
-                16,
-                HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
-                false);
-        hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+    SECTION("Case Sensitive interface") {
+        SECTION("hashtable_spsc_find_bucket_index_by_key_cs") {
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
 
-        SECTION("value found - existing key") {
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index].key = key;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
-            hashtable_buckets[hashtable_key_bucket_index].value = value1;
+            hashtable_spsc_t *hashtable2 = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    true,
+                    false);
+            hashtable_spsc_bucket_t *hashtable2_buckets = hashtable_spsc_get_buckets(hashtable2);
+            hashtable_spsc_bucket_count_t hashtable2_key_bucket_index = key_hash & (hashtable2->buckets_count_pow2 - 1);
 
-            REQUIRE(hashtable_spsc_op_get(hashtable, key, key_length) == value1);
+            SECTION("bucket found - key exists") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key_hash, key, key_length) == hashtable_key_bucket_index);
+            }
+
+            SECTION("bucket found - same hash but different key_length and key") {
+                hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
+
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash =
+                        hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash;
+                hashtable_buckets[hashtable_key_bucket_index].key = key2;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key2_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key_hash, key, key_length) == hashtable_key_bucket_index + 1);
+            }
+
+            SECTION("bucket found - same hash and same key_length but different key") {
+                hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
+                hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
+
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash =
+                        hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash;
+                hashtable_buckets[hashtable_key_bucket_index].key = key2;
+                hashtable_buckets[hashtable_key_bucket_index].key_length =
+                        hashtable_buckets[hashtable_key_bucket_index + 1].key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key_hash, key, key_length) == hashtable_key_bucket_index + 1);
+            }
+
+            SECTION("bucket found - key exists, not first bucket") {
+                int extra_slots = 6;
+
+                for (int index = 0; index < extra_slots; index++) {
+                    hashtable->hashes[hashtable_key_bucket_index + index].set = true;
+                    hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = (key_hash & 0x7FFF) + 1 + index;
+                }
+
+                hashtable->hashes[hashtable_key_bucket_index + extra_slots].set = true;
+                hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index + extra_slots].key = key;
+                hashtable_buckets[hashtable_key_bucket_index + extra_slots].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key_hash, key, key_length) == hashtable_key_bucket_index + extra_slots);
+            }
+
+            SECTION("bucket found - key exists, last bucket within max range") {
+                hashtable_key_bucket_index += hashtable->max_range - 1;
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key_hash, key, key_length) == hashtable_key_bucket_index);
+            }
+
+            SECTION("bucket not found - key with different case") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key_hash, key_different_case, key_length) == -1);
+            }
+
+            SECTION("bucket not found - key not-existent") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(
+                        hashtable, key2_ci_hash, key2, key2_length) == -1);
+            }
+
+            SECTION("bucket not found - key outside max range") {
+                hashtable_key_bucket_index += hashtable->max_range;
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(hashtable, key_hash, key, key_length) == -1);
+            }
+
+            SECTION("bucket not found - key exists but not set buckets on the way") {
+                hashtable2_key_bucket_index += hashtable2->max_range;
+                hashtable2->hashes[hashtable2_key_bucket_index].set = true;
+                hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable2_buckets[hashtable2_key_bucket_index].key = key;
+                hashtable2_buckets[hashtable2_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_find_bucket_index_by_key_cs(hashtable2, key_hash, key, key_length) == -1);
+            }
+
+            hashtable_spsc_free(hashtable);
+            hashtable_spsc_free(hashtable2);
         }
 
-        SECTION("value not found - non-existent key") {
-            REQUIRE(hashtable_spsc_op_get(hashtable, key, key_length) == NULL);
+        SECTION("hashtable_spsc_op_try_set_cs") {
+            char *value1 = "first value";
+            char *value2 = "second value";
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
+            hashtable_spsc_bucket_count_t hashtable_key_different_case_bucket_index =
+                    key_different_case_hash & (hashtable->buckets_count_pow2 - 1);
+
+            // The hashtable is small and the hashes end-up colliding, so it's necessary to access the bucket right after,
+            // anyway for future reference making it a dynamic check in case the hashtable size is changed
+            if (hashtable_key_bucket_index == hashtable_key_different_case_bucket_index) {
+                hashtable_key_different_case_bucket_index++;
+            }
+
+            SECTION("value set - insert") {
+                REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key, key_length, value1));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
+            }
+
+            SECTION("value set - update") {
+                REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key, key_length, value1));
+                REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key, key_length, value2));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
+            }
+
+            SECTION("value set - insert - key with different key") {
+                REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key, key_length, value1));
+                REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key_different_case, key_length, value2));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
+
+                REQUIRE(hashtable->hashes[hashtable_key_different_case_bucket_index].set);
+                REQUIRE(hashtable->hashes[hashtable_key_different_case_bucket_index].cmp_hash ==
+                        (key_different_case_hash & 0x7FFF));
+                REQUIRE(hashtable_buckets[hashtable_key_different_case_bucket_index].key == key_different_case);
+                REQUIRE(hashtable_buckets[hashtable_key_different_case_bucket_index].key_length == key_length);
+                REQUIRE(hashtable_buckets[hashtable_key_different_case_bucket_index].value == value2);
+            }
+
+            SECTION("value not set - no free buckets in range") {
+                for (int index = 0; index < hashtable->max_range; index++) {
+                    hashtable->hashes[hashtable_key_bucket_index + index].set = true;
+                }
+
+                REQUIRE(!hashtable_spsc_op_try_set_cs(hashtable, key, key_length, &value1));
+            }
+
+            SECTION("value not set - hashtable full") {
+                for (int index = 0; index < hashtable->buckets_count_real; index++) {
+                    hashtable->hashes[index].set = true;
+                }
+
+                REQUIRE(!hashtable_spsc_op_try_set_cs(hashtable, key, key_length, &value1));
+            }
+
+            hashtable_spsc_free(hashtable);
         }
 
-        hashtable_spsc_free(hashtable);
-    }
+        SECTION("hashtable_spsc_op_get_cs") {
+            char *value1 = "first value";
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
-    SECTION("hashtable_spsc_op_delete") {
-        hashtable_spsc_t *hashtable = hashtable_spsc_new(
-                16,
-                HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
-                false);
-        hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
 
-        hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
+            SECTION("value found - existing key ") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+                hashtable_buckets[hashtable_key_bucket_index].value = value1;
 
-        SECTION("value deleted - existing key") {
-            hashtable->hashes[hashtable_key_bucket_index].set = true;
-            hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
-            hashtable_buckets[hashtable_key_bucket_index].key = key;
-            hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+                REQUIRE(hashtable_spsc_op_get_cs(hashtable, key, key_length) == value1);
+            }
 
-            REQUIRE(hashtable_spsc_op_delete(hashtable, key, key_length));
+            SECTION("value not found - existing key with different case") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+                hashtable_buckets[hashtable_key_bucket_index].value = value1;
 
-            REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set == false);
+                REQUIRE(hashtable_spsc_op_get_cs(hashtable, key_different_case, key_length) == NULL);
+            }
+
+            SECTION("value not found - non-existent key") {
+                REQUIRE(hashtable_spsc_op_get_cs(hashtable, key, key_length) == NULL);
+            }
+
+            hashtable_spsc_free(hashtable);
         }
 
-        SECTION("value not deleted - non-existent key") {
-            REQUIRE(!hashtable_spsc_op_delete(hashtable, key, key_length));
-        }
+        SECTION("hashtable_spsc_op_delete_cs") {
+            hashtable_spsc_t *hashtable = hashtable_spsc_new(
+                    16,
+                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
+                    false,
+                    false);
+            hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
-        hashtable_spsc_free(hashtable);
+            hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_hash & (hashtable->buckets_count_pow2 - 1);
+
+            SECTION("value deleted - existing key") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(hashtable_spsc_op_delete_cs(hashtable, key, key_length));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set == false);
+            }
+
+            SECTION("value not deleted - existing key with different case") {
+                hashtable->hashes[hashtable_key_bucket_index].set = true;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable_buckets[hashtable_key_bucket_index].key = key;
+                hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
+
+                REQUIRE(!hashtable_spsc_op_delete_cs(hashtable, key_different_case, key_length));
+
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set == true);
+            }
+
+            SECTION("value not deleted - non-existent key") {
+                REQUIRE(!hashtable_spsc_op_delete_cs(hashtable, key, key_length));
+            }
+
+            hashtable_spsc_free(hashtable);
+        }
     }
 
     SECTION("hashtable_spsc_op_iter") {

--- a/tests/unit_tests/modules/redis/test-module-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-module-redis-commands.cpp
@@ -87,12 +87,12 @@ TEST_CASE("module/redis/module_redis_commands.c", "[module][redis][module_redis_
 
         REQUIRE(hashtable != nullptr);
 
-        REQUIRE(hashtable_spsc_op_get(
+        REQUIRE(hashtable_spsc_op_get_ci(
                 hashtable,
                 command_infos_map[0].string,
                 command_infos_map[0].string_len) == &command_infos_map[0]);
 
-        REQUIRE(hashtable_spsc_op_get(
+        REQUIRE(hashtable_spsc_op_get_ci(
                 hashtable,
                 command_infos_map[1].string,
                 command_infos_map[1].string_len) == &command_infos_map[1]);
@@ -177,7 +177,7 @@ TEST_CASE("module/redis/module_redis_commands.c", "[module][redis][module_redis_
                     command_infos_map[0].arguments_count,
                     hashtable) == true);
 
-            token_entry = (module_redis_command_parser_context_argument_token_entry_t*)hashtable_spsc_op_get(
+            token_entry = (module_redis_command_parser_context_argument_token_entry_t*) hashtable_spsc_op_get_ci(
                     hashtable,
                     "LIMIT",
                     strlen("LIMIT"));
@@ -189,7 +189,7 @@ TEST_CASE("module/redis/module_redis_commands.c", "[module][redis][module_redis_
             REQUIRE(token_entry->one_of_tokens[0] == nullptr);
             REQUIRE(token_entry->one_of_token_count == 0);
 
-            token_entry = (module_redis_command_parser_context_argument_token_entry_t*)hashtable_spsc_op_get(
+            token_entry = (module_redis_command_parser_context_argument_token_entry_t*) hashtable_spsc_op_get_ci(
                     hashtable,
                     "ASC",
                     strlen("ASC"));
@@ -233,7 +233,7 @@ TEST_CASE("module/redis/module_redis_commands.c", "[module][redis][module_redis_
         REQUIRE(command_infos_map[0].tokens_hashtable != nullptr);
         REQUIRE(command_infos_map[1].tokens_hashtable == nullptr);
 
-        token_entry = (module_redis_command_parser_context_argument_token_entry_t*)hashtable_spsc_op_get(
+        token_entry = (module_redis_command_parser_context_argument_token_entry_t*) hashtable_spsc_op_get_ci(
                 command_infos_map[0].tokens_hashtable,
                 "LIMIT",
                 strlen("LIMIT"));

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -59,7 +59,7 @@ std::string string_format( const std::string& format, Args ... args ) {
     auto size = static_cast<size_t>( size_s );
     std::unique_ptr<char[]> buf( new char[ size ] );
     std::snprintf( buf.get(), size, format.c_str(), args ... );
-    return ( buf.get(), buf.get() + size - 1 );
+    return std::string( buf.get(), buf.get() + size - 1 );
 }
 
 #define PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(WORKER_CONTEXT, RUNNING) { \

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -1252,7 +1252,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
                     "$-1\r\n"));
         }
 
-        SECTION("Existing key - short") {
+        SECTION("Existing key - short value") {
             SECTION("all") {
                 REQUIRE(send_recv_resp_command_text(
                         client_fd,
@@ -1312,9 +1312,33 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
                         std::vector<std::string>{"GETRANGE", "a_key", "-4", "-2"},
                         "$3\r\nalu\r\n"));
             }
+
+            SECTION("start after end") {
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SET", "a_key", "b_value"},
+                        "+OK\r\n"));
+
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"GETRANGE", "a_key", "7", "3"},
+                        "$-1\r\n"));
+            }
+
+            SECTION("start before end, length after end") {
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SET", "a_key", "b_value"},
+                        "+OK\r\n"));
+
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"GETRANGE", "a_key", "3", "15"},
+                        "$4\r\nalue\r\n"));
+            }
         }
 
-        SECTION("Existing key - large") {
+        SECTION("Existing key - long value") {
             char *expected_response;
             size_t long_value_length = 4 * 1024 * 1024;
             config_module_redis.max_command_length = long_value_length + 1024;

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -53,14 +53,13 @@
 int recv_packet_size = 32 * 1024;
 
 template<typename ... Args>
-std::string string_format( const std::string& format, Args ... args )
-{
-    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1; // Extra space for '\0'
+std::string string_format( const std::string& format, Args ... args ) {
+    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1;
     if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
     auto size = static_cast<size_t>( size_s );
     std::unique_ptr<char[]> buf( new char[ size ] );
     std::snprintf( buf.get(), size, format.c_str(), args ... );
-    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+    return ( buf.get(), buf.get() + size - 1 );
 }
 
 #define PROGRAM_WAIT_FOR_WORKER_RUNNING_STATUS(WORKER_CONTEXT, RUNNING) { \
@@ -97,13 +96,7 @@ size_t build_resp_command(
     return buffer_offset;
 }
 
-size_t string_replace(
-        char *input,
-        size_t input_len,
-        char *output,
-        size_t output_len,
-        int count,
-        ...) {
+size_t string_replace(char *input, size_t input_len, char *output, size_t output_len, int count, ...) {
     va_list arg_ptr;
     char *current_char = input;
     char *output_begin = output;
@@ -113,16 +106,17 @@ size_t string_replace(
     char **with_list = (char**)malloc(sizeof(char*) * count);
     size_t *with_len_list = (size_t*)malloc(sizeof(size_t) * count);
 
-    int arg_index = 0;
     va_start(arg_ptr, count);
+
+    int arg_index = 0;
     while(arg_index < count) {
         replace_list[arg_index] = va_arg(arg_ptr, char *);
         replace_len_list[arg_index] = va_arg(arg_ptr, size_t);
         with_list[arg_index] = va_arg(arg_ptr, char *);
         with_len_list[arg_index] = va_arg(arg_ptr, size_t);
-
         arg_index++;
     }
+
     va_end(arg_ptr);
 
     while(current_char - input < input_len) {
@@ -164,7 +158,7 @@ size_t send_recv_resp_command_calculate_multi_recv(
         return 1;
     }
 
-    return 1 + ceil((float)expected_length / (float)recv_packet_size) + 1;
+    return 1 + (size_t)ceil((float)expected_length / (float)recv_packet_size) + 1;
 }
 
 bool send_recv_resp_command_multi_recv(
@@ -1029,7 +1023,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             // Fill with random data the long value
             char range = 'z' - 'a';
             for (size_t i = 0; i < long_value_length; i++) {
-                long_value[i] = (char) (i % range) + 'a';
+                long_value[i] = ((char)i % range) + 'a';
             }
 
             // This is legit as long_value_length + 1 is actually being allocated
@@ -1078,7 +1072,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             // Fill with random data the long value
             char range = 'z' - 'a';
             for (size_t i = 0; i < long_value_length; i++) {
-                long_value[i] = (char) (i % range) + 'a';
+                long_value[i] = ((char)i % range) + 'a';
             }
 
             // This is legit as long_value_length + 1 is actually being allocated
@@ -1183,7 +1177,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             // Fill with random data the long value
             char range = 'z' - 'a';
             for (size_t i = 0; i < long_value_length; i++) {
-                long_value[i] = (char) (i % range) + 'a';
+                long_value[i] = ((char)i % range) + 'a';
             }
 
             // This is legit as long_value_length + 1 is actually being allocated
@@ -1327,8 +1321,8 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         }
 
         SECTION("Existing key - long value") {
-            char *expected_response = NULL;
-            char *expected_response_static[256] = { 0 };
+            char *expected_response = nullptr;
+            char *expected_response_static[256] = { nullptr };
             size_t long_value_length = 4 * 1024 * 1024;
             config_module_redis.max_command_length = long_value_length + 1024;
 
@@ -1339,7 +1333,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             // Fill with random data the long value
             char range = 'z' - 'a';
             for (size_t i = 0; i < long_value_length; i++) {
-                long_value[i] = (char) (i % range) + 'a';
+                long_value[i] = ((char)i % range) + 'a';
             }
 
             // This is legit as long_value_length + 1 is actually being allocated
@@ -1515,8 +1509,8 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
     }
 
     SECTION("Redis - command - SETRANGE") {
-        char *expected_response = NULL;
-        char *expected_response_static[256] = { 0 };
+        char *expected_response = nullptr;
+        char *expected_response_static[256] = { nullptr };
         size_t long_value_length = 4 * 1024 * 1024;
         config_module_redis.max_command_length = long_value_length + 1024;
 
@@ -1527,7 +1521,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         // Fill with random data the long value
         char range = 'z' - 'a';
         for (size_t i = 0; i < long_value_length; i++) {
-            long_value[i] = (char) (i % range) + 'a';
+            long_value[i] = ((char)i % range) + 'a';
         }
 
         // This is legit as long_value_length + 1 is actually being allocated
@@ -1837,7 +1831,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
     }
 
     SECTION("Redis - command - COPY") {
-        SECTION("Non existant key") {
+        SECTION("Non existent key") {
             REQUIRE(send_recv_resp_command_text(
                     client_fd,
                     std::vector<std::string>{"COPY", "a_key", "b_key"},
@@ -1872,7 +1866,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             // Fill with random data the long value
             char range = 'z' - 'a';
             for (size_t i = 0; i < long_value_length; i++) {
-                long_value[i] = (char) (i % range) + 'a';
+                long_value[i] = ((char)i % range) + 'a';
             }
 
             // This is legit as long_value_length + 1 is actually being allocated

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -1620,6 +1620,96 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
                         send_recv_resp_command_calculate_multi_recv(header_len + offset + strlen("b_value\r\n"))));
             }
         }
+
+        SECTION("Existing key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "a_key", "value_f"},
+                    "+OK\r\n"));
+
+            SECTION("Beginning of first chunk") {
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", "0", "b_value"},
+                        ":7\r\n"));
+
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"GET", "a_key"},
+                        "$7\r\nb_value\r\n"));
+            }
+
+            SECTION("Offset 10, padded with nulls") {
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", "10", "b_value"},
+                        ":17\r\n"));
+
+                REQUIRE(send_recv_resp_command(
+                        client_fd,
+                        std::vector<std::string>{"GET", "a_key"},
+                        "$17\r\nvalue_f\0\0\0b_value\r\n",
+                        24));
+            }
+
+            SECTION("Pad then overwrite padding") {
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", "10", "b_value"},
+                        ":17\r\n"));
+
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", "3", "b_value"},
+                        ":17\r\n"));
+
+                REQUIRE(send_recv_resp_command(
+                        client_fd,
+                        std::vector<std::string>{"GET", "a_key"},
+                        "$17\r\nvalb_valueb_value\r\n",
+                        24));
+            }
+
+            SECTION("Pad then pad again padding") {
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", "10", "b_value"},
+                        ":17\r\n"));
+
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", "20", "value_z"},
+                        ":27\r\n"));
+
+                REQUIRE(send_recv_resp_command(
+                        client_fd,
+                        std::vector<std::string>{"GET", "a_key"},
+                        "$27\r\nvalue_f\0\0\0b_value\0\0\0value_z\r\n",
+                        34));
+            }
+
+            SECTION("Pad till a few bytes before the end of first chunk and then write at the beginning of the second") {
+                char offset_str[16] = { 0 };
+                off_t offset = STORAGE_DB_CHUNK_MAX_SIZE - 3;
+                snprintf(offset_str, sizeof(offset_str), "%ld", offset);
+
+                char expected[STORAGE_DB_CHUNK_MAX_SIZE + 64] = { 0 };
+                size_t header_len = snprintf(expected, sizeof(expected), "$%lu\r\n%s", offset + strlen("b_value"), "value_f");
+                memcpy(expected + header_len + offset, "b_value\r\n", strlen("b_value\r\n"));
+
+                REQUIRE(send_recv_resp_command_text(
+                        client_fd,
+                        std::vector<std::string>{"SETRANGE", "a_key", offset_str, "b_value"},
+                        ":65539\r\n"));
+
+                REQUIRE(send_recv_resp_command_multi_recv(
+                        client_fd,
+                        std::vector<std::string>{"GET", "a_key"},
+                        (char*)expected,
+                        header_len + offset + strlen("b_value\r\n"),
+                        send_recv_resp_command_calculate_multi_recv(header_len + offset + strlen("b_value\r\n"))));
+            }
+        }
     }
 
     SECTION("Redis - command - GETEX") {

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -258,25 +258,23 @@ bool send_recv_resp_command_multi_recv(
     return_res = total_send_length == buffer_send_length && total_recv_length == expected_length && recv_matches_expected;
 
     if (!return_res) {
-        char temp_buffer_1[256] = { 0 };
-        char temp_buffer_2[256] = { 0 };
+        char temp_buffer_1[1024] = { 0 };
+        char temp_buffer_2[1024] = { 0 };
 
         memset(temp_buffer_1, 0, sizeof(temp_buffer_1));
         memset(temp_buffer_2, 0, sizeof(temp_buffer_2));
         string_replace(
-                buffer_send,
-                total_send_length > 64 ? 64 : total_send_length,
-                "\r\n",
-                "\\r\\n",
-                temp_buffer_1,
-                sizeof(temp_buffer_1));
+                buffer_send, total_send_length > 64 ? 64 : total_send_length,
+                temp_buffer_1, sizeof(temp_buffer_1),
+                2,
+                "\r\n", 2, "\\r\\n", 4,
+                "\0", 1, "\\0", 2);
         string_replace(
-                buffer_send + total_send_length - (64 > total_send_length ? total_send_length : 64),
-                64 > total_send_length ? total_send_length : 64,
-                "\r\n",
-                "\\r\\n",
-                temp_buffer_2,
-                sizeof(temp_buffer_2));
+                buffer_send + total_send_length - (64 > total_send_length ? total_send_length : 64), 64 > total_send_length ? total_send_length : 64,
+                temp_buffer_2, sizeof(temp_buffer_2),
+                2,
+                "\r\n", 2, "\\r\\n", 4,
+                "\0", 1, "\\0", 2);
 
         fprintf(
                 stderr,
@@ -288,19 +286,17 @@ bool send_recv_resp_command_multi_recv(
         memset(temp_buffer_1, 0, sizeof(temp_buffer_1));
         memset(temp_buffer_2, 0, sizeof(temp_buffer_2));
         string_replace(
-                buffer_recv,
-                total_recv_length > 64 ? 64 : total_recv_length,
-                "\r\n",
-                "\\r\\n",
-                temp_buffer_1,
-                sizeof(temp_buffer_1));
+                buffer_recv, total_recv_length > 64 ? 64 : total_recv_length,
+                temp_buffer_1, sizeof(temp_buffer_1),
+                2,
+                "\r\n", 2, "\\r\\n", 4,
+                "\0", 1, "\\0", 2);
         string_replace(
-                buffer_recv + total_recv_length - (64 > total_recv_length ? total_recv_length : 64),
-                64 > total_recv_length ? total_recv_length : 64,
-                "\r\n",
-                "\\r\\n",
-                temp_buffer_2,
-                sizeof(temp_buffer_2));
+                buffer_recv + total_recv_length - (64 > total_recv_length ? total_recv_length : 64), 64 > total_recv_length ? total_recv_length : 64,
+                temp_buffer_2, sizeof(temp_buffer_2),
+                2,
+                "\r\n", 2, "\\r\\n", 4,
+                "\0", 1, "\\0", 2);
         fprintf(
                 stderr,
                 "[ BUFFER RECV(%ld) ]\n'%s' (%lu)\n'%s' (%lu)\n\n",
@@ -311,19 +307,17 @@ bool send_recv_resp_command_multi_recv(
         memset(temp_buffer_1, 0, sizeof(temp_buffer_1));
         memset(temp_buffer_2, 0, sizeof(temp_buffer_2));
         string_replace(
-                expected,
-                expected_length > 64 ? 64 : expected_length,
-                "\r\n",
-                "\\r\\n",
-                temp_buffer_1,
-                sizeof(temp_buffer_1));
+                expected, expected_length > 64 ? 64 : expected_length,
+                temp_buffer_1, sizeof(temp_buffer_1),
+                2,
+                "\r\n", 2, "\\r\\n", 4,
+                "\0", 1, "\\0", 2);
         string_replace(
-                expected + expected_length - (64 > expected_length ? expected_length : 64),
-                64 > expected_length ? expected_length : 64,
-                "\r\n",
-                "\\r\\n",
-                temp_buffer_2,
-                sizeof(temp_buffer_2));
+                expected + expected_length - (64 > expected_length ? expected_length : 64), 64 > expected_length ? expected_length : 64,
+                temp_buffer_2, sizeof(temp_buffer_2),
+                2,
+                "\r\n", 2, "\\r\\n", 4,
+                "\0", 1, "\\0", 2);
         fprintf(
                 stderr,
                 "[ EXPECTED RECV(%ld) ]\n'%s' (%lu)\n'%s' (%lu)\n\n",

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -1530,6 +1530,13 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
         char end[32] = { 0 };
         snprintf(end, sizeof(end), "%lu", long_value_length - 1);
 
+        SECTION("Invalid offset") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SETRANGE", "a_key", "-10", "b_value"},
+                    "-ERR offset is out of range\r\n"));
+        }
+
         SECTION("Non-existing key") {
             SECTION("Beginning of first chunk") {
                 REQUIRE(send_recv_resp_command_text(

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -1665,7 +1665,7 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
                 REQUIRE(send_recv_resp_command(
                         client_fd,
                         std::vector<std::string>{"GET", "a_key"},
-                        (char*)string_format("$17\r\n%.*s%s%s\r\n", 3, value1, value2, value2).c_str(),
+                        "$17\r\nvalb_valueb_value\r\n",
                         24));
             }
 


### PR DESCRIPTION
This PR implements the GETRANGE and SETRANGE commands.

Although it should have been in a separated PR, this one also includes some refactoring for the spsc hashtable to properly implement and distinguish case sensitive vs case insensitive get/set/delete operations.
