### PR TITLE
Increase the max number of recv by 5 to fix flakyness

### DIFF
--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
@@ -451,7 +451,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"GET", "a_key"},
                 expected_response,
                 expected_response_length,
-                send_recv_resp_command_calculate_multi_recv(expected_response_length) + 10));
+                send_recv_resp_command_calculate_multi_recv(expected_response_length) + 15));
 
         free(expected_response);
     }


### PR DESCRIPTION
This PR fixes a test for the Redis SET command which is flaky and in some cases the server needs to send an extra packet.

For a normal client this isn't a problem per-se, as it parses the protocol, but the unit tests use a dummy system to keep it as simple as possible and need to know how many packets might be send maximum.

To resolve the flakyness the test has been updated to expect potentially 5 extra packets.