### PR TITLE
Fix hugepage cache stats usage

### DIFF
--- a/src/hugepage_cache.c
+++ b/src/hugepage_cache.c
@@ -70,10 +70,6 @@ void hugepage_cache_push(void* hugepage_addr) {
     hugepage_cache = &hugepage_cache_per_numa_node[numa_node_index];
 
     queue_mpmc_push(hugepage_cache->free_queue, hugepage_addr);
-
-    hugepage_cache->stats.in_use--;
-
-    assert(hugepage_cache->stats.in_use != UINT32_MAX);
 }
 
 void* hugepage_cache_pop() {
@@ -92,10 +88,7 @@ void* hugepage_cache_pop() {
         if (hugepage_addr == NULL) {
             return NULL;
         }
-        hugepage_cache->stats.total++;
     }
-
-    hugepage_cache->stats.in_use++;
 
     return hugepage_addr;
 }

--- a/src/hugepage_cache.h
+++ b/src/hugepage_cache.h
@@ -9,10 +9,6 @@ typedef struct hugepage_cache hugepage_cache_t;
 struct hugepage_cache {
     int numa_node_index;
     queue_mpmc_t *free_queue;
-    struct {
-        uint32_t total;
-        uint32_t in_use;
-    } stats;
 };
 
 hugepage_cache_t* hugepage_cache_init();

--- a/tests/unit_tests/test-hugepages-cache.cpp
+++ b/tests/unit_tests/test-hugepages-cache.cpp
@@ -29,8 +29,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
             for(int i = 0; i < numa_node_count; i++) {
                 REQUIRE(hugepage_cache_per_numa_node[i].free_queue != nullptr);
                 REQUIRE(hugepage_cache_per_numa_node[i].numa_node_index == i);
-                REQUIRE(hugepage_cache_per_numa_node[i].stats.in_use == 0);
-                REQUIRE(hugepage_cache_per_numa_node[i].stats.total == 0);
             }
 
             hugepage_cache_free();
@@ -49,8 +47,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     nullptr);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 1);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 1);
 
                 xalloc_hugepage_free(hugepage_addr1, HUGEPAGE_SIZE_2MB);
             }
@@ -65,8 +61,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     nullptr);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 2);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 2);
 
                 xalloc_hugepage_free(hugepage_addr1, HUGEPAGE_SIZE_2MB);
                 xalloc_hugepage_free(hugepage_addr2, HUGEPAGE_SIZE_2MB);
@@ -83,8 +77,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     nullptr);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 3);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 3);
 
                 xalloc_hugepage_free(hugepage_addr1, HUGEPAGE_SIZE_2MB);
                 xalloc_hugepage_free(hugepage_addr2, HUGEPAGE_SIZE_2MB);
@@ -108,8 +100,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     hugepage_addr);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 0);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 1);
             }
 
             SECTION("pop and push two hugepage from cache") {
@@ -124,8 +114,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     hugepage_addr2);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 0);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 2);
             }
 
             SECTION("pop and push three hugepage from cache") {
@@ -142,8 +130,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     hugepage_addr3);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 0);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 3);
             }
 
             SECTION("pop three and push two hugepage from/to cache") {
@@ -159,8 +145,6 @@ TEST_CASE("hugepage_cache.c", "[hugepage_cache]") {
                 REQUIRE(queue_mpmc_peek(hugepage_cache_per_numa_node[numa_node_index].free_queue) ==
                     hugepage_addr2);
                 REQUIRE(hugepage_cache_per_numa_node[numa_node_index].numa_node_index == numa_node_index);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.in_use == 1);
-                REQUIRE(hugepage_cache_per_numa_node[numa_node_index].stats.total == 3);
 
                 xalloc_hugepage_free(hugepage_addr3, HUGEPAGE_SIZE_2MB);
             }


### PR DESCRIPTION
This PR drops the support for the statistics in the hugepage cache as these are not in use and they were being updated without using atomic operations causing serious problems.