### PR TITLE
Implement transactions for rmw ops

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -19,6 +19,8 @@
 #include "exttypes.h"
 #include "misc.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "xalloc.h"
 #include "log/log.h"
 #include "fatal.h"

--- a/src/data_structures/hashtable/mcmp/hashtable.c
+++ b/src/data_structures/hashtable/mcmp/hashtable.c
@@ -13,6 +13,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "xalloc.h"
 #include "pow2.h"
 

--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -120,7 +120,7 @@ typedef union {
 typedef struct hashtable_half_hashes_chunk hashtable_half_hashes_chunk_t;
 typedef _Volatile(hashtable_half_hashes_chunk_t) hashtable_half_hashes_chunk_volatile_t;
 struct hashtable_half_hashes_chunk {
-    spinlock_lock_volatile_t write_lock;
+    transaction_spinlock_lock_volatile_t write_lock;
     union {
         uint32_t padding;
         struct {
@@ -184,6 +184,7 @@ typedef struct hashtable_mcmp_op_rmw_transaction hashtable_mcmp_op_rmw_status_t;
 struct hashtable_mcmp_op_rmw_transaction {
     hashtable_hash_t hash;
     hashtable_t *hashtable;
+    transaction_t *transaction;
     hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk;
     hashtable_key_value_volatile_t *key_value;
     hashtable_key_data_t *key;

--- a/src/data_structures/hashtable/mcmp/hashtable_config.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_config.c
@@ -14,6 +14,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "xalloc.h"
 
 #include "hashtable.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_data.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.c
@@ -19,6 +19,8 @@
 #include "xalloc.h"
 #include "pow2.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "slab_allocator.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "log/log.h"
 
 #include "hashtable.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
@@ -19,6 +19,8 @@
 #include "log/log.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "slab_allocator.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.c
@@ -18,6 +18,8 @@
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "slab_allocator.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -16,6 +16,8 @@
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "slab_allocator.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
@@ -45,6 +45,8 @@ bool hashtable_mcmp_op_rmw_begin(
     hashtable_chunk_slot_index_t chunk_slot_index = 0;
     hashtable_key_value_volatile_t *key_value = 0;
 
+    assert(transaction->transaction_id.id != TRANSACTION_ID_NOT_ACQUIRED);
+
     hash = hashtable_mcmp_support_hash_calculate(key, key_size);
 
     assert(*key != 0);

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.h
@@ -7,6 +7,7 @@ extern "C" {
 
 bool hashtable_mcmp_op_rmw_begin(
         hashtable_t *hashtable,
+        transaction_t *transaction,
         hashtable_mcmp_op_rmw_status_t *rmw_status,
         hashtable_key_data_t *key,
         hashtable_key_size_t key_size,

--- a/src/data_structures/hashtable/mcmp/hashtable_op_set.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_set.c
@@ -18,6 +18,8 @@
 #include "memory_fences.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "log/log.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
@@ -42,6 +44,7 @@ bool hashtable_mcmp_op_set(
     hashtable_chunk_index_t chunk_index = 0;
     hashtable_chunk_slot_index_t chunk_slot_index = 0;
     hashtable_key_value_volatile_t* key_value = 0;
+    transaction_t transaction = { 0 };
 
     hash = hashtable_mcmp_support_hash_calculate(key, key_size);
 
@@ -49,6 +52,8 @@ bool hashtable_mcmp_op_set(
     LOG_DI("hash = 0x%016x", hash);
 
     assert(*key != 0);
+
+    transaction_acquire(&transaction);
 
     // TODO: there is no support for resizing right now but when creating a new item the function must be aware that
     //       it has to be created in the new hashtable and not in the one being looked into
@@ -58,6 +63,7 @@ bool hashtable_mcmp_op_set(
             key_size,
             hash,
             true,
+            &transaction,
             &created_new,
             &chunk_index,
             &half_hashes_chunk,
@@ -69,6 +75,7 @@ bool hashtable_mcmp_op_set(
     LOG_DI("key_value =  0x%016x", key_value);
 
     if (ret == false) {
+        transaction_release(&transaction);
         LOG_DI("key not found or not created, continuing");
         return false;
     }
@@ -127,7 +134,7 @@ bool hashtable_mcmp_op_set(
     }
 
     // Will perform the memory fence for us
-    spinlock_unlock(&half_hashes_chunk->write_lock);
+    transaction_release(&transaction);
 
     LOG_DI("unlocking half_hashes_chunk 0x%016x", half_hashes_chunk);
 

--- a/src/data_structures/hashtable/mcmp/hashtable_support_index.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_index.c
@@ -13,6 +13,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "hashtable.h"
 #include "hashtable_support_index.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op.c
@@ -15,6 +15,8 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "log/log.h"
 
 #include "hashtable.h"
@@ -71,6 +73,7 @@ bool hashtable_mcmp_support_op_search_key_or_create_new(
         hashtable_key_size_t key_size,
         hashtable_hash_t hash,
         bool create_new_if_missing,
+        transaction_t *transaction,
         bool *created_new,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_half_hashes_chunk_volatile_t **found_half_hashes_chunk,

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op.h
@@ -20,6 +20,7 @@ extern bool hashtable_mcmp_support_op_search_key_or_create_new(
         hashtable_key_size_t key_size,
         hashtable_hash_t hash,
         bool create_new_if_missing,
+        transaction_t *transaction,
         bool *created_new,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_half_hashes_chunk_volatile_t **found_half_hashes_chunk,

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -233,6 +233,8 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
     *found_chunk_index = 0;
     *found_chunk_slot_index = 0;
 
+    assert(transaction->transaction_id.id != TRANSACTION_ID_NOT_ACQUIRED);
+
     bucket_index = hashtable_mcmp_support_index_from_hash(hashtable_data->buckets_count, hash);
     chunk_index_start = chunk_index_start_initial = bucket_index / HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
 

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.h
@@ -24,6 +24,7 @@ extern "C" {
             hashtable_key_size_t key_size, \
             hashtable_hash_t hash, \
             bool create_new_if_missing, \
+            transaction_t *transaction, \
             bool *created_new, \
             hashtable_chunk_index_t *found_chunk_index, \
             hashtable_half_hashes_chunk_volatile_t **found_half_hashes_chunk, \

--- a/src/main.c
+++ b/src/main.c
@@ -14,9 +14,12 @@
 #include <netdb.h>
 #include <sys/resource.h>
 
+#include "misc.h"
 #include "exttypes.h"
-#include "spinlock.h"
 #include "clock.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"

--- a/src/module/prometheus/module_prometheus.c
+++ b/src/module/prometheus/module_prometheus.c
@@ -22,6 +22,8 @@
 #include "clock.h"
 #include "utils_string.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_dbsize.c
+++ b/src/module/redis/command/module_redis_command_dbsize.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_decr.c
+++ b/src/module/redis/command/module_redis_command_decr.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_decrby.c
+++ b/src/module/redis/command/module_redis_command_decrby.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_del.c
+++ b/src/module/redis/command/module_redis_command_del.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_exists.c
+++ b/src/module/redis/command/module_redis_command_exists.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -16,6 +16,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -39,11 +41,16 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
     bool abort_rmw = false;
     bool metadata_updated = false;
     storage_db_entry_index_t *current_entry_index = NULL;
-    module_redis_command_expire_context_t *context = connection_context->command.context;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    module_redis_command_expire_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
@@ -96,6 +103,8 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
     }
 
 end:
+
+    transaction_release(&transaction);
 
     return module_redis_connection_send_number(
             connection_context,

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -66,8 +66,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
     } else {
         expiry_time = current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
                 ? -1
-                : current_entry_index->expiry_time_ms;
-
+                : (current_entry_index->expiry_time_ms / 1000);
     }
 
 end:

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -16,6 +16,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,33 +40,40 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
     bool return_res = false;
     storage_db_entry_index_t *current_entry_index = NULL;
-    module_redis_command_expiretime_context_t *context = connection_context->command.context;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+    int64_t expiry_time;
+
+    module_redis_command_expiretime_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        transaction_release(&transaction);
         return module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR expiretime failed");
     }
 
     if (unlikely(!current_entry_index)) {
-        return module_redis_connection_send_number(
-                connection_context,
-                -2);
+        expiry_time = -2;
+    } else {
+        expiry_time = current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
+                ? -1
+                : current_entry_index->expiry_time_ms;
+
     }
 
-    return_res = module_redis_connection_send_number(
-            connection_context,
-            current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
-            ? -1
-            : current_entry_index->expiry_time_ms / 1000);
+end:
 
     storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    transaction_release(&transaction);
 
-    return return_res;
+    return module_redis_connection_send_number( connection_context, expiry_time);
 }

--- a/src/module/redis/command/module_redis_command_flushdb.c
+++ b/src/module/redis/command/module_redis_command_flushdb.c
@@ -16,6 +16,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_get.c
+++ b/src/module/redis/command/module_redis_command_get.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_getrange.c
+++ b/src/module/redis/command/module_redis_command_getrange.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_getset.c
+++ b/src/module/redis/command/module_redis_command_getset.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,15 +42,21 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getset) {
     bool return_res = false;
     storage_db_entry_index_t *previous_entry_index = NULL;
-    module_redis_command_getset_context_t *context = connection_context->command.context;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    module_redis_command_getset_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
             &previous_entry_index))) {
+        transaction_release(&transaction);
         return_res = module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR getset failed");
@@ -68,11 +76,14 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getset) {
             &rmw_status,
             context->value.value.chunk_sequence,
             STORAGE_DB_ENTRY_NO_EXPIRY))) {
+        transaction_release(&transaction);
         return_res = module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR set failed");
         goto end;
     }
+
+    transaction_release(&transaction);
 
     if (likely(previous_entry_index)) {
         return_res = module_redis_command_stream_entry(

--- a/src/module/redis/command/module_redis_command_hello.c
+++ b/src/module/redis/command/module_redis_command_hello.c
@@ -21,6 +21,8 @@
 #include "log/log.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/module/redis/command/module_redis_command_incr.c
+++ b/src/module/redis/command/module_redis_command_incr.c
@@ -20,6 +20,8 @@
 #include "log/log.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/module/redis/command/module_redis_command_incrby.c
+++ b/src/module/redis/command/module_redis_command_incrby.c
@@ -20,6 +20,8 @@
 #include "log/log.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/module/redis/command/module_redis_command_incrbyfloat.c
+++ b/src/module/redis/command/module_redis_command_incrbyfloat.c
@@ -20,6 +20,8 @@
 #include "log/log.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/module/redis/command/module_redis_command_keys.c
+++ b/src/module/redis/command/module_redis_command_keys.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_lcs.c
+++ b/src/module/redis/command/module_redis_command_lcs.c
@@ -19,6 +19,8 @@
 #include "clock.h"
 #include "spinlock.h"
 #include "xalloc.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/module/redis/command/module_redis_command_mget.c
+++ b/src/module/redis/command/module_redis_command_mget.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_mset.c
+++ b/src/module/redis/command/module_redis_command_mset.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_persist.c
+++ b/src/module/redis/command/module_redis_command_persist.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,15 +42,21 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
     bool abort_rmw = false;
     bool metadata_updated = false;
     storage_db_entry_index_t *current_entry_index = NULL;
-    module_redis_command_expire_context_t *context = connection_context->command.context;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    module_redis_command_expire_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        transaction_release(&transaction);
         return module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR persist failed");
@@ -74,6 +82,8 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
     }
 
 end:
+
+    transaction_release(&transaction);
 
     return module_redis_connection_send_number(
             connection_context,

--- a/src/module/redis/command/module_redis_command_pexpire.c
+++ b/src/module/redis/command/module_redis_command_pexpire.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,15 +42,21 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
     bool abort_rmw = false;
     bool metadata_updated = false;
     storage_db_entry_index_t *current_entry_index = NULL;
-    module_redis_command_pexpire_context_t *context = connection_context->command.context;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    module_redis_command_pexpire_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        transaction_release(&transaction);
         return module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR pexpire failed");
@@ -98,6 +106,8 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
     }
 
 end:
+
+    transaction_release(&transaction);
 
     return module_redis_connection_send_number(
             connection_context,

--- a/src/module/redis/command/module_redis_command_pexpireat.c
+++ b/src/module/redis/command/module_redis_command_pexpireat.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,15 +42,21 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
     bool abort_rmw = false;
     bool metadata_updated = false;
     storage_db_entry_index_t *current_entry_index = NULL;
-    module_redis_command_pexpireat_context_t *context = connection_context->command.context;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    module_redis_command_pexpireat_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        transaction_release(&transaction);
         return module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR pexpireat failed");
@@ -97,6 +105,8 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
     }
 
 end:
+
+    transaction_release(&transaction);
 
     return module_redis_connection_send_number(
             connection_context,

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -66,9 +66,8 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
         expiry_time = -2;
     } else {
         expiry_time = current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
-                      ? -1
-                      : current_entry_index->expiry_time_ms;
-
+                ? -1
+                  : current_entry_index->expiry_time_ms;
     }
 
 end:

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -39,33 +41,40 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
     bool return_res = false;
     storage_db_entry_index_t *current_entry_index = NULL;
-    module_redis_command_expiretime_context_t *context = connection_context->command.context;
+    int64_t expiry_time;
+    transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };
+
+    module_redis_command_expiretime_context_t *context = connection_context->command.context;
+
+    transaction_acquire(&transaction);
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,
             &current_entry_index))) {
+        transaction_release(&transaction);
         return module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR pexpiretime failed");
     }
 
     if (unlikely(!current_entry_index)) {
-        return module_redis_connection_send_number(
-                connection_context,
-                -2);
+        expiry_time = -2;
+    } else {
+        expiry_time = current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
+                      ? -1
+                      : current_entry_index->expiry_time_ms;
+
     }
 
-    return_res = module_redis_connection_send_number(
-            connection_context,
-            current_entry_index->expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY
-            ? -1
-            : current_entry_index->expiry_time_ms);
+end:
 
     storage_db_op_rmw_abort(connection_context->db, &rmw_status);
+    transaction_release(&transaction);
 
-    return return_res;
+    return module_redis_connection_send_number(connection_context, expiry_time);
 }

--- a/src/module/redis/command/module_redis_command_ping.c
+++ b/src/module/redis/command/module_redis_command_ping.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_psetex.c
+++ b/src/module/redis/command/module_redis_command_psetex.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_pttl.c
+++ b/src/module/redis/command/module_redis_command_pttl.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_quit.c
+++ b/src/module/redis/command/module_redis_command_quit.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_randomkey.c
+++ b/src/module/redis/command/module_redis_command_randomkey.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/module/redis/command/module_redis_command_renamenx.c
+++ b/src/module/redis/command/module_redis_command_renamenx.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,6 +42,8 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(renamenx) {
     bool return_res = false;
     bool abort_rmw = true;
+    bool release_transaction = true;
+    transaction_t transaction = { 0 };
     bool rmw_status_source_started = false;
     bool rmw_status_destination_started = false;
     storage_db_entry_index_t *source_entry_index = NULL, *destination_entry_index = NULL;
@@ -54,8 +58,11 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(renamenx) {
         return module_redis_connection_send_number(connection_context, 0);
     }
 
+    transaction_acquire(&transaction);
+
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->key.value.key,
             context->key.value.length,
             &rmw_status_source,
@@ -79,6 +86,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(renamenx) {
 
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
+            &transaction,
             context->newkey.value.key,
             context->newkey.value.length,
             &rmw_status_destination,
@@ -97,12 +105,16 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(renamenx) {
 
     rmw_status_destination_started = true;
 
-    storage_db_op_rmw_commit_rename(connection_context->db, &rmw_status_source, &rmw_status_destination);
-
-    return_res = module_redis_connection_send_number(connection_context, 1);
+    storage_db_op_rmw_commit_rename(
+            connection_context->db,
+            &rmw_status_source,
+            &rmw_status_destination);
+    transaction_release(&transaction);
 
     context->newkey.value.key = NULL;
     abort_rmw = false;
+    release_transaction = false;
+    return_res = module_redis_connection_send_number(connection_context, 1);
 
 end:
 
@@ -114,6 +126,10 @@ end:
         if (rmw_status_destination_started) {
             storage_db_op_rmw_abort(connection_context->db, &rmw_status_destination);
         }
+    }
+
+    if (unlikely(release_transaction)) {
+        transaction_release(&transaction);
     }
 
     return return_res;

--- a/src/module/redis/command/module_redis_command_scan.c
+++ b/src/module/redis/command/module_redis_command_scan.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_setex.c
+++ b/src/module/redis/command/module_redis_command_setex.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_shutdown.c
+++ b/src/module/redis/command/module_redis_command_shutdown.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_strlen.c
+++ b/src/module/redis/command/module_redis_command_strlen.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_substr.c
+++ b/src/module/redis/command/module_redis_command_substr.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_ttl.c
+++ b/src/module/redis/command/module_redis_command_ttl.c
@@ -18,6 +18,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/command/module_redis_command_unlink.c
+++ b/src/module/redis/command/module_redis_command_unlink.c
@@ -17,6 +17,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/module_redis.c
+++ b/src/module/redis/module_redis.c
@@ -20,6 +20,8 @@
 #include "fatal.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -22,6 +22,8 @@
 #include "exttypes.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "clock.h"
 #include "config.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/module/redis/module_redis_commands.c
+++ b/src/module/redis/module_redis_commands.c
@@ -18,6 +18,8 @@
 #include "exttypes.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "clock.h"
 #include "config.h"
 #include "xalloc.h"

--- a/src/module/redis/module_redis_connection.c
+++ b/src/module/redis/module_redis_connection.c
@@ -18,6 +18,8 @@
 #include "exttypes.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "clock.h"
 #include "config.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/network/channel/network_channel.c
+++ b/src/network/channel/network_channel.c
@@ -16,6 +16,8 @@
 #include "exttypes.h"
 #include "misc.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "log/log.h"
 #include "xalloc.h"
 #include "config.h"

--- a/src/network/channel/network_channel_iouring.c
+++ b/src/network/channel/network_channel_iouring.c
@@ -13,6 +13,8 @@
 #include "xalloc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -21,6 +21,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "log/log.h"
 #include "fiber.h"
 #include "fiber_scheduler.h"

--- a/src/program.c
+++ b/src/program.c
@@ -33,6 +33,8 @@
 #include "log/sink/log_sink_console.h"
 #include "hugepages.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "config.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -6,85 +6,13 @@
  * of the BSD license.  See the LICENSE file for details.
  **/
 
-#include <stdlib.h>
 #include <stdint.h>
-#include <stdbool.h>
-#include <stdatomic.h>
-#include <pthread.h>
 
-#if DEBUG == 1
-#include <assert.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/syscall.h>
-#endif
-
-#include "memory_fences.h"
-#include "misc.h"
-#include "exttypes.h"
 #include "spinlock.h"
-#include "log/log.h"
-#include "fatal.h"
 
 #define TAG "spinlock"
 
 void spinlock_init(
         spinlock_lock_volatile_t* spinlock) {
     spinlock->lock = SPINLOCK_UNLOCKED;
-}
-
-void spinlock_unlock(
-        spinlock_lock_volatile_t* spinlock) {
-#if DEBUG == 1
-    long thread_id = syscall(__NR_gettid);
-    uint32_t expected_lock = (uint32_t)thread_id;
-    assert(spinlock->lock == expected_lock);
-#endif
-
-    spinlock->lock = SPINLOCK_UNLOCKED;
-    MEMORY_FENCE_STORE();
-}
-
-bool spinlock_is_locked(
-        spinlock_lock_volatile_t *spinlock) {
-    MEMORY_FENCE_LOAD();
-    return spinlock->lock != SPINLOCK_UNLOCKED;
-}
-
-bool spinlock_try_lock(
-        spinlock_lock_volatile_t *spinlock) {
-#if DEBUG == 1
-    long thread_id = syscall(__NR_gettid);
-    uint32_t new_value = thread_id;
-    uint32_t expected_value = SPINLOCK_UNLOCKED;
-#else
-    uint32_t new_value = SPINLOCK_LOCKED;
-    uint32_t expected_value = SPINLOCK_UNLOCKED;
-#endif
-
-    return __sync_bool_compare_and_swap(&spinlock->lock, expected_value, new_value);
-}
-
-bool spinlock_lock_internal(
-        spinlock_lock_volatile_t *spinlock,
-        bool retry,
-        const char* src_path,
-        const char* src_func,
-        uint32_t src_line) {
-    bool res = false;
-    uint32_t max_spins_before_probably_stuck = UINT32_MAX >> 1;
-
-    while (unlikely(!(res = spinlock_try_lock(spinlock)) && retry)) {
-        uint64_t spins = 0;
-        while (likely(spinlock_is_locked(spinlock) && spins < max_spins_before_probably_stuck)) {
-            spins++;
-        }
-
-        if (spins == max_spins_before_probably_stuck) {
-            LOG_E(TAG, "Possible stuck spinlock detected for thread %lu in %s at %s:%u",
-                    pthread_self(), src_func, src_path, src_line);
-        }
-    }
-
-    return res;
 }

--- a/src/spinlock.h
+++ b/src/spinlock.h
@@ -2,18 +2,33 @@
 #define CACHEGRAND_SPINLOCK_H
 
 #ifdef __cplusplus
+#include <atomic>
+#else
+#include <stdatomic.h>
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
+#include <stdbool.h>
+#include <pthread.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#if DEBUG == 1
+#include <assert.h>
+#include <sys/types.h>
+#endif
+
 #include "cmake_config.h"
+#include "misc.h"
+#include "exttypes.h"
+#include "memory_fences.h"
+#include "log/log.h"
 
 #define SPINLOCK_UNLOCKED   0
 #define SPINLOCK_LOCKED     1
-
-#define SPINLOCK_FLAG_POTENTIALLY_STUCK     0x01
-
-typedef uint8_t spinlock_flag_t;
-typedef _Volatile(uint8_t) spinlock_flag_volatile_t;
 
 typedef struct spinlock_lock spinlock_lock_t;
 typedef _Volatile(spinlock_lock_t) spinlock_lock_volatile_t;
@@ -24,39 +39,59 @@ struct spinlock_lock {
 void spinlock_init(
         spinlock_lock_volatile_t* spinlock);
 
-bool spinlock_try_lock(
-        spinlock_lock_volatile_t* spinlock);
+static inline __attribute__((always_inline)) void spinlock_unlock(
+        spinlock_lock_volatile_t* spinlock) {
+#if DEBUG == 1
+    long thread_id = syscall(__NR_gettid);
+    uint32_t expected_lock = (uint32_t)thread_id;
+    assert(spinlock->lock == expected_lock);
+#endif
 
-bool spinlock_is_locked(
-        spinlock_lock_volatile_t* spinlock);
+    spinlock->lock = SPINLOCK_UNLOCKED;
+    MEMORY_FENCE_STORE();
+}
 
-bool spinlock_lock_internal(
-        spinlock_lock_volatile_t* spinlock,
-        bool retry,
+static inline __attribute__((always_inline)) bool spinlock_is_locked(
+        spinlock_lock_volatile_t *spinlock) {
+    MEMORY_FENCE_LOAD();
+    return spinlock->lock != SPINLOCK_UNLOCKED;
+}
+
+static inline __attribute__((always_inline)) bool spinlock_try_lock(
+        spinlock_lock_volatile_t *spinlock) {
+#if DEBUG == 1
+    long thread_id = syscall(__NR_gettid);
+    uint32_t new_value = thread_id;
+    uint32_t expected_value = SPINLOCK_UNLOCKED;
+#else
+    uint32_t new_value = SPINLOCK_LOCKED;
+    uint32_t expected_value = SPINLOCK_UNLOCKED;
+#endif
+
+    return __sync_bool_compare_and_swap(&spinlock->lock, expected_value, new_value);
+}
+
+static inline __attribute__((always_inline)) void spinlock_lock_internal(
+        spinlock_lock_volatile_t *spinlock,
         const char* src_path,
-        const char* src_func,
-        uint32_t src_line);
+        uint32_t src_line) {
+    uint32_t max_spins_before_probably_stuck = 1 << 23;
 
-void spinlock_unlock(
-        spinlock_lock_volatile_t* spinlock);
-
-void spinlock_set_flag(
-        spinlock_lock_volatile_t *spinlock,
-        spinlock_flag_t flag);
-
-void spinlock_unset_flag(
-        spinlock_lock_volatile_t *spinlock,
-        spinlock_flag_t flag);
-
-bool spinlock_has_flag(
-        spinlock_lock_volatile_t *spinlock,
-        spinlock_flag_t flag);
+    uint64_t spins = 0;
+    while (unlikely(!spinlock_try_lock(spinlock))) {
+        if (unlikely(spins++ == max_spins_before_probably_stuck)) {
+            LOG_E("spinlock", "Possible stuck spinlock detected for thread %lu in %s:%u",
+                  syscall(__NR_gettid), src_path, src_line);
+            spins = 0;
+        }
+    }
+}
 
 /**
- * Uses a macro to wrap _spinlock_lock to automatically define the path, func and line args
+ * Uses a macro to wrap spinlock_lock_internal to automatically define the path and the line args
  */
-#define spinlock_lock(spinlock, retry) \
-    spinlock_lock_internal(spinlock, retry, CACHEGRAND_SRC_PATH, __func__, __LINE__)
+#define spinlock_lock(spinlock) \
+    spinlock_lock_internal(spinlock, CACHEGRAND_SRC_PATH, __LINE__)
 
 #ifdef __cplusplus
 }

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1150,6 +1150,7 @@ bool storage_db_op_rmw_begin(
         size_t key_length,
         storage_db_op_rmw_status_t *rmw_status,
         storage_db_entry_index_t **current_entry_index) {
+    assert(transaction->transaction_id.id != TRANSACTION_ID_NOT_ACQUIRED);
 
     if (unlikely(!hashtable_mcmp_op_rmw_begin(
             db->hashtable,

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -23,6 +23,8 @@
 #include "clock.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "utils_string.h"
 #include "xalloc.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
@@ -380,7 +382,7 @@ storage_db_shard_t *storage_db_new_active_shard(
     // the initial owner of the lock will never get the chance to finish the operation.
     // For this reason, if the lock is in use, the fiber yields to ensure that at some point the original fiber that
     // acquired the lock will get the chance to complete the operations.
-    while (!spinlock_lock(&db->shards.write_spinlock, false)) {
+    while (!spinlock_try_lock(&db->shards.write_spinlock)) {
         fiber_scheduler_switch_back();
     }
 
@@ -1002,10 +1004,15 @@ storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(
         // If the storage db entry index is actually expired it's necessary to start a read modify write operation
         // because the check has to be carried out again under the lock to check if the entry index only has to be
         // deleted or the entire bucket in the hashtable has to be deleted
+        transaction_t transaction = { 0 };
         storage_db_op_rmw_status_t rmw_status = { 0 };
+
+        transaction_acquire(&transaction);
+
         storage_db_entry_index_t *current_entry_index = NULL;
         if (unlikely(!storage_db_op_rmw_begin(
                 db,
+                &transaction,
                 key,
                 key_length,
                 &rmw_status,
@@ -1138,6 +1145,7 @@ end:
 
 bool storage_db_op_rmw_begin(
         storage_db_t *db,
+        transaction_t *transaction,
         char *key,
         size_t key_length,
         storage_db_op_rmw_status_t *rmw_status,
@@ -1145,6 +1153,7 @@ bool storage_db_op_rmw_begin(
 
     if (unlikely(!hashtable_mcmp_op_rmw_begin(
             db->hashtable,
+            transaction,
             &rmw_status->hashtable,
             key,
             key_length,
@@ -1152,6 +1161,7 @@ bool storage_db_op_rmw_begin(
         return false;
     }
 
+    rmw_status->transaction = transaction;
     rmw_status->current_entry_index = *current_entry_index;
 
     if (
@@ -1161,10 +1171,6 @@ bool storage_db_op_rmw_begin(
         *current_entry_index = NULL;
     }
 
-    if (*current_entry_index) {
-        storage_db_entry_index_touch(*current_entry_index);
-    }
-
     return true;
 }
 
@@ -1172,6 +1178,10 @@ storage_db_entry_index_t *storage_db_op_rmw_current_entry_index_prep_for_read(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status,
         storage_db_entry_index_t *entry_index) {
+    if (entry_index && !rmw_status->delete_entry_index_on_abort) {
+        storage_db_entry_index_touch(entry_index);
+    }
+
     // Try to acquire a reader lock until it's successful or the entry index has been marked as deleted
     storage_db_entry_index_status_increase_readers_counter(
             entry_index,
@@ -1183,7 +1193,10 @@ storage_db_entry_index_t *storage_db_op_rmw_current_entry_index_prep_for_read(
 bool storage_db_op_rmw_commit_metadata(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status) {
-    storage_db_entry_index_touch(rmw_status->current_entry_index);
+    if (rmw_status->current_entry_index && !rmw_status->delete_entry_index_on_abort) {
+        storage_db_entry_index_touch(rmw_status->current_entry_index);
+    }
+
     hashtable_mcmp_op_rmw_commit_update(
             &rmw_status->hashtable,
             (uintptr_t)rmw_status->current_entry_index);
@@ -1248,12 +1261,10 @@ bool storage_db_op_rmw_commit_update(
 
     result_res = true;
 
-    end:
+end:
 
     if (!result_res) {
-        if (entry_index) {
-            storage_db_entry_index_free(db, entry_index);
-        }
+        storage_db_entry_index_free(db, entry_index);
 
         // Abort the underlying rmw operation in the hashtable if the commit fails
         hashtable_mcmp_op_rmw_abort(&rmw_status->hashtable);
@@ -1266,8 +1277,6 @@ void storage_db_op_rmw_commit_rename(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status_source,
         storage_db_op_rmw_status_t *rmw_status_destination) {
-    storage_db_entry_index_touch(rmw_status_source->current_entry_index);
-
     hashtable_mcmp_op_rmw_commit_update(
             &rmw_status_destination->hashtable,
             (uintptr_t)rmw_status_source->current_entry_index);
@@ -1279,6 +1288,10 @@ void storage_db_op_rmw_commit_rename(
     }
 
     hashtable_mcmp_op_rmw_commit_delete(&rmw_status_source->hashtable);
+
+    if (rmw_status_source->current_entry_index && !rmw_status_source->delete_entry_index_on_abort) {
+        storage_db_entry_index_touch(rmw_status_source->current_entry_index);
+    }
 }
 
 void storage_db_op_rmw_commit_delete(

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -123,6 +123,7 @@ struct storage_db_entry_index {
 typedef struct storage_db_op_rmw_transaction storage_db_op_rmw_status_t;
 struct storage_db_op_rmw_transaction {
     hashtable_mcmp_op_rmw_status_t hashtable;
+    transaction_t *transaction;
     storage_db_entry_index_t *current_entry_index;
     bool delete_entry_index_on_abort;
 };
@@ -314,6 +315,7 @@ bool storage_db_op_set(
 
 bool storage_db_op_rmw_begin(
         storage_db_t *db,
+        transaction_t *transaction,
         char *key,
         size_t key_length,
         storage_db_op_rmw_status_t *rmw_status,

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "clock.h"
+#include "config.h"
+#include "fiber.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+#include "worker/worker.h"
+#include "data_structures/small_circular_queue/small_circular_queue.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+
+#include "transaction.h"
+#include "transaction_spinlock.h"
+
+#define TAG "transaction_spinlock"
+
+thread_local uint32_t transaction_manager_worker_index = 0;
+thread_local uint16_t transaction_manager_transaction_index = 0;
+pthread_once_t transaction_manager_init_once_control = PTHREAD_ONCE_INIT;
+
+void transaction_set_worker_index(
+        uint32_t worker_index) {
+    transaction_manager_worker_index = worker_index;
+}
+
+void transaction_manager_init() {
+    transaction_set_worker_index(worker_context_get()->worker_index);
+    assert(transaction_manager_worker_index <= UINT16_MAX);
+}
+
+bool transaction_expand_locks_list(
+        transaction_t *transaction) {
+    size_t current_mem_size = sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size;
+
+    transaction->locks.size = transaction->locks.size * 2;
+    transaction->locks.list = slab_allocator_mem_realloc(
+            transaction->locks.list,
+            current_mem_size,
+            sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size,
+            false);
+
+    return transaction->locks.list != NULL;
+}
+
+uint16_t transaction_peek_current_thread_index() {
+    return transaction_manager_transaction_index;
+}
+
+bool transaction_acquire(
+        transaction_t *transaction) {
+    pthread_once(&transaction_manager_init_once_control, transaction_manager_init);
+
+    transaction_manager_transaction_index++;
+
+    if (unlikely(transaction_manager_worker_index == 0 &&
+        transaction_manager_transaction_index == TRANSACTION_ID_NOT_ACQUIRED)) {
+        transaction_manager_transaction_index++;
+    }
+
+    transaction->transaction_id.worker_index = transaction_manager_worker_index;
+    transaction->transaction_id.transaction_index = transaction_manager_transaction_index;
+
+    transaction->locks.count = 0;
+    transaction->locks.size = 8;
+    transaction->locks.list = slab_allocator_mem_alloc(
+            sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size);
+
+    if (transaction->locks.list == NULL) {
+        return false;
+    }
+
+    return true;
+}
+
+void transaction_release(
+        transaction_t *transaction) {
+    assert(transaction->transaction_id.id != TRANSACTION_ID_NOT_ACQUIRED);
+
+    for(uint32_t index = 0; index < transaction->locks.count; index++) {
+#if DEBUG == 1
+        transaction_spinlock_unlock_internal(transaction->locks.list[index], transaction);
+#else
+        transaction_spinlock_unlock_internal(transaction->locks.list[index]);
+#endif
+    }
+
+    slab_allocator_mem_free(transaction->locks.list);
+
+    transaction->locks.list = NULL;
+    transaction->transaction_id.id = TRANSACTION_ID_NOT_ACQUIRED;
+}

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -1,0 +1,70 @@
+#ifndef CACHEGRAND_TRANSACTION_H
+#define CACHEGRAND_TRANSACTION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct transaction_spinlock_lock transaction_spinlock_lock_t;
+typedef _Volatile(transaction_spinlock_lock_t) transaction_spinlock_lock_volatile_t;
+
+typedef struct transaction_id transaction_id_t;
+struct transaction_id {
+    union {
+        struct {
+            uint16_t worker_index;
+            uint16_t transaction_index;
+        };
+        uint32_volatile_t id;
+    };
+};
+
+typedef struct transaction transaction_t;
+struct transaction {
+    transaction_id_t transaction_id;
+    struct {
+        uint32_t count;
+        uint32_t size;
+        transaction_spinlock_lock_volatile_t **list;
+    } locks;
+};
+
+void transaction_set_worker_index(
+        uint32_t worker_index);
+
+bool transaction_expand_locks_list(
+        transaction_t *transaction);
+
+uint16_t transaction_peek_current_thread_index();
+
+bool transaction_acquire(
+        transaction_t* transaction);
+
+void transaction_release(
+        transaction_t* transaction);
+
+static inline __attribute__((always_inline)) bool transaction_needs_expand_locks_list(
+        transaction_t* transaction) {
+    return transaction->locks.count == transaction->locks.size;
+}
+
+static inline __attribute__((always_inline)) bool transaction_locks_list_add(
+        transaction_t *transaction,
+        transaction_spinlock_lock_volatile_t *transaction_spinlock) {
+    if (unlikely(transaction_needs_expand_locks_list(transaction))) {
+        if (unlikely(!transaction_expand_locks_list(transaction))) {
+            return false;
+        }
+    }
+
+    transaction->locks.list[transaction->locks.count] = transaction_spinlock;
+    transaction->locks.count++;
+
+    return true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_TRANSACTION_H

--- a/src/transaction_spinlock.c
+++ b/src/transaction_spinlock.c
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "misc.h"
+#include "exttypes.h"
+
+#include "transaction.h"
+#include "transaction_spinlock.h"
+
+#define TAG "transaction_spinlock"
+
+void transaction_spinlock_init(
+        transaction_spinlock_lock_volatile_t* spinlock) {
+    spinlock->transaction_id = TRANSACTION_SPINLOCK_UNLOCKED;
+}

--- a/src/transaction_spinlock.h
+++ b/src/transaction_spinlock.h
@@ -1,0 +1,115 @@
+#ifndef CACHEGRAND_TRANSACTION_SPINLOCK_H
+#define CACHEGRAND_TRANSACTION_SPINLOCK_H
+
+#ifdef __cplusplus
+#include <atomic>
+#else
+#include <stdatomic.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <pthread.h>
+#include <assert.h>
+
+#include "cmake_config.h"
+#include "misc.h"
+#include "exttypes.h"
+#include "memory_fences.h"
+#include "log/log.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+
+#define TRANSACTION_ID_NOT_ACQUIRED (0)
+#define TRANSACTION_SPINLOCK_UNLOCKED   (0)
+
+typedef struct transaction transaction_t;
+
+typedef struct transaction_spinlock_lock transaction_spinlock_lock_t;
+typedef _Volatile(transaction_spinlock_lock_t) transaction_spinlock_lock_volatile_t;
+struct transaction_spinlock_lock {
+    uint32_volatile_t transaction_id;
+} __attribute__((aligned(4)));
+
+void transaction_spinlock_init(
+        transaction_spinlock_lock_volatile_t* spinlock);
+
+static inline __attribute__((always_inline)) void transaction_spinlock_unlock_internal(
+        transaction_spinlock_lock_volatile_t* spinlock
+#if DEBUG == 1
+        ,transaction_t *transaction
+#endif
+    ) {
+
+#if DEBUG == 1
+    assert(spinlock->transaction_id == transaction->transaction_id.id);
+#endif
+
+    spinlock->transaction_id = TRANSACTION_SPINLOCK_UNLOCKED;
+    MEMORY_FENCE_STORE();
+}
+
+static inline __attribute__((always_inline)) bool transaction_spinlock_is_locked(
+        transaction_spinlock_lock_volatile_t *spinlock) {
+    MEMORY_FENCE_LOAD();
+    return spinlock->transaction_id != TRANSACTION_SPINLOCK_UNLOCKED;
+}
+
+static inline __attribute__((always_inline)) bool transaction_spinlock_is_owned_by_transaction(
+        transaction_spinlock_lock_volatile_t *spinlock,
+        transaction_t *transaction) {
+    MEMORY_FENCE_LOAD();
+    return spinlock->transaction_id == transaction->transaction_id.id;
+}
+
+static inline __attribute__((always_inline)) bool transaction_spinlock_try_lock(
+        transaction_spinlock_lock_volatile_t *spinlock,
+        transaction_t *transaction) {
+    assert(transaction->transaction_id.id != TRANSACTION_ID_NOT_ACQUIRED);
+
+    uint32_t new_value = transaction->transaction_id.id;
+    uint32_t expected_value = TRANSACTION_SPINLOCK_UNLOCKED;
+
+    bool res = __sync_bool_compare_and_swap(&spinlock->transaction_id, expected_value, new_value);
+
+    if (likely(res)) {
+        transaction_locks_list_add(transaction, spinlock);
+    }
+
+    return res;
+}
+
+static inline __attribute__((always_inline)) bool transaction_spinlock_lock_internal(
+        transaction_spinlock_lock_volatile_t *spinlock,
+        transaction_t *transaction,
+        const char* src_path,
+        uint32_t src_line) {
+    uint32_t max_spins_before_probably_stuck = 1 << 26;
+
+    uint64_t spins = 0;
+    while (unlikely(!transaction_spinlock_try_lock(spinlock, transaction))) {
+        if (unlikely(spins++ == max_spins_before_probably_stuck)) {
+            LOG_E("transaction_spinlock", "Possible stuck transactional spinlock detected for thread %lu in %s:%u",
+                  syscall(__NR_gettid), src_path, src_line);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Uses a macro to wrap transaction_spinlock_lock_internal to automatically define the path and the line args
+ */
+#define transaction_spinlock_lock(transaction_spinlock_var, transaction) \
+    transaction_spinlock_lock_internal(transaction_spinlock_var, transaction, CACHEGRAND_SRC_PATH, __LINE__)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_TRANSACTION_SPINLOCK_H

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -28,6 +28,8 @@
 #include "clock.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "config.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -26,6 +26,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"

--- a/src/worker/storage/worker_storage_iouring_op.c
+++ b/src/worker/storage/worker_storage_iouring_op.c
@@ -17,6 +17,8 @@
 #include "clock.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/worker/storage/worker_storage_posix_op.c
+++ b/src/worker/storage/worker_storage_posix_op.c
@@ -20,6 +20,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -33,6 +33,8 @@
 #include "clock.h"
 #include "thread.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "memory_fences.h"
 #include "utils_numa.h"
 #include "log/log.h"

--- a/src/worker/worker_context.c
+++ b/src/worker/worker_context.c
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "config.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"

--- a/src/worker/worker_iouring.c
+++ b/src/worker/worker_iouring.c
@@ -26,6 +26,8 @@
 #include "fatal.h"
 #include "xalloc.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "config.h"
 #include "fiber.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/src/worker/worker_iouring_op.c
+++ b/src/worker/worker_iouring_op.c
@@ -18,6 +18,8 @@
 #include "exttypes.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "config.h"
 #include "fiber.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/src/worker/worker_op.c
+++ b/src/worker/worker_op.c
@@ -16,6 +16,8 @@
 #include "fiber.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"

--- a/src/worker/worker_stats.c
+++ b/src/worker/worker_stats.c
@@ -17,6 +17,8 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "config.h"
 #include "fiber.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-config.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-config.cpp
@@ -11,6 +11,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_config.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-data.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-data.cpp
@@ -11,6 +11,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_data.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-delete.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-delete.cpp
@@ -13,6 +13,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "random.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-get.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-get.cpp
@@ -14,6 +14,8 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "xalloc.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-iter.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-iter.cpp
@@ -14,6 +14,8 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "xalloc.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
@@ -6,13 +6,14 @@
  * of the BSD license.  See the LICENSE file for details.
  **/
 
-#include <catch2/catch.hpp>
+#include <cstdint>
+#include <cstring>
 #include <numa.h>
-
-#include <string.h>
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "misc.h"
 #include "log/log.h"
 
@@ -23,6 +24,8 @@
 
 #include "../../../support.h"
 #include "fixtures-hashtable-mpmc.h"
+
+#include <catch2/catch.hpp>
 
 TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashtable_mcmp_op_set]") {
     SECTION("hashtable_mcmp_op_set") {
@@ -97,7 +100,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         &prev_value));
 
                 // Check if the write lock has been released
-                REQUIRE(!spinlock_is_locked(&half_hashes_chunk->write_lock));
+                REQUIRE(!transaction_spinlock_is_locked(&half_hashes_chunk->write_lock));
 
                 // Check if the first slot of the chain ring contains the correct key/value
                 REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);
@@ -484,7 +487,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                             NULL));
 
                     // Check if the write lock has been released
-                    REQUIRE(!spinlock_is_locked(&half_hashes_chunk->write_lock));
+                    REQUIRE(!transaction_spinlock_is_locked(&half_hashes_chunk->write_lock));
 
                     // Check if the first slot of the chain ring contains the correct key/value
                     REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash-search.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash-search.cpp
@@ -11,6 +11,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "misc.h"
 #include "log/log.h"
 

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash.cpp
@@ -11,6 +11,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_support_hash.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-index.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-index.cpp
@@ -11,6 +11,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_support_index.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-op.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-op.cpp
@@ -11,6 +11,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_data.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc.cpp
@@ -12,6 +12,8 @@
 
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_config.h"

--- a/tests/unit_tests/modules/prometheus/test-program-prometheus.cpp
+++ b/tests/unit_tests/modules/prometheus/test-program-prometheus.cpp
@@ -28,6 +28,8 @@
 #include "xalloc.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
@@ -57,25 +57,25 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
 
     SECTION("Non-existing key") {
         SECTION("Append once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", "b_value"},
                     ":7\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("Append twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", "b_value"},
                     ":7\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", "c_value"},
                     ":14\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$14\r\nb_valuec_value\r\n"));
         }
@@ -92,7 +92,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     sizeof(expected),
                     ":%lu\r\n",
                     sizeof(value));
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", value},
                     expected));
 
@@ -103,9 +103,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     sizeof(value),
                     (int)sizeof(value),
                     value);
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
-                    (char*)expected,
+                    (char *) expected,
                     expected_length,
                     send_recv_resp_command_calculate_multi_recv(expected_length)));
         }
@@ -135,11 +135,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     (int) long_value_length,
                     long_value);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", long_value},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
 
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,
@@ -173,11 +173,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     (int) long_value_length,
                     long_value);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", long_value},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
 
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,
@@ -192,30 +192,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
         size_t value1_len = strlen(value1);
         char *value2 = "b_value";
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", value1},
                 "+OK\r\n"));
 
         SECTION("Append once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", value2},
                     ":14\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$14\r\nvalue_fb_value\r\n"));
         }
 
         SECTION("Append twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", value2},
                     ":14\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", value1},
                     ":21\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$21\r\nvalue_fb_valuevalue_f\r\n"));
         }
@@ -232,7 +232,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     sizeof(expected),
                     ":%lu\r\n",
                     value1_len + sizeof(value));
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", value},
                     expected));
 
@@ -244,9 +244,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     value1,
                     (int)sizeof(value),
                     value);
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
-                    (char*)expected,
+                    (char *) expected,
                     expected_length,
                     send_recv_resp_command_calculate_multi_recv(expected_length)));
         }
@@ -278,11 +278,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     (int) long_value_length,
                     long_value);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", long_value},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
 
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,
@@ -328,15 +328,15 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     (int) long_value_length,
                     long_value);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", long_value},
