### PR TITLE
docs(benches): `storage` fixup

### DIFF
--- a/benches/bench-hashtable-mpmc-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-op-set.cpp
@@ -125,7 +125,7 @@ public:
             BenchmarkSupport::CollectHashtableStatsAndUpdateState(
                     (benchmark::State&)state, this->_hashtable);
 
-            // Free the stoarge
+            // Free the storage
             hashtable_mcmp_free(this->_hashtable);
         }
 
@@ -316,7 +316,7 @@ public:
             BenchmarkSupport::CollectHashtableStatsAndUpdateState(
                     (benchmark::State&)state, this->_hashtable);
 
-            // Free the stoarge
+            // Free the storage
             hashtable_mcmp_free(this->_hashtable);
         }
 

--- a/benches/bench-storage-db-op-set.cpp
+++ b/benches/bench-storage-db-op-set.cpp
@@ -163,7 +163,7 @@ public:
             BenchmarkSupport::CollectHashtableStatsAndUpdateState(
                     (benchmark::State&)state, this->_db->hashtable);
 
-            // Free the stoarge
+            // Free the storage
             storage_db_free(this->_db, this->_workers_count);
         }
 


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

Small fixup in the benchmarks comment.
```bash
grep -r stoarge
bench-hashtable-mpmc-op-set.cpp:            // Free the stoarge
bench-hashtable-mpmc-op-set.cpp:            // Free the stoarge
bench-storage-db-op-set.cpp:            // Free the stoarge
```

Checked to ensure there are no further matches in the repo outside this directory