### PR TITLE
Fix benchmark hashtable mpmc op set

### DIFF
--- a/benches/bench-hashtable-mpmc-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-op-set.cpp
@@ -11,16 +11,33 @@
 
 #include <benchmark/benchmark.h>
 
+#include "misc.h"
 #include "exttypes.h"
+#include "clock.h"
+#include "config.h"
+#include "thread.h"
+#include "memory_fences.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
 #include "spinlock.h"
 #include "log/log.h"
 #include "memory_fences.h"
 #include "utils_cpu.h"
+#include "fiber.h"
+#include "fiber_scheduler.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "memory_allocator/ffma.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
-#include "data_structures/hashtable/mcmp/hashtable_op_set.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+#include "worker/worker.h"
 
-#include "../tests/support.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_set.h"
+#include "data_structures/hashtable/mcmp/hashtable_op_get.h"
+
+#include "../tests/unit_tests/support.h"
 
 #include "benchmark-program.hpp"
 #include "benchmark-support.hpp"

--- a/benches/bench-hashtable-mpmc-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-op-set.cpp
@@ -80,6 +80,11 @@ public:
 
     void SetUp(const ::benchmark::State& state) override {
         char error_message[150] = {0};
+        worker_context_t worker_context = { 0 };
+
+        worker_context.worker_index = state.thread_index();
+        worker_context_set(&worker_context);
+        transaction_set_worker_index(worker_context.worker_index);
 
         test_support_set_thread_affinity(state.thread_index());
 
@@ -221,6 +226,11 @@ public:
 
     void SetUp(const ::benchmark::State& state) override {
         char error_message[150] = {0};
+        worker_context_t worker_context = { 0 };
+
+        worker_context.worker_index = state.thread_index();
+        worker_context_set(&worker_context);
+        transaction_set_worker_index(worker_context.worker_index);
 
         test_support_set_thread_affinity(state.thread_index());
 

--- a/tests/unit_tests/support.c
+++ b/tests/unit_tests/support.c
@@ -317,7 +317,6 @@ static void* test_support_build_keys_random_max_length_thread_func(
         sched_yield();
     } while (*ti->start_flag == 0);
 
-
     uint32_t key_length = TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH;
     for (uint64_t i = ti->start; i < ti->end; i++) {
         char *key_current_char, *key;
@@ -326,7 +325,7 @@ static void* test_support_build_keys_random_max_length_thread_func(
         // Allocate enough memory for the accelerate string comparison to work properly
         size_t key_mem_alloc =
                 TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL - (TEST_SUPPORT_RANDOM_KEYS_MAX_LENGTH_WITH_NULL % 32) + 32;
-        key_current_char = key = ffma_mem_alloc(key_mem_alloc);
+        key_current_char = key = xalloc_alloc(key_mem_alloc);
 
         for (uint32_t i2 = 0; i2 < key_length; i2++) {
             *key_current_char = ti->charset_list[random_generate() % ti->charset_size];
@@ -368,7 +367,7 @@ static void* test_support_build_keys_random_random_length_thread_func(
         // Allocate enough memory for the accelerate string comparison to work properly
         size_t key_mem_alloc =
                 (key_length + 1) - ((key_length + 1) % 32) + 32;
-        key_current_char = key = ffma_mem_alloc(key_mem_alloc);
+        key_current_char = key = xalloc_alloc(key_mem_alloc);
 
         for (uint8_t i2 = 0; i2 < key_length; i2++) {
             *key_current_char = ti->charset_list[random_generate() % ti->charset_size];


### PR DESCRIPTION
This PR updates the benchmark for the set operation of the hashtable multi producer multi consumer after the implementation of the transaction maanger.

This work is also needed in preparation of some optimization work for the hashtable that needs to be tested with it.