### PR TITLE
Fix invalid expiration time handling in set and getex

### DIFF
--- a/src/module/redis/command/module_redis_command_getex.c
+++ b/src/module/redis/command/module_redis_command_getex.c
@@ -81,12 +81,40 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getex) {
     storage_db_expiry_time_ms_t expiry_time_ms = current_entry_index->expiry_time_ms;
 
     if (context->expiration.value.pxat_unix_time_milliseconds.has_token) {
+        if (context->expiration.value.pxat_unix_time_milliseconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'getex' command");
+            goto end;
+        }
+
         expiry_time_ms = (int64_t)context->expiration.value.pxat_unix_time_milliseconds.value;
     } else if (context->expiration.value.exat_unix_time_seconds.has_token) {
+        if (context->expiration.value.exat_unix_time_seconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'getex' command");
+            goto end;
+        }
+
         expiry_time_ms = (int64_t)context->expiration.value.exat_unix_time_seconds.value * 1000;
     } else if (context->expiration.value.px_milliseconds.has_token) {
+        if (context->expiration.value.px_milliseconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'getex' command");
+            goto end;
+        }
+
         expiry_time_ms = clock_realtime_coarse_int64_ms() + (int64_t)context->expiration.value.px_milliseconds.value;
     } else if (context->expiration.value.ex_seconds.has_token) {
+        if (context->expiration.value.ex_seconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'getex' command");
+            goto end;
+        }
+
         expiry_time_ms = clock_realtime_coarse_int64_ms() + ((int64_t)context->expiration.value.ex_seconds.value * 1000);
     } else if (context->expiration.value.persist_persist.has_token) {
         expiry_time_ms =  STORAGE_DB_ENTRY_NO_EXPIRY;

--- a/src/module/redis/command/module_redis_command_set.c
+++ b/src/module/redis/command/module_redis_command_set.c
@@ -58,12 +58,40 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(set) {
     storage_db_expiry_time_ms_t expiry_time_ms = STORAGE_DB_ENTRY_NO_EXPIRY;
 
     if (context->expiration.value.pxat_unix_time_milliseconds.has_token) {
+        if (context->expiration.value.pxat_unix_time_milliseconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'set' command");
+            goto end;
+        }
+
         expiry_time_ms = (int64_t)context->expiration.value.pxat_unix_time_milliseconds.value;
     } else if (context->expiration.value.exat_unix_time_seconds.has_token) {
+        if (context->expiration.value.exat_unix_time_seconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'set' command");
+            goto end;
+        }
+
         expiry_time_ms = (int64_t)context->expiration.value.exat_unix_time_seconds.value * 1000;
     } else if (context->expiration.value.px_milliseconds.has_token) {
+        if (context->expiration.value.px_milliseconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'set' command");
+            goto end;
+        }
+
         expiry_time_ms = clock_realtime_coarse_int64_ms() + (int64_t)context->expiration.value.px_milliseconds.value;
     } else if (context->expiration.value.ex_seconds.has_token) {
+        if (context->expiration.value.ex_seconds.value <= 0) {
+            return_res = module_redis_connection_error_message_printf_noncritical(
+                    connection_context,
+                    "ERR invalid expire time in 'set' command");
+            goto end;
+        }
+
         expiry_time_ms = clock_realtime_coarse_int64_ms() + ((int64_t)context->expiration.value.ex_seconds.value * 1000);
     }
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
@@ -419,7 +419,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         // Fill with random data the long value
         char range = 'z' - 'a';
         for (size_t i = 0; i < long_value_length; i++) {
-            long_value[i] = ((char)i % range) + 'a';
+            long_value[i] = (char)(i % range) + 'a';
         }
 
         // This is legit as long_value_length + 1 is actually being allocated
@@ -468,7 +468,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         // Fill with random data the long value
         char range = 'z' - 'a';
         for (size_t i = 0; i < long_value_length; i++) {
-            long_value[i] = ((char)i % range) + 'a';
+            long_value[i] = (char)(i % range) + 'a';
         }
 
         // This is legit as long_value_length + 1 is actually being allocated
@@ -504,5 +504,33 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 send_recv_resp_command_calculate_multi_recv(long_value_length)));
 
         free(expected_response);
+    }
+
+    SECTION("Invalid EX") {
+        REQUIRE(send_recv_resp_command_text(
+                client_fd,
+                std::vector<std::string>{"SET", "a_key", "b_value", "EX", "0"},
+                "-ERR invalid expire time in 'set' command\r\n"));
+    }
+
+    SECTION("Invalid PX") {
+        REQUIRE(send_recv_resp_command_text(
+                client_fd,
+                std::vector<std::string>{"SET", "a_key", "b_value", "PX", "0"},
+                "-ERR invalid expire time in 'set' command\r\n"));
+    }
+
+    SECTION("Invalid EXAT") {
+        REQUIRE(send_recv_resp_command_text(
+                client_fd,
+                std::vector<std::string>{"SET", "a_key", "b_value", "EXAT", "0"},
+                "-ERR invalid expire time in 'set' command\r\n"));
+    }
+
+    SECTION("Invalid PXAT") {
+        REQUIRE(send_recv_resp_command_text(
+                client_fd,
+                std::vector<std::string>{"SET", "a_key", "b_value", "PXAT", "0"},
+                "-ERR invalid expire time in 'set' command\r\n"));
     }
 }


### PR DESCRIPTION
This PR fixes some minor issues in the SET and GETEX commands, the expiration time passed via EX, PX, EXAT and PXAT as always be greater then zero.