-                    (char*)expected_response_static1));
+                    (char *) expected_response_static1));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"APPEND", "a_key", long_value},
-                    (char*)expected_response_static2));
+                    (char *) expected_response_static2));
 
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
@@ -18,6 +18,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
@@ -58,29 +58,24 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
     SECTION("Non-existing key") {
         SECTION("Append once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", "b_value"},
                     ":7\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("Append twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", "b_value"},
                     ":7\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", "c_value"},
                     ":14\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     "$14\r\nb_valuec_value\r\n"));
         }
@@ -98,7 +93,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     ":%lu\r\n",
                     sizeof(value));
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", value},
                     expected));
 
@@ -110,7 +104,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     (int)sizeof(value),
                     value);
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     (char*)expected,
                     expected_length,
@@ -143,12 +136,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     long_value);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", long_value},
                     (char*)expected_response_static));
 
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,
@@ -183,12 +174,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     long_value);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", long_value},
                     (char*)expected_response_static));
 
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,
@@ -204,35 +193,29 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
         char *value2 = "b_value";
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", value1},
                 "+OK\r\n"));
 
         SECTION("Append once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", value2},
                     ":14\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     "$14\r\nvalue_fb_value\r\n"));
         }
 
         SECTION("Append twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", value2},
                     ":14\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", value1},
                     ":21\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     "$21\r\nvalue_fb_valuevalue_f\r\n"));
         }
