### PR TITLE
Implement types support in the storage db

### DIFF
--- a/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
+++ b/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
@@ -136,6 +136,7 @@ bool module_redis_command_helper_incr_decr(
     if (!storage_db_op_rmw_commit_update(
             connection_context->db,
             &rmw_status,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             chunk_sequence_new,
             expiry_time_ms)) {
         return_res = module_redis_connection_error_message_printf_noncritical(
@@ -330,6 +331,7 @@ bool module_redis_command_helper_incr_decr_float(
     if (!storage_db_op_rmw_commit_update(
             connection_context->db,
             &rmw_status,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             chunk_sequence_new,
             expiry_time_ms)) {
         return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_append.c
+++ b/src/module/redis/command/module_redis_command_append.c
@@ -170,6 +170,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(append) {
     if (unlikely(!storage_db_op_rmw_commit_update(
             connection_context->db,
             &rmw_status,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             destination_chunk_sequence,
             expiry_time_ms))) {
         return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_copy.c
+++ b/src/module/redis/command/module_redis_command_copy.c
@@ -180,6 +180,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(copy) {
     if (unlikely(!storage_db_op_rmw_commit_update(
             connection_context->db,
             &rmw_status,
+            entry_index_source->value_type,
             chunk_sequence_destination,
             STORAGE_DB_ENTRY_NO_EXPIRY))) {
         // entry_index_destination_new is freed by storage_db_op_rmw_commit_update if the operation fails

--- a/src/module/redis/command/module_redis_command_getset.c
+++ b/src/module/redis/command/module_redis_command_getset.c
@@ -74,6 +74,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getset) {
     if (unlikely(!storage_db_op_rmw_commit_update(
             connection_context->db,
             &rmw_status,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             context->value.value.chunk_sequence,
             STORAGE_DB_ENTRY_NO_EXPIRY))) {
         transaction_release(&transaction);

--- a/src/module/redis/command/module_redis_command_mset.c
+++ b/src/module/redis/command/module_redis_command_mset.c
@@ -48,6 +48,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(mset) {
                 connection_context->db,
                 key_value->key.value.key,
                 key_value->key.value.length,
+                STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
                 key_value->value.value.chunk_sequence,
                 STORAGE_DB_ENTRY_NO_EXPIRY)) {
             return module_redis_connection_error_message_printf_noncritical(connection_context, "ERR mset failed");

--- a/src/module/redis/command/module_redis_command_msetnx.c
+++ b/src/module/redis/command/module_redis_command_msetnx.c
@@ -95,6 +95,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(msetnx) {
             if (unlikely(!storage_db_op_rmw_commit_update(
                     connection_context->db,
                     &rmw_statuses[index],
+                    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
                     key_value->value.value.chunk_sequence,
                     STORAGE_DB_ENTRY_NO_EXPIRY))) {
                 return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_psetex.c
+++ b/src/module/redis/command/module_redis_command_psetex.c
@@ -57,6 +57,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(psetex) {
             connection_context->db,
             context->key.value.key,
             context->key.value.length,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             context->value.value.chunk_sequence,
             expiry_time_ms))) {
         return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_set.c
+++ b/src/module/redis/command/module_redis_command_set.c
@@ -102,6 +102,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(set) {
                 connection_context->db,
                 context->key.value.key,
                 context->key.value.length,
+                STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
                 context->value.value.chunk_sequence,
                 expiry_time_ms))) {
             return_res = module_redis_connection_error_message_printf_noncritical(
@@ -156,6 +157,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(set) {
             if (unlikely(!storage_db_op_rmw_commit_update(
                     connection_context->db,
                     &rmw_status,
+                    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
                     context->value.value.chunk_sequence,
                     expiry_time_ms))) {
                 return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_setex.c
+++ b/src/module/redis/command/module_redis_command_setex.c
@@ -58,6 +58,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setex) {
             connection_context->db,
             context->key.value.key,
             context->key.value.length,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             context->value.value.chunk_sequence,
             expiry_time_ms))) {
         return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_setnx.c
+++ b/src/module/redis/command/module_redis_command_setnx.c
@@ -79,6 +79,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setnx) {
         if (unlikely(!storage_db_op_rmw_commit_update(
                 connection_context->db,
                 &rmw_status,
+                STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
                 context->value.value.chunk_sequence,
                 expiry_time_ms))) {
             return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -266,6 +266,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
     if (unlikely(!storage_db_op_rmw_commit_update(
             connection_context->db,
             &rmw_status,
+            STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
             destination_chunk_sequence,
             STORAGE_DB_ENTRY_NO_EXPIRY))) {
         return_res = module_redis_connection_error_message_printf_noncritical(

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1080,6 +1080,7 @@ bool storage_db_op_set(
         storage_db_t *db,
         char *key,
         size_t key_length,
+        storage_db_entry_index_value_type_t value_type,
         storage_db_chunk_sequence_t *value_chunk_sequence,
         storage_db_expiry_time_ms_t expiry_time_ms) {
     bool result_res = false;
@@ -1208,6 +1209,7 @@ bool storage_db_op_rmw_commit_metadata(
 bool storage_db_op_rmw_commit_update(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status,
+        storage_db_entry_index_value_type_t value_type,
         storage_db_chunk_sequence_t *value_chunk_sequence,
         storage_db_expiry_time_ms_t expiry_time_ms) {
     bool result_res = false;

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -33,6 +33,15 @@ enum storage_db_backend_type {
 };
 typedef enum storage_db_backend_type storage_db_backend_type_t;
 
+enum storage_db_entry_index_value_type {
+    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_UNKNOWN = 1,
+    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING = 2,
+    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_LIST = 3,
+    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_HASHSET = 4,
+    STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_SORTEDSET = 5
+};
+typedef enum storage_db_entry_index_value_type storage_db_entry_index_value_type_t;
+
 // general config parameters to initialize and use the internal storage db (e.g. storage backend, amount of memory for
 // the hashtable, other optional stuff)
 typedef struct storage_db_config storage_db_config_t;
@@ -113,6 +122,7 @@ struct storage_db_chunk_sequence {
 typedef struct storage_db_entry_index storage_db_entry_index_t;
 struct storage_db_entry_index {
     storage_db_entry_index_status_t status;
+    storage_db_entry_index_value_type_t value_type:8;
     storage_db_create_time_ms_t created_time_ms;
     storage_db_expiry_time_ms_t expiry_time_ms;
     storage_db_last_access_time_ms_t last_access_time_ms;
@@ -310,6 +320,7 @@ bool storage_db_op_set(
         storage_db_t *db,
         char *key,
         size_t key_length,
+        storage_db_entry_index_value_type_t value_type,
         storage_db_chunk_sequence_t *value_chunk_sequence,
         storage_db_expiry_time_ms_t expiry_time_ms);
 
@@ -333,6 +344,7 @@ bool storage_db_op_rmw_commit_metadata(
 bool storage_db_op_rmw_commit_update(
         storage_db_t *db,
         storage_db_op_rmw_status_t *rmw_status,
+        storage_db_entry_index_value_type_t value_type,
         storage_db_chunk_sequence_t *value_chunk_sequence,
         storage_db_expiry_time_ms_t expiry_time_ms);
 


### PR DESCRIPTION
This PR adds the necessary field to the storage db entry index to indicate which type of data are stored in the value chunk sequence.

The 2 interfaces that create and write entry indexes have been updated as well to allow specifying the type and the Redis commands have been updated to take advantage of the new interface. 

This PR closes #221 