### PR TITLE
Fix hashtable counter expansion

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable_thread_counters.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_thread_counters.c
@@ -74,10 +74,11 @@ void hashtable_mcmp_thread_counters_expand_to(
         uint32_t new_size) {
     assert(hashtable_data->thread_counters.size < UINT32_MAX);
 
+    // The function is invoked only if the resize is needed, so no need to check outside the spinlock
     spinlock_lock(&hashtable_data->thread_counters.lock);
 
     // Ensure that the resize is actually needed under lock
-    if (new_size <= hashtable_data->thread_counters.size) {
+    if (likely(new_size <= hashtable_data->thread_counters.size)) {
         spinlock_unlock(&hashtable_data->thread_counters.lock);
         return;
     }

--- a/src/data_structures/hashtable/mcmp/hashtable_thread_counters.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_thread_counters.c
@@ -88,10 +88,10 @@ void hashtable_mcmp_thread_counters_expand_to(
     hashtable_counters_volatile_t **counters = xalloc_alloc(sizeof(hashtable_counters_t*) * new_size);
 
     // Copy the previous set of pointers
-    if (hashtable_data->thread_counters.list) {
+    if (likely(hashtable_data->thread_counters.list)) {
         memcpy(
-                (hashtable_counters_t*)*counters,
-                (hashtable_counters_t*)*hashtable_data->thread_counters.list,
+                counters,
+                hashtable_data->thread_counters.list,
                 sizeof(hashtable_counters_t*) * hashtable_data->thread_counters.size);
     }
 


### PR DESCRIPTION
Fix a bug introduced with the hashtable counters that was triggered when using more than one thread, it's necessary to not only introduce tests for the hashtable counters but also change the amount of workers used in the tests to ensure that the multi-threading aspect is tested properly