### PR TITLE
General improvements for the existing commands

### DIFF
--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -64,7 +64,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
                 "ERR expire failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         goto end;
     }
 
@@ -90,13 +90,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
         }
     }
 
-    if (abort_rmw) {
+    if (unlikely(abort_rmw)) {
         storage_db_op_rmw_abort(connection_context->db, &rmw_status);
     } else {
         current_entry_index->expiry_time_ms = clock_realtime_coarse_int64_ms() + milliseconds;
         metadata_updated = true;
 
-        if (milliseconds <= 0) {
+        if (unlikely(milliseconds <= 0)) {
             storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
         } else {
             storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);

--- a/src/module/redis/command/module_redis_command_expireat.c
+++ b/src/module/redis/command/module_redis_command_expireat.c
@@ -64,7 +64,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expireat) {
                 "ERR expireat failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         goto end;
     }
 

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -63,7 +63,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
                 "ERR expiretime failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         return module_redis_connection_send_number(
                 connection_context,
                 -2);

--- a/src/module/redis/command/module_redis_command_getset.c
+++ b/src/module/redis/command/module_redis_command_getset.c
@@ -95,7 +95,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getset) {
 
 end:
 
-    if (previous_entry_index) {
+    if (likely(previous_entry_index)) {
         storage_db_entry_index_status_decrease_readers_counter(previous_entry_index, NULL);
         previous_entry_index = NULL;
     }

--- a/src/module/redis/command/module_redis_command_mget.c
+++ b/src/module/redis/command/module_redis_command_mget.c
@@ -49,7 +49,7 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(mget) {
     module_redis_command_mget_context_t *context = connection_context->command.context;
 
-    if (!module_redis_connection_send_array(connection_context, context->key.count)) {
+    if (unlikely(!module_redis_connection_send_array(connection_context, context->key.count))) {
         return false;
     }
 

--- a/src/module/redis/command/module_redis_command_msetnx.c
+++ b/src/module/redis/command/module_redis_command_msetnx.c
@@ -125,7 +125,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(msetnx) {
                 &rmw_statuses[index]);
     }
 
-    if (!error_found) {
+    if (likely(!error_found)) {
         return_res = module_redis_connection_send_number(connection_context, command_response);
     }
 

--- a/src/module/redis/command/module_redis_command_persist.c
+++ b/src/module/redis/command/module_redis_command_persist.c
@@ -64,15 +64,15 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
                 "ERR persist failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         goto end;
     }
 
-    if (current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+    if (unlikely(current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY)) {
         abort_rmw = true;
     }
 
-    if (abort_rmw) {
+    if (unlikely(abort_rmw)) {
         storage_db_op_rmw_abort(connection_context->db, &rmw_status);
     } else {
         current_entry_index->expiry_time_ms = STORAGE_DB_ENTRY_NO_EXPIRY;

--- a/src/module/redis/command/module_redis_command_pexpire.c
+++ b/src/module/redis/command/module_redis_command_pexpire.c
@@ -64,7 +64,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
                 "ERR pexpire failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         goto end;
     }
 
@@ -90,14 +90,14 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
         }
     }
 
-    if (abort_rmw) {
+    if (unlikely(abort_rmw)) {
         storage_db_op_rmw_abort(connection_context->db, &rmw_status);
     } else {
         current_entry_index->expiry_time_ms =
                 clock_realtime_coarse_int64_ms() + context->milliseconds.value;
         metadata_updated = true;
 
-        if (milliseconds <= 0) {
+        if (unlikely(milliseconds <= 0)) {
             storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
         } else {
             storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);

--- a/src/module/redis/command/module_redis_command_pexpireat.c
+++ b/src/module/redis/command/module_redis_command_pexpireat.c
@@ -64,7 +64,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
                 "ERR pexpireat failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         goto end;
     }
 
@@ -90,13 +90,13 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
         }
     }
 
-    if (abort_rmw) {
+    if (unlikely(abort_rmw)) {
         storage_db_op_rmw_abort(connection_context->db, &rmw_status);
     } else {
         current_entry_index->expiry_time_ms = milliseconds;
         metadata_updated = true;
 
-        if (milliseconds <= 0) {
+        if (unlikely(milliseconds <= 0)) {
             storage_db_op_rmw_commit_delete(connection_context->db, &rmw_status);
         } else {
             storage_db_op_rmw_commit_metadata(connection_context->db, &rmw_status);

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -63,7 +63,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
                 "ERR pexpiretime failed");
     }
 
-    if (!current_entry_index) {
+    if (unlikely(!current_entry_index)) {
         return module_redis_connection_send_number(
                 connection_context,
                 -2);

--- a/src/module/redis/command/module_redis_command_ping.c
+++ b/src/module/redis/command/module_redis_command_ping.c
@@ -34,6 +34,8 @@
 #include "storage/channel/storage_channel.h"
 #include "storage/db/storage_db.h"
 #include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "module/redis/module_redis_command.h"
 #include "network/network.h"
 #include "worker/worker_stats.h"
 #include "worker/worker_context.h"
@@ -41,39 +43,14 @@
 #define TAG "module_redis_command_ping"
 
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(ping) {
-    network_channel_buffer_data_t *send_buffer, *send_buffer_start;
     module_redis_command_ping_context_t *context = connection_context->command.context;
-    char *string = context->message.value.short_string ? context->message.value.short_string : "PONG";
-    int string_length = context->message.value.short_string ? (int)context->message.value.length : 4;
+    char *string = context->message.value.short_string
+            ? context->message.value.short_string
+            : "PONG";
+    int string_length = context->message.value.short_string
+            ? (int)context->message.value.length
+            : 4;
 
-    // The string gets truncated if string_length + 32 > 64kb, not really great but no person should EVER use a string
-    // so long for a ping as it would be devastating for performances so we don't really care and trucate it if needed
-    string_length = string_length + 32 > 64 * 1024 ? (64 * 1024) - 32 : string_length;
-
-    size_t slice_length = 32 + string_length;
-
-    send_buffer = send_buffer_start = network_send_buffer_acquire_slice(
-            connection_context->network_channel,
-            slice_length);
-    if (send_buffer_start == NULL) {
-        LOG_E(TAG, "Unable to acquire send buffer slice!");
-        return false;
-    }
-
-    send_buffer_start = protocol_redis_writer_write_blob_string(
-            send_buffer_start,
-            slice_length,
-            string,
-            string_length);
-
-    network_send_buffer_release_slice(
-            connection_context->network_channel,
-            send_buffer_start ? send_buffer_start - send_buffer : 0);
-
-    if (send_buffer_start == NULL) {
-        LOG_E(TAG, "buffer length incorrectly calculated, not enough space!");
-        return false;
-    }
-
-    return true;
+    string_length = string_length + 32 > NETWORK_CHANNEL_MAX_PACKET_SIZE ? NETWORK_CHANNEL_MAX_PACKET_SIZE - 32 : string_length;
+    return module_redis_connection_send_string(connection_context, string, string_length);
 }

--- a/src/module/redis/command/module_redis_command_touch.c
+++ b/src/module/redis/command/module_redis_command_touch.c
@@ -64,7 +64,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(touch) {
                     "ERR expire failed");
         }
 
-        if (current_entry_index) {
+        if (likely(current_entry_index)) {
             touched_keys_count++;
         }
 

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -407,7 +407,7 @@ bool module_redis_command_process_argument_full(
         size_t chunk_length) {
     char *string_value, *integer_value_end_ptr, *double_value_end_ptr;
     uint64_t *integer_value;
-    double *double_value;
+    long double *double_value;
     bool check_tokens = false, token_found = false, is_in_block = false;
     uint16_t block_argument_index = 0;
     module_redis_command_argument_t *guessed_argument = NULL;
@@ -647,7 +647,7 @@ bool module_redis_command_process_argument_full(
 
         case MODULE_REDIS_COMMAND_ARGUMENT_TYPE_DOUBLE:
             double_value = base_addr;
-            *double_value = strtod(chunk_data, &double_value_end_ptr);
+            *double_value = strtold(chunk_data, &double_value_end_ptr);
 
             if (errno == ERANGE || double_value_end_ptr != chunk_data + chunk_length) {
                 return module_redis_connection_error_message_printf_noncritical(
@@ -906,6 +906,10 @@ bool module_redis_command_stream_entry_range_with_multiple_chunks(
                     network_channel,
                     buffer_to_send + sent_data,
                     data_to_send_length) != NETWORK_OP_RESULT_OK) {
+                if (allocated_new_buffer) {
+                    slab_allocator_mem_free(buffer_to_send);
+                }
+
                 return false;
             }
 


### PR DESCRIPTION
A number of commands were written before the introductions of the wrappers to simplify sending back numbers, strings, etc.

This PR updates these "old" commands to take advantage fo the new mechanisms, dropping a lot of duplicated scaffolding code. It also includes some minor performance improvement marking as unlikely all the branches in the slow paths and likely the ones in the fast paths in the commands touched by this PR.