@@ -250,7 +233,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     ":%lu\r\n",
                     value1_len + sizeof(value));
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", value},
                     expected));
 
@@ -263,7 +245,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     (int)sizeof(value),
                     value);
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     (char*)expected,
                     expected_length,
@@ -298,12 +279,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     long_value);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", long_value},
                     (char*)expected_response_static));
 
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,
@@ -350,17 +329,14 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - APPEND", "[r
                     long_value);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", long_value},
                     (char*)expected_response_static1));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"APPEND", "a_key", long_value},
                     (char*)expected_response_static2));
 
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     expected_response,
                     expected_response_length,

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-copy.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-copy.cpp
@@ -38,21 +38,21 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - COPY", "[redis][command][COPY]") {
     SECTION("Non existent key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"COPY", "a_key", "b_key"},
                 ":0\r\n"));
     }
 
     SECTION("Existent key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"COPY", "a_key", "b_key"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
     }
@@ -91,21 +91,21 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - COPY", "[red
                 (int) long_value_length,
                 long_value);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"COPY", "a_key", "b_key"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_multi_recv(
+        REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 expected_response,
                 expected_response_length,
                 send_recv_resp_command_calculate_multi_recv(long_value_length)));
 
-        REQUIRE(send_recv_resp_command_multi_recv(
+        REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 expected_response,
                 expected_response_length,
@@ -115,29 +115,29 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - COPY", "[red
     }
 
     SECTION("Existent destination key - fail") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"COPY", "a_key", "b_key"},
                 ":0\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
     }
 
     SECTION("Existent destination key - Overwrite") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"COPY", "a_key", "b_key", "REPLACE"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-dbsize.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-dbsize.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,70 +39,58 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DBSIZE", "[redis][command][DBSIZE]") {
     SECTION("Empty database") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DBSIZE"},
                 ":0\r\n"));
     }
 
     SECTION("Database with 1 key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DBSIZE"},
                 ":1\r\n"));
     }
 
     SECTION("Database with 1 key overwritten") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "value_z"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DBSIZE"},
                 ":1\r\n"));
     }
 
     SECTION("Database with 1 key deleted") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DEL", "a_key"},
                 ":1\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DBSIZE"},
                 ":0\r\n"));
     }
 
     SECTION("Database with 1 key flushed") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"FLUSHDB"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DBSIZE"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-dbsize.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-dbsize.cpp
@@ -38,59 +38,59 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DBSIZE", "[redis][command][DBSIZE]") {
     SECTION("Empty database") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DBSIZE"},
                 ":0\r\n"));
     }
 
     SECTION("Database with 1 key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DBSIZE"},
                 ":1\r\n"));
     }
 
     SECTION("Database with 1 key overwritten") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DBSIZE"},
                 ":1\r\n"));
     }
 
     SECTION("Database with 1 key deleted") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DEL", "a_key"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DBSIZE"},
                 ":0\r\n"));
     }
 
     SECTION("Database with 1 key flushed") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"FLUSHDB"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DBSIZE"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-decr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-decr.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,19 +40,16 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
     SECTION("Non-existing key") {
         SECTION("Decrease once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-1\r\n"));
         }
 
         SECTION("Decrease twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-2\r\n"));
         }
@@ -59,25 +58,21 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
     SECTION("Existing key") {
         SECTION("Simple negative number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Decrease once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         ":-6\r\n"));
             }
 
             SECTION("Decrease twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         ":-6\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         ":-7\r\n"));
             }
@@ -85,25 +80,21 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
 
         SECTION("Simple positive number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Decrease once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         ":4\r\n"));
             }
 
             SECTION("Decrease twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         ":4\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         ":3\r\n"));
             }
@@ -111,12 +102,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
 
         SECTION("Decrease INT64_MAX") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "9223372036854775807"},
                     "+OK\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECR", "a_key"},
                     ":9223372036854775806\r\n"));
         }
@@ -124,36 +113,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
         SECTION("Non numeric") {
             SECTION("String") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
@@ -161,17 +144,14 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
 
         SECTION("Overflow number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-9223372036854775807"},
                     "+OK\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-9223372036854775808\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECR", "a_key"},
                     "-ERR increment or decrement would overflow\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-decr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-decr.cpp
@@ -39,17 +39,17 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[redis][command][DECR]") {
     SECTION("Non-existing key") {
         SECTION("Decrease once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-1\r\n"));
         }
 
         SECTION("Decrease twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-2\r\n"));
         }
@@ -57,101 +57,101 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECR", "[red
 
     SECTION("Existing key") {
         SECTION("Simple negative number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Decrease once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         ":-6\r\n"));
             }
 
             SECTION("Decrease twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         ":-6\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         ":-7\r\n"));
             }
         }
 
         SECTION("Simple positive number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Decrease once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         ":4\r\n"));
             }
 
             SECTION("Decrease twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         ":4\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         ":3\r\n"));
             }
         }
 
         SECTION("Decrease INT64_MAX") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "9223372036854775807"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECR", "a_key"},
                     ":9223372036854775806\r\n"));
         }
 
         SECTION("Non numeric") {
             SECTION("String") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
         }
 
         SECTION("Overflow number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-9223372036854775807"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECR", "a_key"},
                     ":-9223372036854775808\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECR", "a_key"},
                     "-ERR increment or decrement would overflow\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-decrby.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-decrby.cpp
@@ -39,33 +39,33 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[redis][command][DECRBY]") {
     SECTION("Non-existing key") {
         SECTION("Decrease 1 - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECRBY", "a_key", "1"},
                     ":-1\r\n"));
         }
 
         SECTION("Decrease 1 - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECRBY", "a_key", "1"},
                     ":-1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECRBY", "a_key", "1"},
                     ":-2\r\n"));
         }
 
         SECTION("Decrease amount - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECRBY", "a_key", "5"},
                     ":-5\r\n"));
         }
 
         SECTION("Decrease amount - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECRBY", "a_key", "5"},
                     ":-5\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"DECRBY", "a_key", "6"},
                     ":-11\r\n"));
         }
@@ -73,76 +73,76 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
 
     SECTION("Existing key") {
         SECTION("Simple negative number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Decrease 1 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-6\r\n"));
             }
 
             SECTION("Decrease 1 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-6\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-7\r\n"));
             }
 
             SECTION("Decrease amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":-10\r\n"));
             }
 
             SECTION("Decrease amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":-10\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "6"},
                         ":-16\r\n"));
             }
         }
 
         SECTION("Simple positive number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Decrease 1 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":4\r\n"));
             }
 
             SECTION("Decrease 1 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":4\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":3\r\n"));
             }
 
             SECTION("Decrease amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":0\r\n"));
             }
 
             SECTION("Decrease amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "6"},
                         ":-6\r\n"));
             }
@@ -150,11 +150,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
 
         SECTION("Decrement INT64_MAX") {
             SECTION("One") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775807"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":9223372036854775806\r\n"));
             }
@@ -162,31 +162,31 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
 
         SECTION("Non numeric") {
             SECTION("String") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
@@ -194,25 +194,25 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
 
         SECTION("Overflow number") {
             SECTION("One") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775807"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-9223372036854775808\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR increment or decrement would overflow\r\n"));
             }
 
             SECTION("Amount") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775807"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"DECRBY", "a_key", "2"},
                         "-ERR increment or decrement would overflow\r\n"));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-decrby.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-decrby.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,38 +40,32 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
     SECTION("Non-existing key") {
         SECTION("Decrease 1 - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECRBY", "a_key", "1"},
                     ":-1\r\n"));
         }
 
         SECTION("Decrease 1 - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECRBY", "a_key", "1"},
                     ":-1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECRBY", "a_key", "1"},
                     ":-2\r\n"));
         }
 
         SECTION("Decrease amount - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECRBY", "a_key", "5"},
                     ":-5\r\n"));
         }
 
         SECTION("Decrease amount - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECRBY", "a_key", "5"},
                     ":-5\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"DECRBY", "a_key", "6"},
                     ":-11\r\n"));
         }
@@ -78,44 +74,37 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
     SECTION("Existing key") {
         SECTION("Simple negative number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Decrease 1 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-6\r\n"));
             }
 
             SECTION("Decrease 1 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-6\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-7\r\n"));
             }
 
             SECTION("Decrease amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":-10\r\n"));
             }
 
             SECTION("Decrease amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":-10\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "6"},
                         ":-16\r\n"));
             }
@@ -123,44 +112,37 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
 
         SECTION("Simple positive number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Decrease 1 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":4\r\n"));
             }
 
             SECTION("Decrease 1 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":4\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":3\r\n"));
             }
 
             SECTION("Decrease amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":0\r\n"));
             }
 
             SECTION("Decrease amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "5"},
                         ":0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "6"},
                         ":-6\r\n"));
             }
@@ -169,12 +151,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
         SECTION("Decrement INT64_MAX") {
             SECTION("One") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775807"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":9223372036854775806\r\n"));
             }
@@ -183,36 +163,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
         SECTION("Non numeric") {
             SECTION("String") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
@@ -221,29 +195,24 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DECRBY", "[r
         SECTION("Overflow number") {
             SECTION("One") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775807"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         ":-9223372036854775808\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "1"},
                         "-ERR increment or decrement would overflow\r\n"));
             }
 
             SECTION("Amount") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775807"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"DECRBY", "a_key", "2"},
                         "-ERR increment or decrement would overflow\r\n"));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-del.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-del.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,38 +39,32 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DEL", "[redis][command][DEL]") {
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DEL", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("Multiple key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DEL", "a_key", "b_key", "c_key"},
                 ":3\r\n"));
     }
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DEL", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Missing parameters - key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"DEL"},
                 "-ERR wrong number of arguments for 'del' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-del.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-del.cpp
@@ -38,33 +38,33 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - DEL", "[redis][command][DEL]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DEL", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("Multiple key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DEL", "a_key", "b_key", "c_key"},
                 ":3\r\n"));
     }
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DEL", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"DEL"},
                 "-ERR wrong number of arguments for 'del' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-exists.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-exists.cpp
@@ -38,37 +38,37 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXISTS", "[redis][command][EXISTS]") {
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXISTS", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("1 key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXISTS", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("2 keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXISTS", "a_key", "b_key"},
                 ":2\r\n"));
     }
 
     SECTION("Repeated key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXISTS", "a_key", "a_key", "a_key"},
                 ":3\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-exists.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-exists.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,43 +39,36 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXISTS", "[redis][command][EXISTS]") {
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXISTS", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("1 key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXISTS", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("2 keys") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXISTS", "a_key", "b_key"},
                 ":2\r\n"));
     }
 
     SECTION("Repeated key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXISTS", "a_key", "a_key", "a_key"},
                 ":3\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expire.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expire.cpp
