### PR TITLE
Include the cachegrand-benchmark-generator only when building the internal benches

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory(cachegrand-benchmark-generator)
+if (BUILD_INTERNAL_BENCHES)
+    add_subdirectory(cachegrand-benchmark-generator)
+endif()


### PR DESCRIPTION
Include the cachegrand-benchmark-generator only when building the internal benches