### PR TITLE
Add keys validation hashtable mpmc set test

### DIFF
--- a/benches/bench-hashtable-mpmc-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-op-set.cpp
@@ -42,12 +42,14 @@
 #include "benchmark-program.hpp"
 #include "benchmark-support.hpp"
 
+#define TEST_VALIDATE_KEYS 0
+
 // Set the generator to use
 #define KEYSET_GENERATOR_METHOD     TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_MAX_LENGTH
 
 // It is possible to control the amount of threads used for the test tuning the two defines below
-#define TEST_THREADS_RANGE_BEGIN (1)
-#define TEST_THREADS_RANGE_END (utils_cpu_count())
+#define TEST_THREADS_RANGE_BEGIN (4)
+#define TEST_THREADS_RANGE_END (4)
 
 // These two are kept static and external because
 // - Google Benchmark invokes the setup multiple times, once per thread, but it doesn't have an entry point invoked
@@ -203,6 +205,46 @@ BENCHMARK_DEFINE_F(HashtableOpSetInsertFixture, hashtable_op_set_insert)(benchma
             }
         }
     }
+
+#if TEST_VALIDATE_KEYS == 1
+    for(
+            uint64_t key_index = state.thread_index();
+            key_index < requested_keyset_size;
+            key_index += state.threads()) {
+        hashtable_value_data_t data = 0;
+
+        result = hashtable_mcmp_op_get(
+                hashtable,
+                keyset_slots[key_index].key,
+                keyset_slots[key_index].key_length,
+                &data);
+
+        if (!result) {
+            sprintf(
+                    error_message,
+                    "Unable to find the key <%s (%d)> with index <%ld> for the thread <%d>",
+                    keyset_slots[key_index].key,
+                    keyset_slots[key_index].key_length,
+                    key_index,
+                    state.thread_index());
+            state.SkipWithError(error_message);
+            break;
+        }
+
+        if (data != key_index) {
+            sprintf(
+                    error_message,
+                    "The key <%s> with index <%ld> for the thread <%d> holds the value <%ld> but the expected one is <%ld>",
+                    keyset_slots[key_index].key,
+                    key_index,
+                    state.thread_index(),
+                    data,
+                    key_index);
+            state.SkipWithError(error_message);
+            break;
+        }
+    }
+#endif
 }
 
 class HashtableOpSetUpdateFixture : public benchmark::Fixture {
@@ -400,13 +442,53 @@ BENCHMARK_DEFINE_F(HashtableOpSetUpdateFixture, hashtable_op_set_update)(benchma
             }
         }
     }
+
+
+#if TEST_VALIDATE_KEYS == 1
+    for(
+            uint64_t key_index = state.thread_index();
+            key_index < requested_keyset_size;
+            key_index += state.threads()) {
+        hashtable_value_data_t data = 0;
+
+        result = hashtable_mcmp_op_get(
+                hashtable,
+                keyset_slots[key_index].key,
+                keyset_slots[key_index].key_length,
+                &data);
+
+        if (!result) {
+            sprintf(
+                    error_message,
+                    "Unable to find the key <%s (%d)> with index <%ld> for the thread <%d>",
+                    keyset_slots[key_index].key,
+                    keyset_slots[key_index].key_length,
+                    key_index,
+                    state.thread_index());
+            state.SkipWithError(error_message);
+            break;
+        }
+
+        if (data != key_index) {
+            sprintf(
+                    error_message,
+                    "The key <%s> with index <%ld> for the thread <%d> holds the value <%ld> but the expected one is <%ld>",
+                    keyset_slots[key_index].key,
+                    key_index,
+                    state.thread_index(),
+                    data,
+                    key_index);
+            state.SkipWithError(error_message);
+            break;
+        }
+    }
+#endif
 }
 
 static void BenchArguments(benchmark::internal::Benchmark* b) {
     b
             ->ArgsProduct({
-                                  { 0x0000FFFFu, 0x000FFFFFu, 0x001FFFFFu, 0x007FFFFFu, 0x00FFFFFFu, 0x01FFFFFFu, 0x07FFFFFFu,
-                                          0x0FFFFFFFu, 0x1FFFFFFFu, 0x3FFFFFFFu, 0x7FFFFFFFu },
+                                  { 0x0000FFFFu, 0x000FFFFFu, 0x001FFFFFu, 0x007FFFFFu },
                                   { 50, 75 },
                           })
             ->ThreadRange(TEST_THREADS_RANGE_BEGIN, TEST_THREADS_RANGE_END)

--- a/benches/bench-hashtable-mpmc-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-op-set.cpp
@@ -88,7 +88,7 @@ public:
         running_threads.fetch_sub(1);
     }
 
-    void RunningThreadsWait(int thread_index) {
+    void RunningThreadsWait() {
         while(running_threads.load() > 0) {
             usleep(100000);
         }
@@ -158,7 +158,7 @@ public:
 
     void TearDown(const ::benchmark::State& state) override {
         this->RunningThreadsDecrement();
-        this->RunningThreadsWait(state.thread_index());
+        this->RunningThreadsWait();
 
         if (state.thread_index() != 0) {
             return;

--- a/benches/bench-hashtable-mpmc-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-op-set.cpp
@@ -48,8 +48,8 @@
 #define KEYSET_GENERATOR_METHOD     TEST_SUPPORT_RANDOM_KEYS_GEN_FUNC_RANDOM_STR_MAX_LENGTH
 
 // It is possible to control the amount of threads used for the test tuning the two defines below
-#define TEST_THREADS_RANGE_BEGIN (4)
-#define TEST_THREADS_RANGE_END (4)
+#define TEST_THREADS_RANGE_BEGIN (1)
+#define TEST_THREADS_RANGE_END (utils_cpu_count())
 
 // These two are kept static and external because
 // - Google Benchmark invokes the setup multiple times, once per thread, but it doesn't have an entry point invoked


### PR DESCRIPTION
This PR adds some testing & validation functionalities to the hashtable mpmc op set benchmark that takes care of validating the keys just inserted during the benchmark to ensure that they have the expected value. 