@@ -38,117 +38,117 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIRE", "[redis][command][EXPIRE]") {
     SECTION("No key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expire.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expire.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,139 +39,116 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIRE", "[redis][command][EXPIRE]") {
     SECTION("No key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRE", "a_key", "5", "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expireat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expireat.cpp
@@ -42,117 +42,117 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIREAT", "
     snprintf(unixtime_plus_5s_str, sizeof(unixtime_plus_5s_str), "%ld", unixtime_plus_5);
 
     SECTION("No key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expireat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expireat.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -41,139 +43,116 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIREAT", "
 
     SECTION("No key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIREAT", "a_key", unixtime_plus_5s_str, "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expiretime.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,19 +39,16 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIRETIME", "[redis][command][EXPIRETIME]") {
     SECTION("No key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRETIME", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Existing key - no expiration") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRETIME", "a_key"},
                 ":-1\r\n"));
     }
@@ -60,12 +59,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIRETIME",
         snprintf(buffer, sizeof(buffer), ":%ld\r\n", unixtime_plus_5s);
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"EXPIRETIME", "a_key"},
                 buffer));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expiretime.cpp
@@ -56,9 +56,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIRETIME",
     SECTION("Existing key - expiration") {
         char buffer[32] = { 0 };
         size_t out_buffer_length = 0;
-        int64_t unixtime_response = 0;
+        int64_t unixtime_response;
         int64_t unixtime_plus_5s = (clock_realtime_coarse_int64_ms() / 1000) + 5;
-        size_t expected_length = snprintf(NULL, 0, ":%ld\r\n", unixtime_plus_5s);
+        size_t expected_length = snprintf(nullptr, 0, ":%ld\r\n", unixtime_plus_5s);
 
         REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
@@ -72,7 +72,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - EXPIRETIME",
                 expected_length,
                 send_recv_resp_command_calculate_multi_recv(expected_length)));
 
-        unixtime_response = strtoll(buffer + 1, NULL, 10);
+        unixtime_response = strtoll(buffer + 1, nullptr, 10);
 
         REQUIRE((unixtime_response == unixtime_plus_5s - 1 || unixtime_response == unixtime_plus_5s));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
@@ -29,6 +29,8 @@
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -51,16 +53,6 @@
 #include "test-modules-redis-command-fixture.hpp"
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
-
-template<typename ... Args>
-std::string string_format( const std::string& format, Args ... args ) {
-    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1;
-    if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
-    auto size = static_cast<size_t>( size_s );
-    std::unique_ptr<char[]> buf( new char[ size ] );
-    std::snprintf( buf.get(), size, format.c_str(), args ... );
-    return std::string( buf.get(), buf.get() + size - 1 );
-}
 
 TestModulesRedisCommandFixture::TestModulesRedisCommandFixture() {
     terminate_event_loop = false;
@@ -269,7 +261,6 @@ size_t TestModulesRedisCommandFixture::send_recv_resp_command_calculate_multi_re
 }
 
 bool TestModulesRedisCommandFixture::send_recv_resp_command_multi_recv(
-        int client_fd,
         const std::vector<std::string>& arguments,
         char *expected,
         size_t expected_length,
@@ -435,16 +426,14 @@ bool TestModulesRedisCommandFixture::send_recv_resp_command_multi_recv(
 }
 
 bool TestModulesRedisCommandFixture::send_recv_resp_command(
-        int client_fd,
         const std::vector<std::string>& arguments,
         char *expected,
         size_t expected_length) {
-    return send_recv_resp_command_multi_recv(client_fd, arguments, expected, expected_length, 1);
+    return send_recv_resp_command_multi_recv(arguments, expected, expected_length, 1);
 }
 
 bool TestModulesRedisCommandFixture::send_recv_resp_command_text(
-        int client_fd,
         const std::vector<std::string>& arguments,
         char *expected) {
-    return send_recv_resp_command(client_fd, arguments, expected, strlen(expected));
+    return send_recv_resp_command(arguments, expected, strlen(expected));
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.hpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.hpp
@@ -57,20 +57,17 @@ protected:
             size_t expected_length);
 
     bool send_recv_resp_command_multi_recv(
-            int client_fd,
             const std::vector<std::string>& arguments,
             char *expected,
             size_t expected_length,
             int max_recv_count);
 
     bool send_recv_resp_command(
-            int client_fd,
             const std::vector<std::string>& arguments,
             char *expected,
             size_t expected_length);
 
     bool send_recv_resp_command_text(
-            int client_fd,
             const std::vector<std::string>& arguments,
             char *expected);
 };

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.hpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.hpp
@@ -6,9 +6,6 @@
     } while((WORKER_CONTEXT)->running == !(RUNNING)); \
 }
 
-template<typename ... Args>
-std::string string_format( const std::string& format, Args ... args );
-
 class TestModulesRedisCommandFixture {
 public:
     TestModulesRedisCommandFixture();
@@ -18,19 +15,19 @@ protected:
     volatile bool terminate_event_loop;
     struct sockaddr_in address = {0};
 
-    size_t buffer_send_data_len;
+    size_t buffer_send_data_len{};
     char buffer_send[16 * 1024] = {0};
     char buffer_recv[16 * 1024] = {0};
     int recv_packet_size = 32 * 1024;
 
-    config_module_network_binding_t config_module_network_binding;
-    config_module_redis_t config_module_redis;
-    config_module_network_timeout_t config_module_network_timeout;
-    config_module_network_t config_module_network;
-    config_module_t config_module;
-    config_network_t config_network;
-    config_database_t config_database;
-    config_t config;
+    config_module_network_binding_t config_module_network_binding{};
+    config_module_redis_t config_module_redis{};
+    config_module_network_timeout_t config_module_network_timeout{};
+    config_module_network_t config_module_network{};
+    config_module_t config_module{};
+    config_network_t config_network{};
+    config_database_t config_database{};
+    config_t config{};
 
     worker_context_t *worker_context;
     uint32_t workers_count;
@@ -40,12 +37,12 @@ protected:
 
     program_context_t *program_context;
 
-    size_t build_resp_command(
+    static size_t build_resp_command(
             char *buffer,
             size_t buffer_size,
             const std::vector<std::string>& arguments);
 
-    size_t string_replace(
+    static size_t string_replace(
             char *input,
             size_t input_len,
             char *output,
@@ -54,20 +51,35 @@ protected:
             ...);
 
     size_t send_recv_resp_command_calculate_multi_recv(
-            size_t expected_length);
+            size_t expected_length) const;
 
     bool send_recv_resp_command_multi_recv(
+            const std::vector<std::string>& arguments,
+            char *buffer_recv,
+            size_t buffer_recv_length,
+            size_t *out_buffer_recv_length,
+            int max_recv_count,
+            size_t expected_len) const;
+
+    bool send_recv_resp_command(
+            const std::vector<std::string>& arguments,
+            char *buffer_recv,
+            size_t buffer_recv_length,
+            size_t *out_buffer_recv_length,
+            size_t expected_len);
+
+    bool send_recv_resp_command_multi_recv_and_validate_recv(
             const std::vector<std::string>& arguments,
             char *expected,
             size_t expected_length,
             int max_recv_count);
 
-    bool send_recv_resp_command(
+    bool send_recv_resp_command_and_validate_recv(
             const std::vector<std::string>& arguments,
             char *expected,
             size_t expected_length);
 
-    bool send_recv_resp_command_text(
+    bool send_recv_resp_command_text_and_validate_recv(
             const std::vector<std::string>& arguments,
             char *expected);
 };

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-generic.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-generic.cpp
@@ -42,7 +42,7 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - generic tests", "[redis][command][generic]") {
     SECTION("Unknown / unsupported command") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"UNKNOWN COMMAND"},
                 "-ERR unknown command `UNKNOWN COMMAND` with `0` args\r\n"));
     }
@@ -61,7 +61,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - generic test
         config_module_network_timeout.read_ms = 1000;
 
         // Send a NOP command to pick up the new timeout
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_value"},
                 "$-1\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-generic.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-generic.cpp
@@ -20,6 +20,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -41,7 +43,6 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - generic tests", "[redis][command][generic]") {
     SECTION("Unknown / unsupported command") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"UNKNOWN COMMAND"},
                 "-ERR unknown command `UNKNOWN COMMAND` with `0` args\r\n"));
     }
@@ -61,7 +62,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - generic test
 
         // Send a NOP command to pick up the new timeout
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_value"},
                 "$-1\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-get.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-get.cpp
@@ -18,6 +18,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -39,12 +41,10 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redis][command][GET]") {
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
@@ -86,7 +86,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redi
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
@@ -126,12 +125,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redi
                 long_value);
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_multi_recv(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 expected_response,
                 expected_response_length,
@@ -142,7 +139,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redi
 
     SECTION("Missing parameters - key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET"},
                 "-ERR wrong number of arguments for 'get' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-get.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-get.cpp
@@ -40,11 +40,11 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redis][command][GET]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
@@ -85,7 +85,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redi
     }
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
@@ -124,11 +124,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redi
                 (int) long_value_length,
                 long_value);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_multi_recv(
+        REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 expected_response,
                 expected_response_length,
@@ -138,7 +138,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GET", "[redi
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET"},
                 "-ERR wrong number of arguments for 'get' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getdel.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getdel.cpp
@@ -38,21 +38,21 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETDEL", "[redis][command][GETDEL]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GETDEL", "a_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GETDEL", "a_key"},
                 "$-1\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getdel.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getdel.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,24 +39,20 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETDEL", "[redis][command][GETDEL]") {
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GETDEL", "a_key"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GETDEL", "a_key"},
                 "$-1\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getex.cpp
@@ -40,12 +40,12 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[redis][command][GETEX]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("No expiration") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
@@ -53,18 +53,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[re
         SECTION("Expire in 500ms") {
             config_module_network_timeout.read_ms = 1000;
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "PX", "500"},
                     "$7\r\nb_value\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
 
             // Wait for 600 ms and try to get the value after the expiration
             usleep((500 + 100) * 1000);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$-1\r\n"));
 
@@ -75,18 +75,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[re
         SECTION("Expire in 1s") {
             config_module_network_timeout.read_ms = 2000;
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "EX", "1"},
                     "$7\r\nb_value\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
 
             // Wait for 1100 ms and try to get the value after the expiration
             usleep((1000 + 100) * 1000);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$-1\r\n"));
 
@@ -95,25 +95,25 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[re
         }
 
         SECTION("Invalid EX") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "EX", "0"},
                     "-ERR invalid expire time in 'getex' command\r\n"));
         }
 
         SECTION("Invalid PX") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "PX", "0"},
                     "-ERR invalid expire time in 'getex' command\r\n"));
         }
 
         SECTION("Invalid EXAT") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "EXAT", "0"},
                     "-ERR invalid expire time in 'getex' command\r\n"));
         }
 
         SECTION("Invalid PXAT") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "PXAT", "0"},
                     "-ERR invalid expire time in 'getex' command\r\n"));
         }
@@ -121,31 +121,31 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[re
 
     SECTION("Non-existing key") {
         SECTION("No expiration") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key"},
                     "$-1\r\n"));
         }
 
         SECTION("Invalid EX") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "EX", "0"},
                     "$-1\r\n"));
         }
 
         SECTION("Invalid PX") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "PX", "0"},
                     "$-1\r\n"));
         }
 
         SECTION("Invalid EXAT") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "EXAT", "0"},
                     "$-1\r\n"));
         }
 
         SECTION("Invalid PXAT") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETEX", "a_key", "PXAT", "0"},
                     "$-1\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getrange.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getrange.cpp
@@ -40,60 +40,60 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "[redis][command][GETRANGE]") {
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Existing key - short value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("all") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "0", "6"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("first char") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "0", "0"},
                     "$1\r\nb\r\n"));
         }
 
         SECTION("last char") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "6", "6"},
                     "$1\r\ne\r\n"));
         }
 
         SECTION("last char - negative start negative end") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "-1", "-1"},
                     "$1\r\ne\r\n"));
         }
 
         SECTION("from the last fourth char to the second from the last") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "-4", "-2"},
                     "$3\r\nalu\r\n"));
         }
 
         SECTION("end before start") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "5", "3"},
                     "$0\r\n\r\n"));
         }
 
         SECTION("start after end") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "7", "15"},
                     "$0\r\n\r\n"));
         }
 
         SECTION("start before end, length after end") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "3", "15"},
                     "$4\r\nalue\r\n"));
         }
@@ -121,7 +121,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
         char end[32] = { 0 };
         snprintf(end, sizeof(end), "%lu", long_value_length - 1);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
@@ -143,7 +143,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
                     (int) long_value_length,
                     long_value);
 
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "0", end},
                     expected_response,
                     expected_response_length,
@@ -153,9 +153,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
         SECTION("first char") {
             snprintf((char*)expected_response_static, sizeof(expected_response_static), "$1\r\n%c\r\n", long_value[0]);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "0", "0"},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("last char") {
@@ -165,9 +165,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
                     "$1\r\n%c\r\n",
                     long_value[long_value_length - 1]);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", end, end},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("last char - negative start negative end") {
@@ -177,9 +177,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
                     "$1\r\n%c\r\n",
                     long_value[long_value_length - 1]);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "-1", "-1"},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("from the last fourth char to the second from the last") {
@@ -190,9 +190,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
                     3,
                     long_value + long_value_length - 4);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", "-4", "-2"},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("end before start") {
@@ -201,7 +201,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
             char end1[32] = { 0 };
             snprintf(end1, sizeof(end1), "%lu", long_value_length - 100);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", start1, end1},
                     "$0\r\n\r\n"));
         }
@@ -212,7 +212,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
             char end1[32] = { 0 };
             snprintf(end1, sizeof(end1), "%lu", long_value_length + 100);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", start1, end1},
                     "$0\r\n\r\n"));
         }
@@ -229,9 +229,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
                     "$4\r\n%s\r\n",
                     long_value + long_value_length - 4);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", start1, end1},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("50 chars after first chunk + 50") {
@@ -259,9 +259,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
                     (int)(end1_int - start1_int + 1),
                     long_value + start1_int);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GETRANGE", "a_key", start1, end1},
-                    (char*)expected_response));
+                    (char *) expected_response));
         }
 
         if (expected_response) {
@@ -270,7 +270,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETRANGE", "
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET"},
                 "-ERR wrong number of arguments for 'get' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getset.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getset.cpp
@@ -38,25 +38,25 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETSET", "[redis][command][GETSET]") {
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GETSET", "a_key", "b_value"},
                 "$-1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GETSET", "a_key", "z_value"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nz_value\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getset.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getset.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,29 +39,24 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETSET", "[redis][command][GETSET]") {
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GETSET", "a_key", "b_value"},
                 "$-1\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GETSET", "a_key", "z_value"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nz_value\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-hello.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-hello.cpp
@@ -18,6 +18,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incr.cpp
@@ -39,17 +39,17 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[redis][command][INCR]") {
     SECTION("Non-existing key") {
         SECTION("Increase once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCR", "a_key"},
                     ":1\r\n"));
         }
 
         SECTION("Increase twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCR", "a_key"},
                     ":1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCR", "a_key"},
                     ":2\r\n"));
         }
@@ -57,101 +57,101 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
 
     SECTION("Existing key") {
         SECTION("Simple positive number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Increase once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         ":6\r\n"));
             }
 
             SECTION("Increase twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         ":6\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         ":7\r\n"));
             }
         }
 
         SECTION("Simple negative number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Increase once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         ":-4\r\n"));
             }
 
             SECTION("Increase twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         ":-4\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         ":-3\r\n"));
             }
         }
 
         SECTION("Increment INT64_MIN") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-9223372036854775808"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCR", "a_key"},
                     ":-9223372036854775807\r\n"));
         }
 
         SECTION("Non numeric") {
             SECTION("String") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
         }
 
         SECTION("Overflow number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "9223372036854775806"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCR", "a_key"},
                     ":9223372036854775807\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCR", "a_key"},
                     "-ERR increment or decrement would overflow\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incr.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,19 +40,16 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
     SECTION("Non-existing key") {
         SECTION("Increase once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCR", "a_key"},
                     ":1\r\n"));
         }
 
         SECTION("Increase twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCR", "a_key"},
                     ":1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCR", "a_key"},
                     ":2\r\n"));
         }
@@ -59,25 +58,21 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
     SECTION("Existing key") {
         SECTION("Simple positive number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Increase once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         ":6\r\n"));
             }
 
             SECTION("Increase twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         ":6\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         ":7\r\n"));
             }
@@ -85,25 +80,21 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
 
         SECTION("Simple negative number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Increase once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         ":-4\r\n"));
             }
 
             SECTION("Increase twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         ":-4\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         ":-3\r\n"));
             }
@@ -111,12 +102,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
 
         SECTION("Increment INT64_MIN") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-9223372036854775808"},
                     "+OK\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCR", "a_key"},
                     ":-9223372036854775807\r\n"));
         }
@@ -124,36 +113,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
         SECTION("Non numeric") {
             SECTION("String") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCR", "a_key"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
@@ -161,17 +144,14 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCR", "[red
 
         SECTION("Overflow number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "9223372036854775806"},
                     "+OK\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCR", "a_key"},
                     ":9223372036854775807\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCR", "a_key"},
                     "-ERR increment or decrement would overflow\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrby.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrby.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,38 +40,32 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
     SECTION("Non-existing key") {
         SECTION("Increase 1 - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBY", "a_key", "1"},
                     ":1\r\n"));
         }
 
         SECTION("Increase 1 - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBY", "a_key", "1"},
                     ":1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBY", "a_key", "1"},
                     ":2\r\n"));
         }
 
         SECTION("Increase amount - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBY", "a_key", "5"},
                     ":5\r\n"));
         }
 
         SECTION("Increase amount - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBY", "a_key", "5"},
                     ":5\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBY", "a_key", "6"},
                     ":11\r\n"));
         }
@@ -78,44 +74,37 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
     SECTION("Existing key") {
         SECTION("Simple positive number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":6\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":6\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":7\r\n"));
             }
 
             SECTION("Increase amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":10\r\n"));
             }
 
             SECTION("Increase amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":10\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "6"},
                         ":16\r\n"));
             }
@@ -123,44 +112,37 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
 
         SECTION("Simple negative number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-4\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-4\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-3\r\n"));
             }
 
             SECTION("Increase amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":0\r\n"));
             }
 
             SECTION("Increase amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "6"},
                         ":6\r\n"));
             }
@@ -169,12 +151,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
         SECTION("Increment INT64_MIN") {
             SECTION("One") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775808"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-9223372036854775807\r\n"));
             }
@@ -183,36 +163,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
         SECTION("Non numeric") {
             SECTION("String") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
@@ -221,29 +195,24 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
         SECTION("Overflow number") {
             SECTION("One") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775806"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":9223372036854775807\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR increment or decrement would overflow\r\n"));
             }
 
             SECTION("Amount") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "9223372036854775806"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBY", "a_key", "2"},
                         "-ERR increment or decrement would overflow\r\n"));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrby.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrby.cpp
@@ -39,33 +39,33 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[redis][command][INCRBY]") {
     SECTION("Non-existing key") {
         SECTION("Increase 1 - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBY", "a_key", "1"},
                     ":1\r\n"));
         }
 
         SECTION("Increase 1 - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBY", "a_key", "1"},
                     ":1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBY", "a_key", "1"},
                     ":2\r\n"));
         }
 
         SECTION("Increase amount - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBY", "a_key", "5"},
                     ":5\r\n"));
         }
 
         SECTION("Increase amount - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBY", "a_key", "5"},
                     ":5\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBY", "a_key", "6"},
                     ":11\r\n"));
         }
