### PR TITLE
Fix contributing.md text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Endeavour
+# Contributing to cachegrand
 
 When contributing to the development of cachegrand, please first discuss the change
 you wish to make via issue, email, or any other method with the maintainers before


### PR DESCRIPTION
The contributing.md has been derived initially by the contributing.md of Endevour, the PR merging the file was containing a reference to it which is being addressed in this pr.