### PR TITLE
Validate the set, mset, setrange and similar refuse to create empty keys

### DIFF
--- a/src/module/redis/command/module_redis_command_mset.c
+++ b/src/module/redis/command/module_redis_command_mset.c
@@ -61,8 +61,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(mset) {
                 key_value->key.value.length,
                 key_value->value.value.chunk_sequence,
                 STORAGE_DB_ENTRY_NO_EXPIRY)) {
-            module_redis_connection_error_message_printf_noncritical(connection_context, "ERR mset failed");
-            return true;
+            return module_redis_connection_error_message_printf_noncritical(connection_context, "ERR mset failed");
         }
 
         // Mark both the key and the chunk_sequence as NULL as the storage db now owns them, we don't want them to be

--- a/src/module/redis/command/module_redis_command_msetnx.c
+++ b/src/module/redis/command/module_redis_command_msetnx.c
@@ -72,8 +72,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(msetnx) {
                 key_value->key.value.length,
                 &rmw_statuses[index],
                 &entry_index))) {
-            module_redis_connection_error_message_printf_noncritical(connection_context, "ERR msetnx failed");
-            return_res = true;
+            return_res = module_redis_connection_error_message_printf_noncritical(connection_context, "ERR msetnx failed");
             can_commit_update = false;
             error_found = true;
             break;
@@ -102,8 +101,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(msetnx) {
                     &rmw_statuses[index],
                     key_value->value.value.chunk_sequence,
                     STORAGE_DB_ENTRY_NO_EXPIRY))) {
-                module_redis_connection_error_message_printf_noncritical(connection_context, "ERR msetnx failed");
-                return_res = true;
+                return_res = module_redis_connection_error_message_printf_noncritical(connection_context, "ERR msetnx failed");
                 error_found = true;
                 break;
             }

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -619,7 +619,7 @@ bool module_redis_command_process_argument_full(
                 return false;
             }
 
-            strncpy(string_value, chunk_data, chunk_length);
+            memcpy(string_value, chunk_data, chunk_length);
 
             if (guessed_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_KEY) {
                 module_redis_key_t *key = base_addr;

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -589,12 +589,17 @@ bool module_redis_command_process_argument_full(
                     connection_context,
                     guessed_argument,
                     chunk_length)) {
-                module_redis_connection_error_message_printf_noncritical(
+                return module_redis_connection_error_message_printf_noncritical(
                         connection_context,
                         "ERR The %s length has exceeded the allowed size of '%u'",
-                        expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_KEY ? "key" : "pattern",
+                        expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_KEY
+                        ? "key"
+                        : (expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_PATTERN
+                            ? "pattern"
+                            : "short string"),
                         connection_context->network_channel->module_config->redis->max_key_length);
-                return true;
+            }
+
             if (unlikely(chunk_length == 0)) {
                 return module_redis_connection_error_message_printf_noncritical(
                         connection_context,

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -595,6 +595,16 @@ bool module_redis_command_process_argument_full(
                         expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_KEY ? "key" : "pattern",
                         connection_context->network_channel->module_config->redis->max_key_length);
                 return true;
+            if (unlikely(chunk_length == 0)) {
+                return module_redis_connection_error_message_printf_noncritical(
+                        connection_context,
+                        "ERR the %s '%s' has length '0', not allowed",
+                        expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_KEY
+                        ? "key"
+                        : (expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_PATTERN
+                           ? "pattern"
+                           : "short string"),
+                       guessed_argument->name);
             }
 
             string_value = slab_allocator_mem_alloc(chunk_length);

--- a/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-program-redis-commands.cpp
@@ -526,6 +526,27 @@ TEST_CASE("program.c-redis-commands", "[program-redis-commands]") {
             REQUIRE(strncmp(buffer_recv, expected_error, strlen(expected_error)) == 0);
         }
 
+        SECTION("Zero length - Key") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SET", "", "b_value"},
+                    "-ERR the key 'key' has length '0', not allowed\r\n"));
+        }
+
+        SECTION("Zero length - Pattern") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"SORT", "a_key", "BY", ""},
+                    "-ERR the pattern 'by_pattern' has length '0', not allowed\r\n"));
+        }
+
+        SECTION("Zero length - Short String") {
+            REQUIRE(send_recv_resp_command_text(
+                    client_fd,
+                    std::vector<std::string>{"PING", ""},
+                    "-ERR the short string 'message' has length '0', not allowed\r\n"));
+        }
+
         SECTION("Max command arguments") {
             off_t buffer_send_offset = 0;
             char expected_error[256] = { 0 };


### PR DESCRIPTION
This PR introduces some constraints on the minimum length of keys, patterns and short strings handled by the Redis command parser to ensure that if an argument of that type is zero-length will be rejected.

Tests are introduced as well to validate the rejection.

On a side, the PR also changes some code to take into account the returned value of module_redis_connection_error_message_printf_*

Closes #199 