@@ -73,76 +73,76 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
 
     SECTION("Existing key") {
         SECTION("Simple positive number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":6\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":6\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":7\r\n"));
             }
 
             SECTION("Increase amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":10\r\n"));
             }
 
             SECTION("Increase amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":10\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "6"},
                         ":16\r\n"));
             }
         }
 
         SECTION("Simple negative number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-4\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-4\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-3\r\n"));
             }
 
             SECTION("Increase amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":0\r\n"));
             }
 
             SECTION("Increase amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "5"},
                         ":0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "6"},
                         ":6\r\n"));
             }
@@ -150,11 +150,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
 
         SECTION("Increment INT64_MIN") {
             SECTION("One") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775808"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":-9223372036854775807\r\n"));
             }
@@ -162,31 +162,31 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
 
         SECTION("Non numeric") {
             SECTION("String") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775808"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "-9223372036854775809"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR value is not an integer or out of range\r\n"));
             }
@@ -194,25 +194,25 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBY", "[r
 
         SECTION("Overflow number") {
             SECTION("One") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775806"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         ":9223372036854775807\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "1"},
                         "-ERR increment or decrement would overflow\r\n"));
             }
 
             SECTION("Amount") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "9223372036854775806"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBY", "a_key", "2"},
                         "-ERR increment or decrement would overflow\r\n"));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrbyfloat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrbyfloat.cpp
@@ -41,81 +41,81 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT", "[redis][command][INCRBYFLOAT]") {
     SECTION("Non-existing key") {
         SECTION("Increase 1 - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                     "$1\r\n1\r\n"));
         }
 
         SECTION("Increase 1 - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                     "$1\r\n1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                     "$1\r\n2\r\n"));
         }
 
         SECTION("Increase 1.5 - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                     "$3\r\n1.5\r\n"));
         }
 
         SECTION("Increase 1.5 - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                     "$3\r\n1.5\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                     "$1\r\n3\r\n"));
         }
 
         SECTION("Increase 0.00001 - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "0.00001"},
                     "$7\r\n0.00001\r\n"));
         }
 
         SECTION("Increase 0.00001 - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "0.00001"},
                     "$7\r\n0.00001\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "0.00001"},
                     "$7\r\n0.00002\r\n"));
         }
 
         SECTION("Increase integer amount - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                     "$1\r\n5\r\n"));
         }
 
         SECTION("Increase integer amount - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                     "$1\r\n5\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "6"},
                     "$2\r\n11\r\n"));
         }
 
         SECTION("Increase decimal amount - once") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                     "$3\r\n5.5\r\n"));
         }
 
         SECTION("Increase decimal amount - twice") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                     "$3\r\n5.5\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "6.4"},
                     "$4\r\n11.9\r\n"));
         }
@@ -123,176 +123,176 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
 
     SECTION("Existing key") {
         SECTION("Simple positive number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$1\r\n6\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$1\r\n6\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$1\r\n7\r\n"));
             }
 
             SECTION("Increase 1.5 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$3\r\n6.5\r\n"));
             }
 
             SECTION("Increase 1.5 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$3\r\n6.5\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$1\r\n8\r\n"));
             }
 
             SECTION("Increase integer amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$2\r\n10\r\n"));
             }
 
             SECTION("Increase integer amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$2\r\n10\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6"},
                         "$2\r\n16\r\n"));
             }
 
             SECTION("Increase decimal amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$4\r\n10.5\r\n"));
             }
 
             SECTION("Increase decimal amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$4\r\n10.5\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6.4"},
                         "$4\r\n16.9\r\n"));
             }
         }
 
         SECTION("Simple negative number") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$2\r\n-4\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$2\r\n-4\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$2\r\n-3\r\n"));
             }
 
             SECTION("Increase 1.5 - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$4\r\n-3.5\r\n"));
             }
 
             SECTION("Increase 1.5 - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$4\r\n-3.5\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$2\r\n-2\r\n"));
             }
 
             SECTION("Increase integer amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$1\r\n0\r\n"));
             }
 
             SECTION("Increase integer amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$1\r\n0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6"},
                         "$1\r\n6\r\n"));
             }
 
             SECTION("Increase decimal amount - once") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$3\r\n0.5\r\n"));
             }
 
             SECTION("Increase decimal amount - twice") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$3\r\n0.5\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6.4"},
                         "$3\r\n6.9\r\n"));
             }
         }
 
         SECTION("Increment INT64_MIN") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "-9223372036854775808"},
                     "+OK\r\n"));
 
             SECTION("Integer") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$20\r\n-9223372036854775807\r\n"));
             }
 
             SECTION("Decimal") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.6"},
                         "$22\r\n-9223372036854775806.5\r\n"));
             }
         }
 
         SECTION("Decrement INT64_MAX") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "9223372036854775807"},
                     "+OK\r\n"));
 
             SECTION("Integer") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1"},
                         "$19\r\n9223372036854775806\r\n"));
             }
 
             SECTION("Decimal") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1.6"},
                         "$21\r\n9223372036854775805.5\r\n"));
             }
@@ -305,31 +305,31 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
             snprintf(huge_val_min, sizeof(huge_val_min), "%Lf", -HUGE_VALL);
 
             SECTION("String") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "-ERR value is not a valid float\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", huge_val_max},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "-ERR increment would produce NaN or Infinity\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", huge_val_min},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "-ERR increment would produce NaN or Infinity\r\n"));
             }
@@ -359,61 +359,61 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
                     buffer_ldbl_min);
 
             SECTION("Increment by one") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_max},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         expected_response_ldbl_max));
             }
 
             SECTION("Increment by integer amount") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_max},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "2"},
                         expected_response_ldbl_max));
             }
 
             SECTION("Increment by decimal amount") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_max},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         expected_response_ldbl_max));
             }
 
             SECTION("Decrement by one") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_min},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1"},
                         expected_response_ldbl_min));
             }
 
             SECTION("Decrement by integer amount") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_min},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-2"},
                         expected_response_ldbl_min));
             }
 
             SECTION("Decrement by decimal amount") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_min},
                         "+OK\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1.5"},
                         expected_response_ldbl_min));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrbyfloat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrbyfloat.cpp
@@ -18,6 +18,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,95 +42,80 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
     SECTION("Non-existing key") {
         SECTION("Increase 1 - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                     "$1\r\n1\r\n"));
         }
 
         SECTION("Increase 1 - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                     "$1\r\n1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                     "$1\r\n2\r\n"));
         }
 
         SECTION("Increase 1.5 - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                     "$3\r\n1.5\r\n"));
         }
 
         SECTION("Increase 1.5 - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                     "$3\r\n1.5\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                     "$1\r\n3\r\n"));
         }
 
         SECTION("Increase 0.00001 - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "0.00001"},
                     "$7\r\n0.00001\r\n"));
         }
 
         SECTION("Increase 0.00001 - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "0.00001"},
                     "$7\r\n0.00001\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "0.00001"},
                     "$7\r\n0.00002\r\n"));
         }
 
         SECTION("Increase integer amount - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                     "$1\r\n5\r\n"));
         }
 
         SECTION("Increase integer amount - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                     "$1\r\n5\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "6"},
                     "$2\r\n11\r\n"));
         }
 
         SECTION("Increase decimal amount - once") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                     "$3\r\n5.5\r\n"));
         }
 
         SECTION("Increase decimal amount - twice") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                     "$3\r\n5.5\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"INCRBYFLOAT", "a_key", "6.4"},
                     "$4\r\n11.9\r\n"));
         }
@@ -137,82 +124,69 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
     SECTION("Existing key") {
         SECTION("Simple positive number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$1\r\n6\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$1\r\n6\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$1\r\n7\r\n"));
             }
 
             SECTION("Increase 1.5 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$3\r\n6.5\r\n"));
             }
 
             SECTION("Increase 1.5 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$3\r\n6.5\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$1\r\n8\r\n"));
             }
 
             SECTION("Increase integer amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$2\r\n10\r\n"));
             }
 
             SECTION("Increase integer amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$2\r\n10\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6"},
                         "$2\r\n16\r\n"));
             }
 
             SECTION("Increase decimal amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$4\r\n10.5\r\n"));
             }
 
             SECTION("Increase decimal amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$4\r\n10.5\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6.4"},
                         "$4\r\n16.9\r\n"));
             }
@@ -220,82 +194,69 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
 
         SECTION("Simple negative number") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-5"},
                     "+OK\r\n"));
 
             SECTION("Increase 1 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$2\r\n-4\r\n"));
             }
 
             SECTION("Increase 1 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$2\r\n-4\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$2\r\n-3\r\n"));
             }
 
             SECTION("Increase 1.5 - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$4\r\n-3.5\r\n"));
             }
 
             SECTION("Increase 1.5 - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$4\r\n-3.5\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         "$2\r\n-2\r\n"));
             }
 
             SECTION("Increase integer amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$1\r\n0\r\n"));
             }
 
             SECTION("Increase integer amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5"},
                         "$1\r\n0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6"},
                         "$1\r\n6\r\n"));
             }
 
             SECTION("Increase decimal amount - once") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$3\r\n0.5\r\n"));
             }
 
             SECTION("Increase decimal amount - twice") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "5.5"},
                         "$3\r\n0.5\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "6.4"},
                         "$3\r\n6.9\r\n"));
             }
@@ -303,20 +264,17 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
 
         SECTION("Increment INT64_MIN") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "-9223372036854775808"},
                     "+OK\r\n"));
 
             SECTION("Integer") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "$20\r\n-9223372036854775807\r\n"));
             }
 
             SECTION("Decimal") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.6"},
                         "$22\r\n-9223372036854775806.5\r\n"));
             }
@@ -324,20 +282,17 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
 
         SECTION("Decrement INT64_MAX") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "9223372036854775807"},
                     "+OK\r\n"));
 
             SECTION("Integer") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1"},
                         "$19\r\n9223372036854775806\r\n"));
             }
 
             SECTION("Decimal") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1.6"},
                         "$21\r\n9223372036854775805.5\r\n"));
             }
@@ -351,36 +306,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
 
             SECTION("String") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", "b_value"},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "-ERR value is not a valid float\r\n"));
             }
 
             SECTION("Greater than INT64_MAX") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", huge_val_max},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "-ERR increment would produce NaN or Infinity\r\n"));
             }
 
             SECTION("Smaller than INT64_MIN") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", huge_val_min},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         "-ERR increment would produce NaN or Infinity\r\n"));
             }
@@ -411,72 +360,60 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - INCRBYFLOAT"
 
             SECTION("Increment by one") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_max},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1"},
                         expected_response_ldbl_max));
             }
 
             SECTION("Increment by integer amount") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_max},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "2"},
                         expected_response_ldbl_max));
             }
 
             SECTION("Increment by decimal amount") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_max},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "1.5"},
                         expected_response_ldbl_max));
             }
 
             SECTION("Decrement by one") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_min},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1"},
                         expected_response_ldbl_min));
             }
 
             SECTION("Decrement by integer amount") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_min},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-2"},
                         expected_response_ldbl_min));
             }
 
             SECTION("Decrement by decimal amount") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SET", "a_key", buffer_ldbl_min},
                         "+OK\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"INCRBYFLOAT", "a_key", "-1.5"},
                         expected_response_ldbl_min));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-keys.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-keys.cpp
@@ -38,61 +38,61 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - KEYS", "[redis][command][KEYS]") {
     SECTION("Empty database") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"KEYS", "nomatch"},
                 "*0\r\n"));
     }
 
     SECTION("One key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("No match") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "nomatch"},
                     "*0\r\n"));
         }
 
         SECTION("Match - simple") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a_key"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - star") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a_*"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - question mark") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a_???"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - backslash") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a\\_key"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - brackets") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "[a-z]_key"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - everything") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "*"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
     }
 
     SECTION("Multiple keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{
                         "MSET",
                         "a_key", "a_value",
@@ -103,49 +103,49 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - KEYS", "[red
                 "+OK\r\n"));
 
         SECTION("No match") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "nomatch"},
                     "*0\r\n"));
         }
 
         SECTION("Match - simple") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a_key"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - star - 1 result") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a_*"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - star - multiple results") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "*key"},
                     "*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
         }
 
         SECTION("Match - question mark") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a_???"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - backslash") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "a\\_key"},
                     "*1\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - brackets") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "[a-z]_key"},
                     "*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
         }
 
         SECTION("Match - everything") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "*"},
                     "*5\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-lcs.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-lcs.cpp
@@ -38,79 +38,79 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - LCS", "[redis][command][LCS]") {
     SECTION("Missing keys - String") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$0\r\n\r\n"));
     }
 
     SECTION("Missing keys - Length") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":0\r\n"));
     }
 
     SECTION("Empty keys - String") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "", "b_key", ""},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$0\r\n\r\n"));
     }
 
     SECTION("Empty keys - Length") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "", "b_key", ""},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":0\r\n"));
     }
 
     SECTION("No common substrings - String") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "qwertyuiop", "b_key", "asdfghjkl"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$0\r\n\r\n"));
     }
 
     SECTION("No common substrings - Length") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "qwertyuiop", "b_key", "asdfghjkl"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":0\r\n"));
     }
 
     SECTION("One common substring - String") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$5\r\nvalue\r\n"));
     }
 
     SECTION("One common substring - String") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":5\r\n"));
     }
 
     SECTION("Multiple common substring - String") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{
                         "MSET",
                         "a_key",
@@ -119,13 +119,13 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - LCS", "[redi
                         "another very string but long"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$13\r\na very string\r\n"));
     }
 
     SECTION("Multiple common substring - Length") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{
                         "MSET",
                         "a_key",
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - LCS", "[redi
                         "another very string but long"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":13\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-lcs.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-lcs.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,93 +39,78 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - LCS", "[redis][command][LCS]") {
     SECTION("Missing keys - String") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$0\r\n\r\n"));
     }
 
     SECTION("Missing keys - Length") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":0\r\n"));
     }
 
     SECTION("Empty keys - String") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "", "b_key", ""},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$0\r\n\r\n"));
     }
 
     SECTION("Empty keys - Length") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "", "b_key", ""},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":0\r\n"));
     }
 
     SECTION("No common substrings - String") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "qwertyuiop", "b_key", "asdfghjkl"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$0\r\n\r\n"));
     }
 
     SECTION("No common substrings - Length") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "qwertyuiop", "b_key", "asdfghjkl"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":0\r\n"));
     }
 
     SECTION("One common substring - String") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$5\r\nvalue\r\n"));
     }
 
     SECTION("One common substring - String") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":5\r\n"));
     }
 
     SECTION("Multiple common substring - String") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{
                         "MSET",
                         "a_key",
@@ -133,14 +120,12 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - LCS", "[redi
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key"},
                 "$13\r\na very string\r\n"));
     }
 
     SECTION("Multiple common substring - Length") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{
                         "MSET",
                         "a_key",
@@ -150,7 +135,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - LCS", "[redi
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"LCS", "a_key", "b_key", "LEN"},
                 ":13\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-mget.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-mget.cpp
@@ -41,11 +41,11 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[redis][command][MGET]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MGET", "a_key"},
                 "*1\r\n$7\r\nb_value\r\n"));
     }
@@ -86,27 +86,27 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[red
     }
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MGET", "a_key"},
                 "*1\r\n$-1\r\n"));
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MGET"},
                 "-ERR wrong number of arguments for 'mget' command\r\n"));
     }
 
     SECTION("Fetch 2 keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key_1", "b_value_1"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key_2", "b_value_2"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MGET", "a_key_1", "a_key_2"},
                 "*2\r\n$9\r\nb_value_1\r\n$9\r\nb_value_2\r\n"));
     }
@@ -123,7 +123,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[red
             snprintf(buffer1, sizeof(buffer1), "a_key_%05d", key_index);
             snprintf(buffer2, sizeof(buffer2), "b_value_%05d", key_index);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", buffer1, buffer2},
                     "+OK\r\n"));
         }
@@ -147,7 +147,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[red
                     key_index);
         }
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 arguments,
                 buffer_recv_cmp));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-mget.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-mget.cpp
@@ -19,6 +19,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,12 +42,10 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[redis][command][MGET]") {
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MGET", "a_key"},
                 "*1\r\n$7\r\nb_value\r\n"));
     }
@@ -87,31 +87,26 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[red
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MGET", "a_key"},
                 "*1\r\n$-1\r\n"));
     }
 
     SECTION("Missing parameters - key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MGET"},
                 "-ERR wrong number of arguments for 'mget' command\r\n"));
     }
 
     SECTION("Fetch 2 keys") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key_1", "b_value_1"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key_2", "b_value_2"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MGET", "a_key_1", "a_key_2"},
                 "*2\r\n$9\r\nb_value_1\r\n$9\r\nb_value_2\r\n"));
     }
@@ -129,7 +124,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[red
             snprintf(buffer2, sizeof(buffer2), "b_value_%05d", key_index);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", buffer1, buffer2},
                     "+OK\r\n"));
         }
@@ -154,7 +148,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MGET", "[red
         }
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 arguments,
                 buffer_recv_cmp));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-mset.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-mset.cpp
@@ -38,25 +38,25 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSET", "[redis][command][MSET]") {
     SECTION("1 key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("2 keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
     }
@@ -76,7 +76,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSET", "[red
             arguments.push_back(buffer2);
         }
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 arguments,
                 "+OK\r\n"));
 
@@ -86,20 +86,20 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSET", "[red
             snprintf(buffer1, sizeof(buffer1), "a_key_%05d", key_index);
             snprintf(expected_response, sizeof(expected_response), "$13\r\nb_value_%05d\r\n", key_index);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", buffer1},
                     expected_response));
         }
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET"},
                 "-ERR wrong number of arguments for 'mset' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key"},
                 "-ERR wrong number of arguments for 'mset' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-msetnx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-msetnx.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,100 +39,93 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSETNX", "[redis][command][MSETNX]") {
     SECTION("1 key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSETNX", "a_key", "b_value"},
                 ":1\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("2 keys") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSETNX", "a_key", "b_value", "b_key", "value_z"},
                 ":1\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
     }
 
     SECTION("Existing keys") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSETNX", "a_key", "b_value", "b_key", "value_z"},
                 ":1\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSETNX", "b_key", "another_value", "c_key", "value_not_being_set"},
                 ":0\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "c_key"},
                 "$-1\r\n"));
     }
 
-        // TODO: need to fix rmw multi key transactions first
-//        SECTION("Set 64 keys") {
-//            int key_count = 64;
-//            std::vector<std::string> arguments = std::vector<std::string>();
-//
-//            arguments.emplace_back("MSETNX");
-//            for(int key_index = 0; key_index < key_count; key_index++) {
-//                arguments.push_back(string_format("a_key_%05d", key_index));
-//                arguments.push_back(string_format("b_value_%05d", key_index));
-//            }
-//
-//            REQUIRE(send_recv_resp_command_text(
-//                    client_fd,
-//                    arguments,
-//                    ":1\r\n"));
-//
-//            for(int key_index = 0; key_index < key_count; key_index++) {
-//                char expected_response[32] = { 0 };
-//                REQUIRE(send_recv_resp_command_text(
-//                        client_fd,
-//                        std::vector<std::string>{ "GET", string_format("a_key_%05d", key_index) },
-//                        (char*)(string_format("$13\r\nb_value_%05d\r\n", key_index).c_str())));
-//            }
-//        }
+    SECTION("Set 64 keys") {
+        int key_count = 64;
+        std::vector<std::string> arguments = std::vector<std::string>();
+
+        arguments.emplace_back("MSETNX");
+        for(int key_index = 0; key_index < key_count; key_index++) {
+            char buffer1[32] = { 0 };
+            char buffer2[32] = { 0 };
+            snprintf(buffer1, sizeof(buffer1), "a_key_%05d", key_index);
+            snprintf(buffer2, sizeof(buffer2), "b_value_%05d", key_index);
+
+            arguments.push_back(buffer1);
+            arguments.push_back(buffer2);
+        }
+
+        REQUIRE(send_recv_resp_command_text(
+                arguments,
+                ":1\r\n"));
+
+        for(int key_index = 0; key_index < key_count; key_index++) {
+            char buffer1[32] = { 0 };
+            char expected_response[64] = { 0 };
+            snprintf(buffer1, sizeof(buffer1), "a_key_%05d", key_index);
+            snprintf(expected_response, sizeof(expected_response), "$13\r\nb_value_%05d\r\n", key_index);
+
+            REQUIRE(send_recv_resp_command_text(
+                    std::vector<std::string>{"GET", buffer1},
+                    expected_response));
+        }
+    }
 
     SECTION("Missing parameters - key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSETNX"},
                 "-ERR wrong number of arguments for 'msetnx' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSETNX", "a_key"},
                 "-ERR wrong number of arguments for 'msetnx' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-msetnx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-msetnx.cpp
@@ -38,51 +38,51 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSETNX", "[redis][command][MSETNX]") {
     SECTION("1 key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSETNX", "a_key", "b_value"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("2 keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSETNX", "a_key", "b_value", "b_key", "value_z"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
     }
 
     SECTION("Existing keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSETNX", "a_key", "b_value", "b_key", "value_z"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSETNX", "b_key", "another_value", "c_key", "value_not_being_set"},
                 ":0\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nvalue_z\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "c_key"},
                 "$-1\r\n"));
     }
@@ -102,7 +102,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSETNX", "[r
             arguments.push_back(buffer2);
         }
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 arguments,
                 ":1\r\n"));
 
@@ -112,20 +112,20 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - MSETNX", "[r
             snprintf(buffer1, sizeof(buffer1), "a_key_%05d", key_index);
             snprintf(expected_response, sizeof(expected_response), "$13\r\nb_value_%05d\r\n", key_index);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", buffer1},
                     expected_response));
         }
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSETNX"},
                 "-ERR wrong number of arguments for 'msetnx' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSETNX", "a_key"},
                 "-ERR wrong number of arguments for 'msetnx' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-persist.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-persist.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,31 +39,26 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PERSIST", "[redis][command][PERSIST]") {
     SECTION("No key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PERSIST", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PERSIST", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PERSIST", "a_key"},
                 ":1\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-persist.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-persist.cpp
@@ -38,27 +38,27 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PERSIST", "[redis][command][PERSIST]") {
     SECTION("No key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PERSIST", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PERSIST", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PERSIST", "a_key"},
                 ":1\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpire.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpire.cpp
@@ -38,117 +38,117 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRE", "[redis][command][PEXPIRE]") {
     SECTION("No key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpire.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpire.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,139 +39,116 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRE", "[redis][command][PEXPIRE]") {
     SECTION("No key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRE", "a_key", "5000", "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpireat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpireat.cpp
@@ -42,117 +42,117 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIREAT", 
     snprintf(unixtime_ms_plus_5s_str, sizeof(unixtime_ms_plus_5s_str), "%ld", unixtime_ms_plus_5s);
 
     SECTION("No key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str},
                 ":0\r\n"));
     }
 
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "NX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - NX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "NX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "XX"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - XX - key with expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "XX"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - GT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "GT"},
                 ":0\r\n"));
     }
 
     SECTION("Existing key - GT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "GT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - lower than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "7"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "LT"},
                 ":1\r\n"));
     }
 
     SECTION("Existing key - LT - key with expiry - greater than") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "3"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIREAT", "a_key", unixtime_ms_plus_5s_str, "LT"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,19 +39,16 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME", "[redis][command][PEXPIRETIME]") {
     SECTION("No key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRETIME", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Existing key - no expiration") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRETIME", "a_key"},
                 ":-1\r\n"));
     }
@@ -60,12 +59,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME"
         snprintf(buffer, sizeof(buffer), ":%ld\r\n", unixtime_ms_plus_5s);
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PEXPIRETIME", "a_key"},
                 buffer));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
@@ -56,9 +56,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME"
     SECTION("Existing key - expiration") {
         char buffer[32] = { 0 };
         size_t out_buffer_length = 0;
-        int64_t unixtime_response = 0;
+        int64_t unixtime_response;
         int64_t unixtime_ms_plus_5s = clock_realtime_coarse_int64_ms() + 5000;
-        size_t expected_length = snprintf(NULL, 0, ":%ld\r\n", unixtime_ms_plus_5s);
+        size_t expected_length = snprintf(nullptr, 0, ":%ld\r\n", unixtime_ms_plus_5s);
 
         REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
@@ -72,7 +72,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME"
                 expected_length,
                 send_recv_resp_command_calculate_multi_recv(expected_length)));
 
-        unixtime_response = strtoll(buffer + 1, NULL, 10);
+        unixtime_response = strtoll(buffer + 1, nullptr, 10);
 
         REQUIRE((unixtime_response >= unixtime_ms_plus_5s - 5 && unixtime_response <= unixtime_ms_plus_5s));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
@@ -38,32 +38,42 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME", "[redis][command][PEXPIRETIME]") {
     SECTION("No key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRETIME", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Existing key - no expiration") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PEXPIRETIME", "a_key"},
                 ":-1\r\n"));
     }
 
     SECTION("Existing key - expiration") {
         char buffer[32] = { 0 };
+        size_t out_buffer_length = 0;
+        int64_t unixtime_response = 0;
         int64_t unixtime_ms_plus_5s = clock_realtime_coarse_int64_ms() + 5000;
-        snprintf(buffer, sizeof(buffer), ":%ld\r\n", unixtime_ms_plus_5s);
+        size_t expected_length = snprintf(NULL, 0, ":%ld\r\n", unixtime_ms_plus_5s);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_multi_recv(
                 std::vector<std::string>{"PEXPIRETIME", "a_key"},
-                buffer));
+                buffer,
+                sizeof(buffer),
+                &out_buffer_length,
+                expected_length,
+                send_recv_resp_command_calculate_multi_recv(expected_length)));
+
+        unixtime_response = strtoll(buffer + 1, NULL, 10);
+
+        REQUIRE((unixtime_response >= unixtime_ms_plus_5s - 5 && unixtime_response <= unixtime_ms_plus_5s));
     }
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-ping.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-ping.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,14 +39,12 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PING", "[redis][command][PING]") {
     SECTION("Without value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PING"},
                 "+PONG\r\n"));
     }
 
     SECTION("With value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PING", "a test"},
                 "$6\r\na test\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-ping.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-ping.cpp
@@ -38,13 +38,13 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PING", "[redis][command][PING]") {
     SECTION("Without value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PING"},
                 "+PONG\r\n"));
     }
 
     SECTION("With value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PING", "a test"},
                 "$6\r\na test\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-psetex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-psetex.cpp
@@ -19,6 +19,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,28 +42,24 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[redis][command][PSETEX]") {
     SECTION("Missing parameters - key, milliseconds and value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PSETEX"},
                 "-ERR wrong number of arguments for 'psetex' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PSETEX", "a_key", "100"},
                 "-ERR wrong number of arguments for 'psetex' command\r\n"));
     }
 
     SECTION("Too many parameters - one extra parameter") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PSETEX", "a_key", "100", "b_value", "extra parameter"},
                 "-ERR wrong number of arguments for 'psetex' command\r\n"));
     }
 
     SECTION("Zero value as expire") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PSETEX", "a_key", "0", "b_value"},
                 "-ERR invalid expire time in 'psetex' command\r\n"));
     }
@@ -72,12 +70,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
         config_module_network_timeout.read_ms = 1000;
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PSETEX", key, "500", value},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
@@ -85,7 +81,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
         usleep((500 + 100) * 1000);
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
@@ -99,12 +94,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
         config_module_network_timeout.read_ms = 2000;
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PSETEX", key, "1000", value},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
@@ -112,7 +105,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
         usleep((1000 + 100) * 1000);
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-psetex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-psetex.cpp
@@ -41,25 +41,25 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[redis][command][PSETEX]") {
     SECTION("Missing parameters - key, milliseconds and value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PSETEX"},
                 "-ERR wrong number of arguments for 'psetex' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PSETEX", "a_key", "100"},
                 "-ERR wrong number of arguments for 'psetex' command\r\n"));
     }
 
     SECTION("Too many parameters - one extra parameter") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PSETEX", "a_key", "100", "b_value", "extra parameter"},
                 "-ERR wrong number of arguments for 'psetex' command\r\n"));
     }
 
     SECTION("Zero value as expire") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PSETEX", "a_key", "0", "b_value"},
                 "-ERR invalid expire time in 'psetex' command\r\n"));
     }
@@ -69,18 +69,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
         char *value = "b_value";
         config_module_network_timeout.read_ms = 1000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PSETEX", key, "500", value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
         // Wait for 600 ms and try to get the value after the expiration
         usleep((500 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
@@ -93,18 +93,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
         char *value = "b_value";
         config_module_network_timeout.read_ms = 2000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PSETEX", key, "1000", value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
         // Wait for 1100 ms and try to get the value after the expiration
         usleep((1000 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pttl.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,32 +40,27 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PTTL", "[red
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PTTL", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PTTL", "a_key"},
                 ":-1\r\n"));
     }
 
     SECTION("Key with 5 second expire") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         // Potentially flaky test
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"PTTL", "a_key"},
                 ":5000\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pttl.cpp
@@ -39,28 +39,28 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PTTL", "[redis][command][PTTL]") {
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PTTL", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PTTL", "a_key"},
                 ":-1\r\n"));
     }
 
     SECTION("Key with 5 second expire") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         // Potentially flaky test
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"PTTL", "a_key"},
                 ":5000\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-quit.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-quit.cpp
@@ -37,7 +37,7 @@
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - QUIT", "[redis][command][QUIT]") {
-    REQUIRE(send_recv_resp_command_text(
+    REQUIRE(send_recv_resp_command_text_and_validate_recv(
             std::vector<std::string>{"QUIT"},
             "+OK\r\n"));
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-quit.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-quit.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -36,7 +38,6 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - QUIT", "[redis][command][QUIT]") {
     REQUIRE(send_recv_resp_command_text(
-            client_fd,
             std::vector<std::string>{"QUIT"},
             "+OK\r\n"));
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-rename.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-rename.cpp
@@ -19,6 +19,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,73 +42,60 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - RENAME", "[redis][command][RENAME]") {
     SECTION("Key not existing") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAME", "a_key", "b_value"},
                 "-ERR no such key\r\n"));
     }
 
     SECTION("Key existing") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAME", "a_key", "b_key"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Overwrite same key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAME", "a_key", "a_key"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("Overwrite key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "b_key", "c_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAME", "a_key", "b_key"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-rename.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-rename.cpp
@@ -41,61 +41,61 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - RENAME", "[redis][command][RENAME]") {
     SECTION("Key not existing") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAME", "a_key", "b_value"},
                 "-ERR no such key\r\n"));
     }
 
     SECTION("Key existing") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAME", "a_key", "b_key"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Overwrite same key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAME", "a_key", "a_key"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("Overwrite key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "b_key", "c_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAME", "a_key", "b_key"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-renamenx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-renamenx.cpp
@@ -41,61 +41,61 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - RENAMENX", "[redis][command][RENAMENX]") {
     SECTION("Key not existing") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAMENX", "a_key", "b_value"},
                 "-ERR no such key\r\n"));
     }
 
     SECTION("Key existing") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAMENX", "a_key", "b_key"},
                 ":1\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Overwrite same key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAMENX", "a_key", "a_key"},
                 ":0\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("Overwrite key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "b_key", "c_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"RENAMENX", "a_key", "b_key"},
                 ":0\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nc_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-renamenx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-renamenx.cpp
@@ -19,6 +19,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,73 +42,60 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - RENAMENX", "[redis][command][RENAMENX]") {
     SECTION("Key not existing") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAMENX", "a_key", "b_value"},
                 "-ERR no such key\r\n"));
     }
 
     SECTION("Key existing") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAMENX", "a_key", "b_key"},
                 ":1\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nb_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Overwrite same key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAMENX", "a_key", "a_key"},
                 ":0\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }
 
     SECTION("Overwrite key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "b_key", "c_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"RENAMENX", "a_key", "b_key"},
                 ":0\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "b_key"},
                 "$7\r\nc_value\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$7\r\nb_value\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-scan.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-scan.cpp
@@ -38,63 +38,63 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[redis][command][SCAN]") {
     SECTION("Unsupported TYPE token") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SCAN", "0", "TYPE"},
                 "-ERR the TYPE parameter is not yet supported\r\n"));
     }
 
     SECTION("Empty database") {
         SECTION("No pattern and no count") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SCAN", "0"},
                     "*2\r\n:0\r\n*0\r\n"));
         }
 
         SECTION("No matching pattern and no count") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch"},
                     "*2\r\n:0\r\n*0\r\n"));
         }
 
         SECTION("No matching pattern and with count") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "10"},
                     "*2\r\n:0\r\n*0\r\n"));
         }
     }
 
     SECTION("One key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("With count") {
             SECTION("No match") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:687\r\n*0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "687", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "687", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Only count") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "687", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
@@ -102,43 +102,43 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
 
         SECTION("With pattern") {
             SECTION("No match") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - star") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_*"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - question mark") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_???"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - backslash") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a\\_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - brackets") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "[a-z]_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - everything") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
@@ -146,7 +146,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
     }
 
     SECTION("Multiple keys") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{
                         "MSET",
                         "a_key", "a_value",
@@ -158,55 +158,55 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
 
         SECTION("With count") {
             SECTION("No match") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:281\r\n*0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "281", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:687\r\n*0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "687", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:841\r\n*0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "841", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:281\r\n*0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "281", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "687", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:841\r\n*0\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "841", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Only count") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "COUNT", "100"},
                         "*2\r\n:281\r\n*2\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "281", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "687", "COUNT", "100"},
                         "*2\r\n:841\r\n*2\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
 
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "841", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
@@ -214,49 +214,49 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
 
         SECTION("With pattern") {
             SECTION("No match") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - star - 1 result") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_*"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - star - multiple results") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*key"},
                         "*2\r\n:0\r\n*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
             }
 
             SECTION("Match - question mark") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_???"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - backslash") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a\\_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - brackets") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "[a-z]_key"},
                         "*2\r\n:0\r\n*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
             }
 
             SECTION("Match - everything") {
-                REQUIRE(send_recv_resp_command_text(
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*"},
                         "*2\r\n:0\r\n*5\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-scan.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-scan.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,7 +39,6 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[redis][command][SCAN]") {
     SECTION("Unsupported TYPE token") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SCAN", "0", "TYPE"},
                 "-ERR the TYPE parameter is not yet supported\r\n"));
     }
@@ -45,21 +46,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
     SECTION("Empty database") {
         SECTION("No pattern and no count") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SCAN", "0"},
                     "*2\r\n:0\r\n*0\r\n"));
         }
 
         SECTION("No matching pattern and no count") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch"},
                     "*2\r\n:0\r\n*0\r\n"));
         }
 
         SECTION("No matching pattern and with count") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "10"},
                     "*2\r\n:0\r\n*0\r\n"));
         }
@@ -67,43 +65,36 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
 
     SECTION("One key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("With count") {
             SECTION("No match") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:687\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "687", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "687", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Only count") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "687", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
@@ -112,49 +103,42 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
         SECTION("With pattern") {
             SECTION("No match") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - star") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_*"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - question mark") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_???"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - backslash") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a\\_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - brackets") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "[a-z]_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - everything") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
@@ -163,7 +147,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
 
     SECTION("Multiple keys") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{
                         "MSET",
                         "a_key", "a_value",
@@ -176,66 +159,54 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
         SECTION("With count") {
             SECTION("No match") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:281\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "281", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:687\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "687", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:841\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "841", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:281\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "281", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "687", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:841\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "841", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Only count") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "COUNT", "100"},
                         "*2\r\n:281\r\n*2\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "281", "COUNT", "100"},
                         "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "687", "COUNT", "100"},
                         "*2\r\n:841\r\n*2\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "841", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
@@ -244,56 +215,48 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
         SECTION("With pattern") {
             SECTION("No match") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - star - 1 result") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_*"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - star - multiple results") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*key"},
                         "*2\r\n:0\r\n*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
             }
 
             SECTION("Match - question mark") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_???"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - backslash") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a\\_key"},
                         "*2\r\n:0\r\n*1\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - brackets") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "[a-z]_key"},
                         "*2\r\n:0\r\n*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
             }
 
             SECTION("Match - everything") {
                 REQUIRE(send_recv_resp_command_text(
-                        client_fd,
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*"},
                         "*2\r\n:0\r\n*5\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
             }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
@@ -43,7 +43,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
     SECTION("New key - short") {
         char *key = "a_key";
         char *value = "b_value";
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value},
                 "+OK\r\n"));
 
@@ -56,7 +56,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         char *key = "a_key";
         char *value = "this is a long key that can't be inlined";
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value},
                 "+OK\r\n"));
 
@@ -70,11 +70,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         char *value1 = "b_value";
         char *value2 = "value_z";
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value1},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value2},
                 "+OK\r\n"));
 
@@ -84,19 +84,19 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
     }
 
     SECTION("Missing parameters - key and value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET"},
                 "-ERR wrong number of arguments for 'set' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key"},
                 "-ERR wrong number of arguments for 'set' command\r\n"));
     }
 
     SECTION("Too many parameters - one extra parameter") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "extra parameter"},
                 "-ERR wrong number of arguments for 'set' command\r\n"));
     }
@@ -106,18 +106,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         char *value = "b_value";
         config_module_network_timeout.read_ms = 1000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value, "PX", "500"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
         // Wait for 600 ms and try to get the value after the expiration
         usleep((500 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
@@ -130,18 +130,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         char *value = "b_value";
         config_module_network_timeout.read_ms = 2000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value, "EX", "1"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
         // Wait for 1100 ms and try to get the value after the expiration
         usleep((1000 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
@@ -155,11 +155,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         char *value2 = "value_z";
         config_module_network_timeout.read_ms = 1000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value1, "PX", "500"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
@@ -171,11 +171,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         // as the initial was in 500ms will expire after 250
         usleep(250 * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", key, value2, "KEEPTTL"},
                 "+OK\r\n"));
 
@@ -183,14 +183,14 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         REQUIRE(entry_index->value->sequence[0].chunk_length == strlen(value2));
         REQUIRE(strncmp((char *) entry_index->value->sequence[0].memory.chunk_data, value2, strlen(value2)) == 0);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nvalue_z\r\n"));
 
         // Wait for 350 ms and try to get the value after the expiration
         usleep((250 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
@@ -200,25 +200,25 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
 
     SECTION("New key - XX") {
         SECTION("Key not existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value", "XX"},
                     "$-1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$-1\r\n"));
         }
 
         SECTION("Key existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "XX"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nc_value\r\n"));
         }
@@ -226,18 +226,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         SECTION("Key expired") {
             config_module_network_timeout.read_ms = 100000;
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value", "PX", "500"},
                     "+OK\r\n"));
 
             // Wait for 600 ms and try to get the value after the expiration
             usleep((500 + 100) * 1000);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "XX"},
                     "$-1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$-1\r\n"));
         }
@@ -245,25 +245,25 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
 
     SECTION("New key - NX") {
         SECTION("Key not existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value", "NX"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("Key existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "NX"},
                     "$-1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
@@ -271,18 +271,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         SECTION("Key expired") {
             config_module_network_timeout.read_ms = 1000;
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value", "PX", "500"},
                     "+OK\r\n"));
 
             // Wait for 600 ms and try to get the value after the expiration
             usleep((500 + 100) * 1000);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "NX"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nc_value\r\n"));
         }
@@ -290,21 +290,21 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
 
     SECTION("New key - GET") {
         SECTION("Key not existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value", "GET"},
                     "$-1\r\n"));
         }
 
         SECTION("Key existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "GET"},
                     "$7\r\nb_value\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nc_value\r\n"));
         }
@@ -312,36 +312,36 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
         SECTION("Key expired") {
             config_module_network_timeout.read_ms = 1000;
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value", "PX", "500"},
                     "+OK\r\n"));
 
             // Wait for 600 ms and try to get the value after the expiration
             usleep((500 + 100) * 1000);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "GET"},
                     "$-1\r\n"));
         }
 
         SECTION("Multiple SET") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "c_value", "GET"},
                     "$7\r\nb_value\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "d_value", "GET"},
                     "$7\r\nc_value\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "e_value", "GET"},
                     "$7\r\nd_value\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\ne_value\r\n"));
         }
@@ -350,14 +350,14 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
     SECTION("New key - SET with GET after key expired (test risk of deadlocks)") {
         config_module_network_timeout.read_ms = 2000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "PX", "500"},
                 "+OK\r\n"));
 
         // Wait for 600 ms and try to set the value after the expiration requesting to get returned the previous one
         usleep((500 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "GET"},
                 "$-1\r\n"));
     }
@@ -396,11 +396,11 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 (int) long_value_length,
                 long_value);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_multi_recv(
+        REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 expected_response,
                 expected_response_length,
@@ -443,39 +443,39 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 (int) long_value_length,
                 long_value);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_multi_recv(
+        REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 expected_response,
                 expected_response_length,
-                send_recv_resp_command_calculate_multi_recv(long_value_length)));
+                send_recv_resp_command_calculate_multi_recv(expected_response_length) + 10));
 
         free(expected_response);
     }
 
     SECTION("Invalid EX") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "0"},
                 "-ERR invalid expire time in 'set' command\r\n"));
     }
 
     SECTION("Invalid PX") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "PX", "0"},
                 "-ERR invalid expire time in 'set' command\r\n"));
     }
 
     SECTION("Invalid EXAT") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EXAT", "0"},
                 "-ERR invalid expire time in 'set' command\r\n"));
     }
 
     SECTION("Invalid PXAT") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "PXAT", "0"},
                 "-ERR invalid expire time in 'set' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-setex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-setex.cpp
@@ -41,25 +41,25 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SETEX", "[redis][command][SETEX]") {
     SECTION("Missing parameters - key, seconds and value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETEX"},
                 "-ERR wrong number of arguments for 'setex' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETEX", "a_key", "100"},
                 "-ERR wrong number of arguments for 'setex' command\r\n"));
     }
 
     SECTION("Too many parameters - one extra parameter") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETEX", "a_key", "100", "b_value", "extra parameter"},
                 "-ERR wrong number of arguments for 'setex' command\r\n"));
     }
 
     SECTION("Zero value as expire") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETEX", "a_key", "0", "b_value"},
                 "-ERR invalid expire time in 'setex' command\r\n"));
     }
@@ -69,18 +69,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SETEX", "[re
         char *value = "b_value";
         config_module_network_timeout.read_ms = 2000;
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETEX", key, "1", value},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
         // Wait for 1100 ms and try to get the value after the expiration
         usleep((1000 + 100) * 1000);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-setnx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-setnx.cpp
@@ -41,44 +41,44 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SETNX", "[redis][command][SETNX]") {
     SECTION("Missing parameters - key and value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETNX"},
                 "-ERR wrong number of arguments for 'setnx' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETNX", "a_key"},
                 "-ERR wrong number of arguments for 'setnx' command\r\n"));
     }
 
     SECTION("Too many parameters - one extra parameter") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SETNX", "a_key", "b_value", "extra parameter"},
                 "-ERR wrong number of arguments for 'setnx' command\r\n"));
     }
 
     SECTION("New key - NX") {
         SECTION("Key not existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SETNX", "a_key", "b_value"},
                     ":1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("Key existing") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SETNX", "a_key", "b_value"},
                     ":1\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SETNX", "a_key", "c_value"},
                     ":0\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-setnx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-setnx.cpp
@@ -19,6 +19,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -40,21 +42,18 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SETNX", "[redis][command][SETNX]") {
     SECTION("Missing parameters - key and value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SETNX"},
                 "-ERR wrong number of arguments for 'setnx' command\r\n"));
     }
 
     SECTION("Missing parameters - value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SETNX", "a_key"},
                 "-ERR wrong number of arguments for 'setnx' command\r\n"));
     }
 
     SECTION("Too many parameters - one extra parameter") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SETNX", "a_key", "b_value", "extra parameter"},
                 "-ERR wrong number of arguments for 'setnx' command\r\n"));
     }
@@ -62,29 +61,24 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SETNX", "[re
     SECTION("New key - NX") {
         SECTION("Key not existing") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SETNX", "a_key", "b_value"},
                     ":1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("Key existing") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SETNX", "a_key", "b_value"},
                     ":1\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SETNX", "a_key", "c_value"},
                     ":0\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"GET", "a_key"},
                     "$7\r\nb_value\r\n"));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-shutdown.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-shutdown.cpp
@@ -39,7 +39,7 @@
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SHUTDOWN", "[redis][command][SHUTDOWN]") {
-    REQUIRE(send_recv_resp_command_text(
+    REQUIRE(send_recv_resp_command_text_and_validate_recv(
             std::vector<std::string>{"SHUTDOWN"},
             "+OK\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-shutdown.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-shutdown.cpp
@@ -18,6 +18,8 @@
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,7 +40,6 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SHUTDOWN", "[redis][command][SHUTDOWN]") {
     REQUIRE(send_recv_resp_command_text(
-            client_fd,
             std::vector<std::string>{"SHUTDOWN"},
             "+OK\r\n"));
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-strlen.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-strlen.cpp
@@ -39,11 +39,11 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - STRLEN", "[redis][command][STRLEN]") {
     SECTION("Existing key") {
         SECTION("Short key") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", "b_value"},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"STRLEN", "a_key"},
                     ":7\r\n"));
         }
@@ -72,18 +72,18 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - STRLEN", "[r
                     ":%lu\r\n",
                     long_value_length);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SET", "a_key", long_value},
                     "+OK\r\n"));
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"STRLEN", "a_key"},
                     expected));
         }
     }
 
     SECTION("Not-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"STRLEN", "a_key"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-strlen.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-strlen.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -38,12 +40,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - STRLEN", "[r
     SECTION("Existing key") {
         SECTION("Short key") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", "b_value"},
                     "+OK\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"STRLEN", "a_key"},
                     ":7\r\n"));
         }
@@ -73,12 +73,10 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - STRLEN", "[r
                     long_value_length);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SET", "a_key", long_value},
                     "+OK\r\n"));
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"STRLEN", "a_key"},
                     expected));
         }
@@ -86,7 +84,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - STRLEN", "[r
 
     SECTION("Not-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"STRLEN", "a_key"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-substr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-substr.cpp
@@ -40,60 +40,60 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[redis][command][SUBSTR]") {
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Existing key - short value") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("all") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "0", "6"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("first char") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "0", "0"},
                     "$1\r\nb\r\n"));
         }
 
         SECTION("last char") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "6", "6"},
                     "$1\r\ne\r\n"));
         }
 
         SECTION("last char - negative start negative end") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "-1", "-1"},
                     "$1\r\ne\r\n"));
         }
 
         SECTION("from the last fourth char to the second from the last") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "-4", "-2"},
                     "$3\r\nalu\r\n"));
         }
 
         SECTION("end before start") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "5", "3"},
                     "$0\r\n\r\n"));
         }
 
         SECTION("start after end") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "7", "15"},
                     "$0\r\n\r\n"));
         }
 
         SECTION("start before end, length after end") {
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "3", "15"},
                     "$4\r\nalue\r\n"));
         }
@@ -121,7 +121,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
         char end[32] = { 0 };
         snprintf(end, sizeof(end), "%lu", long_value_length - 1);
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
@@ -143,7 +143,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     (int) long_value_length,
                     long_value);
 
-            REQUIRE(send_recv_resp_command_multi_recv(
+            REQUIRE(send_recv_resp_command_multi_recv_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "0", end},
                     expected_response,
                     expected_response_length,
@@ -153,9 +153,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
         SECTION("first char") {
             snprintf((char*)expected_response_static, sizeof(expected_response_static), "$1\r\n%c\r\n", long_value[0]);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "0", "0"},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("last char") {
@@ -165,9 +165,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     "$1\r\n%c\r\n",
                     long_value[long_value_length - 1]);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", end, end},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("last char - negative start negative end") {
@@ -177,9 +177,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     "$1\r\n%c\r\n",
                     long_value[long_value_length - 1]);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "-1", "-1"},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("from the last fourth char to the second from the last") {
@@ -190,9 +190,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     3,
                     long_value + long_value_length - 4);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", "-4", "-2"},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("end before start") {
@@ -201,7 +201,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
             char end1[32] = { 0 };
             snprintf(end1, sizeof(end1), "%lu", long_value_length - 100);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
                     "$0\r\n\r\n"));
         }
@@ -212,7 +212,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
             char end1[32] = { 0 };
             snprintf(end1, sizeof(end1), "%lu", long_value_length + 100);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
                     "$0\r\n\r\n"));
         }
@@ -229,9 +229,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     "$4\r\n%s\r\n",
                     long_value + long_value_length - 4);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
-                    (char*)expected_response_static));
+                    (char *) expected_response_static));
         }
 
         SECTION("50 chars after first chunk + 50") {
@@ -259,9 +259,9 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     (int)(end1_int - start1_int + 1),
                     long_value + start1_int);
 
-            REQUIRE(send_recv_resp_command_text(
+            REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
-                    (char*)expected_response));
+                    (char *) expected_response));
         }
 
         if (expected_response) {

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-substr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-substr.cpp
@@ -18,6 +18,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -39,69 +41,59 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[redis][command][SUBSTR]") {
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"GET", "a_key"},
                 "$-1\r\n"));
     }
 
     SECTION("Existing key - short value") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         SECTION("all") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "0", "6"},
                     "$7\r\nb_value\r\n"));
         }
 
         SECTION("first char") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "0", "0"},
                     "$1\r\nb\r\n"));
         }
 
         SECTION("last char") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "6", "6"},
                     "$1\r\ne\r\n"));
         }
 
         SECTION("last char - negative start negative end") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "-1", "-1"},
                     "$1\r\ne\r\n"));
         }
 
         SECTION("from the last fourth char to the second from the last") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "-4", "-2"},
                     "$3\r\nalu\r\n"));
         }
 
         SECTION("end before start") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "5", "3"},
                     "$0\r\n\r\n"));
         }
 
         SECTION("start after end") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "7", "15"},
                     "$0\r\n\r\n"));
         }
 
         SECTION("start before end, length after end") {
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "3", "15"},
                     "$4\r\nalue\r\n"));
         }
@@ -130,7 +122,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
         snprintf(end, sizeof(end), "%lu", long_value_length - 1);
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", long_value},
                 "+OK\r\n"));
 
@@ -153,7 +144,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     long_value);
 
             REQUIRE(send_recv_resp_command_multi_recv(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "0", end},
                     expected_response,
                     expected_response_length,
@@ -164,7 +154,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
             snprintf((char*)expected_response_static, sizeof(expected_response_static), "$1\r\n%c\r\n", long_value[0]);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "0", "0"},
                     (char*)expected_response_static));
         }
@@ -177,7 +166,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     long_value[long_value_length - 1]);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", end, end},
                     (char*)expected_response_static));
         }
@@ -190,7 +178,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     long_value[long_value_length - 1]);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "-1", "-1"},
                     (char*)expected_response_static));
         }
@@ -204,7 +191,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     long_value + long_value_length - 4);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", "-4", "-2"},
                     (char*)expected_response_static));
         }
@@ -216,7 +202,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
             snprintf(end1, sizeof(end1), "%lu", long_value_length - 100);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
                     "$0\r\n\r\n"));
         }
@@ -228,7 +213,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
             snprintf(end1, sizeof(end1), "%lu", long_value_length + 100);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
                     "$0\r\n\r\n"));
         }
@@ -246,7 +230,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     long_value + long_value_length - 4);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
                     (char*)expected_response_static));
         }
@@ -277,7 +260,6 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SUBSTR", "[r
                     long_value + start1_int);
 
             REQUIRE(send_recv_resp_command_text(
-                    client_fd,
                     std::vector<std::string>{"SUBSTR", "a_key", start1, end1},
                     (char*)expected_response));
         }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-touch.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-touch.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,31 +39,26 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - TOUCH", "[redis][command][TOUCH]") {
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"TOUCH", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("Multiple key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"TOUCH", "a_key", "b_key", "c_key"},
                 ":3\r\n"));
     }
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"TOUCH", "a_key"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-touch.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-touch.cpp
@@ -38,27 +38,27 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - TOUCH", "[redis][command][TOUCH]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"TOUCH", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("Multiple key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"TOUCH", "a_key", "b_key", "c_key"},
                 ":3\r\n"));
     }
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"TOUCH", "a_key"},
                 ":0\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-ttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-ttl.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,31 +39,26 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - TTL", "[redis][command][TTL]") {
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"TTL", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Key without expiry") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"TTL", "a_key"},
                 ":-1\r\n"));
     }
 
     SECTION("Key with 5 second expire") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"TTL", "a_key"},
                 ":5\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-ttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-ttl.cpp
@@ -38,27 +38,27 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - TTL", "[redis][command][TTL]") {
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"TTL", "a_key"},
                 ":-2\r\n"));
     }
 
     SECTION("Key without expiry") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"TTL", "a_key"},
                 ":-1\r\n"));
     }
 
     SECTION("Key with 5 second expire") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value", "EX", "5"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"TTL", "a_key"},
                 ":5\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-unlink.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-unlink.cpp
@@ -38,33 +38,33 @@
 
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - UNLINK", "[redis][command][UNLINK]") {
     SECTION("Existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"UNLINK", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("Multiple key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
                 "+OK\r\n"));
 
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"UNLINK", "a_key", "b_key", "c_key"},
                 ":3\r\n"));
     }
 
     SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"UNLINK", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Missing parameters - key") {
-        REQUIRE(send_recv_resp_command_text(
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
                 std::vector<std::string>{"UNLINK"},
                 "-ERR wrong number of arguments for 'unlink' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-unlink.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-unlink.cpp
@@ -16,6 +16,8 @@
 #include "clock.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
@@ -37,38 +39,32 @@
 TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - UNLINK", "[redis][command][UNLINK]") {
     SECTION("Existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"SET", "a_key", "b_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"UNLINK", "a_key"},
                 ":1\r\n"));
     }
 
     SECTION("Multiple key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
                 "+OK\r\n"));
 
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"UNLINK", "a_key", "b_key", "c_key"},
                 ":3\r\n"));
     }
 
     SECTION("Non-existing key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"UNLINK", "a_key"},
                 ":0\r\n"));
     }
 
     SECTION("Missing parameters - key") {
         REQUIRE(send_recv_resp_command_text(
-                client_fd,
                 std::vector<std::string>{"UNLINK"},
                 "-ERR wrong number of arguments for 'unlink' command\r\n"));
     }

--- a/tests/unit_tests/modules/redis/test-module-redis-command.cpp
+++ b/tests/unit_tests/modules/redis/test-module-redis-command.cpp
@@ -17,6 +17,8 @@
 #include "config.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"

--- a/tests/unit_tests/modules/redis/test-module-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-module-redis-commands.cpp
@@ -17,6 +17,8 @@
 #include "config.h"
 #include "clock.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/double_linked_list/double_linked_list.h"

--- a/tests/unit_tests/storage/test-storage.cpp
+++ b/tests/unit_tests/storage/test-storage.cpp
@@ -20,6 +20,8 @@
 #include "exttypes.h"
 #include "xalloc.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "fiber_scheduler.h"
 #include "clock.h"

--- a/tests/unit_tests/support.c
+++ b/tests/unit_tests/support.c
@@ -34,6 +34,8 @@
 #include "memory_fences.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "misc.h"
 #include "log/log.h"
 #include "fatal.h"

--- a/tests/unit_tests/test-program.cpp
+++ b/tests/unit_tests/test-program.cpp
@@ -27,6 +27,8 @@
 #include "xalloc.h"
 #include "memory_fences.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "protocol/redis/protocol_redis.h"
 #include "protocol/redis/protocol_redis_reader.h"

--- a/tests/unit_tests/test-transaction-spinlock.cpp
+++ b/tests/unit_tests/test-transaction-spinlock.cpp
@@ -1,0 +1,307 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch.hpp>
+#include <unistd.h>
+#include <cstring>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <atomic>
+using namespace std;
+
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+
+#include "misc.h"
+#include "exttypes.h"
+#include "memory_fences.h"
+#include "utils_cpu.h"
+#include "thread.h"
+#include "xalloc.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "fiber.h"
+#include "fiber_scheduler.h"
+#include "clock.h"
+#include "config.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+#include "worker/worker.h"
+
+// Returns 1 if it can do the initial lock, 2 instead if it's able to reach the point in which has
+// to wait for the spinlock to become free
+void* test_transaction_spinlock_lock_lock_retry_try_lock_thread_func(void* rawdata) {
+    transaction_t transaction = { .transaction_id = { }, .locks = { .count = 0 , .size = 0, .list = nullptr, } };
+    transaction_id_t *transaction_id = &transaction.transaction_id;
+    transaction_id->worker_index = 0; transaction_id->transaction_index = 0;
+    transaction_spinlock_lock_t* lock = (transaction_spinlock_lock_t*)rawdata;
+
+    transaction_acquire(&transaction);
+    if (transaction_spinlock_try_lock(lock, &transaction)) {
+        transaction_release(&transaction);
+        return (void*)1;
+    }
+
+    REQUIRE(transaction_spinlock_lock(lock, &transaction));
+
+    if (transaction_spinlock_is_locked(lock) == 1) {
+        transaction_release(&transaction);
+        return (void*)2;
+    } else {
+        transaction_release(&transaction);
+        return (void*)1;
+    }
+}
+
+void test_transaction_spinlock_lock_thread_wait_on_flag(
+        volatile bool *flag,
+        bool expecting_value) {
+    do {
+        MEMORY_FENCE_LOAD();
+    } while (*flag != expecting_value);
+}
+
+// Increments a number of times using the spinlock for each increment
+struct test_transaction_spinlock_lock_counter_thread_func_data {
+    bool* start_flag;
+    uint32_t thread_num;
+    pthread_t thread_id;
+    transaction_spinlock_lock_volatile_t* lock;
+    uint64_t increments;
+    uint64_t* counter;
+};
+void* test_transaction_spinlock_lock_counter_thread_func(void* rawdata) {
+    struct test_transaction_spinlock_lock_counter_thread_func_data* data =
+            (struct test_transaction_spinlock_lock_counter_thread_func_data*)rawdata;
+
+    worker_context_t worker_context = { 0 };
+    worker_context.worker_index = data->thread_num;
+    worker_context_set(&worker_context);
+
+    thread_current_set_affinity(data->thread_num);
+
+    test_transaction_spinlock_lock_thread_wait_on_flag(data->start_flag, true);
+
+    for(uint64_t i = 0; i < data->increments; i++) {
+        transaction_t transaction = { .transaction_id = { }, .locks = { .count = 0 , .size = 0, .list = nullptr, } };
+        transaction_id_t *transaction_id = &transaction.transaction_id;
+        transaction_id->worker_index = 0; transaction_id->transaction_index = 0;
+
+        transaction_acquire(&transaction);
+
+        REQUIRE(transaction_spinlock_lock(data->lock, &transaction));
+        (*data->counter)++;
+
+        transaction_release(&transaction);
+    }
+
+    return nullptr;
+}
+
+TEST_CASE("transaction_spinlock.c", "[transaction_spinlock]") {
+    worker_context_t worker_context = { 0 };
+    worker_context.worker_index = UINT16_MAX;
+    worker_context_set(&worker_context);
+    transaction_set_worker_index(worker_context.worker_index);
+
+    SECTION("sizeof(transaction_spinlock_lock_t) == 4") {
+        REQUIRE(sizeof(transaction_spinlock_lock_t) == 4);
+    }
+
+    SECTION("transaction_spinlock_init") {
+        transaction_spinlock_lock_t lock = {0};
+        transaction_spinlock_init(&lock);
+
+        REQUIRE(lock.transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+    }
+
+    SECTION("transaction_spinlock_is_locked") {
+        transaction_spinlock_lock_t lock = {0};
+        transaction_spinlock_init(&lock);
+
+        lock.transaction_id = 1;
+
+        REQUIRE(transaction_spinlock_is_locked(&lock));
+    }
+
+    SECTION("transaction_spinlock_try_lock") {
+        SECTION("lock") {
+            transaction_t transaction = { .transaction_id = { }, .locks = { .count = 0 , .size = 0, .list = nullptr, } };
+            transaction_id_t *transaction_id = &transaction.transaction_id;
+            transaction_id->worker_index = 0; transaction_id->transaction_index = 0;
+            transaction_spinlock_lock_t lock = {0};
+            transaction_spinlock_init(&lock);
+
+            transaction_acquire(&transaction);
+
+            REQUIRE(transaction_spinlock_try_lock(&lock, &transaction));
+
+            REQUIRE(lock.transaction_id != TRANSACTION_SPINLOCK_UNLOCKED);
+            REQUIRE(transaction.locks.size == 8);
+            REQUIRE(transaction.locks.count == 1);
+
+            transaction_release(&transaction);
+        }
+
+        SECTION("lock - fail already locked") {
+            transaction_spinlock_lock_t lock = {0};
+            transaction_spinlock_init(&lock);
+
+            lock.transaction_id = 1;
+
+            REQUIRE(transaction_spinlock_is_locked(&lock));
+
+            REQUIRE(lock.transaction_id != TRANSACTION_SPINLOCK_UNLOCKED);
+        }
+    }
+
+    SECTION("transaction_spinlock_unlock") {
+        SECTION("unlock") {
+            transaction_t transaction = { .transaction_id = { }, .locks = { .count = 0 , .size = 0, .list = nullptr, } };
+            transaction_id_t *transaction_id = &transaction.transaction_id;
+            transaction_id->worker_index = 0; transaction_id->transaction_index = 1;
+            transaction_spinlock_lock_t lock = {0};
+            transaction_spinlock_init(&lock);
+
+            lock.transaction_id = transaction_id->id;
+
+#if DEBUG == 1
+            transaction_spinlock_unlock_internal(&lock, &transaction);
+#else
+            transaction_spinlock_unlock_internal(&lock);
+#endif
+            REQUIRE(lock.transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+        }
+    }
+
+    SECTION("transaction_spinlock_lock") {
+        SECTION("fail already locked") {
+            transaction_t transaction = { .transaction_id = { }, .locks = { .count = 0 , .size = 0, .list = nullptr, } };
+            transaction_id_t *transaction_id = &transaction.transaction_id;
+            transaction_id->worker_index = 0; transaction_id->transaction_index = 0;
+            transaction_spinlock_lock_t lock = {0};
+            transaction_spinlock_init(&lock);
+
+            transaction_acquire(&transaction);
+
+            REQUIRE(transaction_spinlock_lock(&lock, &transaction));
+            REQUIRE(lock.transaction_id == transaction_id->id);
+            REQUIRE(!transaction_spinlock_try_lock(&lock, &transaction));
+
+            transaction_release(&transaction);
+        }
+
+        SECTION("lock") {
+            int res, pthread_return_val, *pthread_return = nullptr;
+            transaction_t transaction = { .transaction_id = { }, .locks = { .count = 0 , .size = 0, .list = nullptr, } };
+            transaction_id_t *transaction_id = &transaction.transaction_id;
+            transaction_id->worker_index = 0; transaction_id->transaction_index = 0;
+            transaction_spinlock_lock_t lock = {0};
+            pthread_t pthread;
+            pthread_attr_t attr;
+
+            transaction_spinlock_init(&lock);
+
+            res = pthread_attr_init(&attr);
+            if (res != 0) {
+                perror("pthread_attr_init");
+            }
+
+            transaction_acquire(&transaction);
+
+            // Lock
+            REQUIRE(transaction_spinlock_try_lock(&lock, &transaction));
+            REQUIRE(lock.transaction_id == transaction_id->id);
+
+            // Create the thread that wait for unlock
+            res = pthread_create(&pthread, &attr, &test_transaction_spinlock_lock_lock_retry_try_lock_thread_func, (void*)&lock);
+            if (res != 0) {
+                perror("pthread_create");
+            }
+
+            // Wait
+            usleep(100000);
+
+            // Unlock
+            transaction_release(&transaction);
+
+            // Wait
+            usleep(1000000);
+
+            // TODO: would be better to come up with a better mechanism to check if the thread has actually finished or
+            //       not but the above sleep seems reasonable, the thread doesn't finish within 1 second the spinlock
+            //       is buggy and stuck
+            int pthread_tryjoin_np_res = pthread_tryjoin_np(pthread, (void**)&pthread_return);
+            pthread_return_val = (int)(uint64_t)pthread_return;
+
+            REQUIRE(pthread_tryjoin_np_res == 0);
+            REQUIRE(pthread_return_val == 2);
+
+            // The difference between this test and the plain spinlock one is that the thread does a transaction release
+            // therefore the lock gets unlocked
+            REQUIRE(lock.transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+        }
+
+        SECTION("test lock parallelism") {
+            void* ret;
+            bool start_flag;
+            transaction_spinlock_lock_volatile_t lock = { 0 };
+            pthread_attr_t attr;
+            uint64_t increments_per_thread_sum = 0, increments_per_thread;
+
+            uint32_t cores_count = utils_cpu_count();
+            uint32_t threads_count = cores_count * 2;
+
+            // Magic numbers to run enough thread in parallel for 1-2s after the thread creation.
+            // The test can be quite time-consuming when with an attached debugger.
+            increments_per_thread = (uint64_t)(20000 /  ((float)threads_count / 48.0));
+
+            REQUIRE(pthread_attr_init(&attr) == 0);
+
+            struct test_transaction_spinlock_lock_counter_thread_func_data* threads_info =
+                    (struct test_transaction_spinlock_lock_counter_thread_func_data*)calloc(
+                            threads_count,
+                            sizeof(test_transaction_spinlock_lock_counter_thread_func_data));
+
+            REQUIRE(threads_info != NULL);
+
+            start_flag = false;
+            transaction_spinlock_init(&lock);
+            for(uint32_t thread_num = 0; thread_num < threads_count; thread_num++) {
+                threads_info[thread_num].thread_num = thread_num;
+                threads_info[thread_num].start_flag = &start_flag;
+                threads_info[thread_num].lock = &lock;
+                threads_info[thread_num].increments = increments_per_thread;
+                threads_info[thread_num].counter = &increments_per_thread_sum;
+
+                REQUIRE(pthread_create(
+                        &threads_info[thread_num].thread_id,
+                        &attr,
+                        &test_transaction_spinlock_lock_counter_thread_func,
+                        &threads_info[thread_num]) == 0);
+            }
+
+            start_flag = true;
+            MEMORY_FENCE_STORE();
+
+            // Wait for all the threads to finish
+            for(uint32_t thread_num = 0; thread_num < threads_count; thread_num++) {
+                REQUIRE(pthread_join(threads_info[thread_num].thread_id, &ret) == 0);
+            }
+
+            free(threads_info);
+
+            REQUIRE(increments_per_thread_sum == increments_per_thread * threads_count);
+        }
+    }
+}

--- a/tests/unit_tests/test-transaction.cpp
+++ b/tests/unit_tests/test-transaction.cpp
@@ -1,0 +1,225 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch.hpp>
+
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "memory_fences.h"
+#include "utils_cpu.h"
+#include "thread.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "slab_allocator.h"
+#include "fiber.h"
+#include "fiber_scheduler.h"
+#include "clock.h"
+#include "config.h"
+
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+#include "worker/worker.h"
+
+TEST_CASE("transaction.c", "[transaction]") {
+    worker_context_t worker_context = { 0 };
+    worker_context.worker_index = UINT16_MAX;
+    worker_context_set(&worker_context);
+    transaction_set_worker_index(worker_context.worker_index);
+
+    SECTION("transaction_expand_locks_list") {
+        transaction_t transaction = { };
+        transaction.locks.count = 0;
+        transaction.locks.size = 8;
+
+        transaction_spinlock_lock_volatile_t** initial_list = (transaction_spinlock_lock_volatile_t**)slab_allocator_mem_alloc(
+                sizeof(void*) * transaction.locks.size);
+        transaction.locks.list = initial_list;
+
+        SECTION("Expand once") {
+            transaction_expand_locks_list(&transaction);
+
+            REQUIRE(transaction.locks.size == 16);
+            REQUIRE(transaction.locks.count == 0);
+            REQUIRE(transaction.locks.list != initial_list);
+        }
+
+        SECTION("Expand twice") {
+            transaction_expand_locks_list(&transaction);
+
+            transaction_spinlock_lock_volatile_t** interim_list = transaction.locks.list;
+            transaction_expand_locks_list(&transaction);
+
+            REQUIRE(transaction.locks.size == 32);
+            REQUIRE(transaction.locks.count == 0);
+            REQUIRE(transaction.locks.list != interim_list);
+        }
+
+        slab_allocator_mem_free(transaction.locks.list);
+    }
+
+    SECTION("transaction_needs_expand_locks_list") {
+        SECTION("Needs expand") {
+            transaction_t transaction = { };
+            transaction.locks.count = 8;
+            transaction.locks.size = 8;
+
+            REQUIRE(transaction_needs_expand_locks_list(&transaction));
+        }
+
+        SECTION("Doesn't needs expand") {
+            transaction_t transaction = { };
+            transaction.locks.count = 7;
+            transaction.locks.size = 8;
+
+            REQUIRE(!transaction_needs_expand_locks_list(&transaction));
+        }
+    }
+
+    SECTION("transaction_locks_list_add") {
+        transaction_t transaction = { };
+        transaction.locks.count = 0;
+        transaction.locks.size = 8;
+        transaction.locks.list = (transaction_spinlock_lock_volatile_t**)slab_allocator_mem_alloc(
+                sizeof(void*) * transaction.locks.size);
+
+        SECTION("Add one lock") {
+            transaction_spinlock_lock_volatile_t lock = { 0 };
+
+            REQUIRE(transaction_locks_list_add(&transaction, &lock));
+            REQUIRE(transaction.locks.count == 1);
+            REQUIRE(transaction.locks.size == 8);
+            REQUIRE(transaction.locks.list[0] == &lock);
+        }
+
+        SECTION("Add two lock") {
+            transaction_spinlock_lock_volatile_t lock[2] = { 0 };
+            REQUIRE(transaction_locks_list_add(&transaction, &lock[0]));
+            REQUIRE(transaction.locks.count == 1);
+            REQUIRE(transaction.locks.size == 8);
+            REQUIRE(transaction.locks.list[0] == &lock[0]);
+
+            REQUIRE(transaction_locks_list_add(&transaction, &lock[1]));
+            REQUIRE(transaction.locks.count == 2);
+            REQUIRE(transaction.locks.size == 8);
+            REQUIRE(transaction.locks.list[1] == &lock[1]);
+        }
+
+        SECTION("Force expansions") {
+            transaction_spinlock_lock_volatile_t lock[10] = { 0 };
+
+            for(int index = 0; index < ARRAY_SIZE(lock); index++) {
+                REQUIRE(transaction_locks_list_add(&transaction, &lock[index]));
+            }
+
+            REQUIRE(transaction.locks.count == ARRAY_SIZE(lock));
+            REQUIRE(transaction.locks.size == 16);
+            REQUIRE(transaction.locks.list[ARRAY_SIZE(lock) - 1] == &lock[ARRAY_SIZE(lock) - 1]);
+        }
+
+        slab_allocator_mem_free(transaction.locks.list);
+    }
+
+    SECTION("transaction_acquire") {
+        SECTION("Acquire one") {
+            transaction_t transaction = { 0 };
+
+            uint16_t current_transaction_index = transaction_peek_current_thread_index();
+
+            REQUIRE(transaction_acquire(&transaction));
+
+            REQUIRE(transaction.transaction_id.worker_index == UINT16_MAX);
+            REQUIRE(transaction.transaction_id.transaction_index == current_transaction_index + 1);
+
+            REQUIRE(transaction.locks.count == 0);
+            REQUIRE(transaction.locks.size == 8);
+            REQUIRE(transaction.locks.list != nullptr);
+
+            slab_allocator_mem_free(transaction.locks.list);
+        }
+
+        SECTION("Acquire two") {
+            transaction_t transaction1 = { 0 };
+            transaction_t transaction2 = { 0 };
+
+            uint16_t current_transaction_index = transaction_peek_current_thread_index();
+
+            REQUIRE(transaction_acquire(&transaction1));
+            REQUIRE(transaction_acquire(&transaction2));
+
+            REQUIRE(transaction2.transaction_id.worker_index == UINT16_MAX);
+            REQUIRE(transaction2.transaction_id.transaction_index == current_transaction_index + 2);
+
+            slab_allocator_mem_free(transaction1.locks.list);
+            slab_allocator_mem_free(transaction2.locks.list);
+        }
+    }
+
+    SECTION("transaction_release") {
+        transaction_t transaction = { 0 };
+        REQUIRE(transaction_acquire(&transaction));
+
+        SECTION("Empty transaction") {
+            transaction_release(&transaction);
+
+            REQUIRE(transaction.locks.list == nullptr);
+            REQUIRE(transaction.transaction_id.id == TRANSACTION_ID_NOT_ACQUIRED);
+        }
+
+        SECTION("With one lock") {
+            transaction_spinlock_lock_volatile_t lock = { transaction.transaction_id.id };
+
+            REQUIRE(transaction_locks_list_add(&transaction, &lock));
+
+            transaction_release(&transaction);
+
+            REQUIRE(lock.transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+            REQUIRE(transaction.locks.list == nullptr);
+            REQUIRE(transaction.transaction_id.id == TRANSACTION_ID_NOT_ACQUIRED);
+        }
+
+        SECTION("With two locks") {
+            transaction_spinlock_lock_volatile_t lock1 = { transaction.transaction_id.id };
+            transaction_spinlock_lock_volatile_t lock2 = { transaction.transaction_id.id };
+
+            REQUIRE(transaction_locks_list_add(&transaction, &lock1));
+            REQUIRE(transaction_locks_list_add(&transaction, &lock2));
+
+            transaction_release(&transaction);
+
+            REQUIRE(lock1.transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+            REQUIRE(lock2.transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+            REQUIRE(transaction.locks.list == nullptr);
+            REQUIRE(transaction.transaction_id.id == TRANSACTION_ID_NOT_ACQUIRED);
+        }
+
+        SECTION("Expanded") {
+            transaction_spinlock_lock_volatile_t lock[10] = { 0 };
+
+            for(int index = 0; index < ARRAY_SIZE(lock); index++) {
+                lock[index].transaction_id = transaction.transaction_id.id;
+                REQUIRE(transaction_locks_list_add(&transaction, &lock[index]));
+            }
+
+            transaction_release(&transaction);
+
+            for(int index = 0; index < ARRAY_SIZE(lock); index++) {
+                REQUIRE(lock[index].transaction_id == TRANSACTION_SPINLOCK_UNLOCKED);
+            }
+            REQUIRE(transaction.locks.list == nullptr);
+            REQUIRE(transaction.transaction_id.id == TRANSACTION_ID_NOT_ACQUIRED);
+        }
+    }
+}

--- a/tests/unit_tests/worker/storage/test-worker-storage-io-uring-op.cpp
+++ b/tests/unit_tests/worker/storage/test-worker-storage-io-uring-op.cpp
@@ -21,6 +21,8 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "support/io_uring/io_uring_support.h"

--- a/tests/unit_tests/worker/storage/test-worker-storage-posix-op.cpp
+++ b/tests/unit_tests/worker/storage/test-worker-storage-posix-op.cpp
@@ -20,6 +20,8 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "fiber.h"
 #include "fiber_scheduler.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"

--- a/tests/unit_tests/worker/test-worker.cpp
+++ b/tests/unit_tests/worker/test-worker.cpp
@@ -22,6 +22,8 @@
 #include "xalloc.h"
 #include "log/log.h"
 #include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/small_circular_queue/small_circular_queue.h"
 #include "data_structures/double_linked_list/double_linked_list.h"

--- a/tools/redis-commands-scaffolding-generator/generate-commands-scaffolding.py
+++ b/tools/redis-commands-scaffolding-generator/generate-commands-scaffolding.py
@@ -477,6 +477,8 @@ class Program:
             "#include \"log/log.h\"",
             "#include \"clock.h\"",
             "#include \"spinlock.h\"",
+            "#include \"transaction.h\"",
+            "#include \"transaction_spinlock.h\"",
             "#include \"data_structures/small_circular_queue/small_circular_queue.h\"",
             "#include \"data_structures/double_linked_list/double_linked_list.h\"",
             "#include \"data_structures/hashtable/spsc/hashtable_spsc.h\"",


### PR DESCRIPTION
This PR contains quite a number of chantes which:
- Optimize the spinlock fastpath
- Impelemnt a simple transaction engine with spinlock support, duplicating the spinlock logic
- Implement a timeout for the transactions which will make the lock fail
- Implement transactions for the RMW operations in the hashtable, in case of failure the operation is reported as failed as needed
- Update the hashtable blind operations to use the transactions transparently
- Update the storage db engine to use and expose the transactions, also don't unlock anymore let the transaction_release do its joib
- Update all the command to acquire and free transactions as needed
- Introduce tests for the transaction and the transaction_spinlock
- Update the tests hashtable tests to reflect the changes

This, already gigantic PR, also contains some extras:
- Cleanup useless variables used in the integration tests for redis via Catch2
- Add a mechanism to return the data received from the remote socket in the redis tests
- Use the above mentioned mechanism to fix the flakyness of the integration tests of the EXPIRETIME and PEXPIRETIME commands

This PR closes #219 