### PR TITLE
Implement epoch gc

### DIFF
--- a/src/epoch_gc.c
+++ b/src/epoch_gc.c
@@ -1,0 +1,333 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include "misc.h"
+#include "xalloc.h"
+#include "spinlock.h"
+#include "intrinsics.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "data_structures/ring_bounded_spsc/ring_bounded_spsc.h"
+#include "memory_allocator/ffma.h"
+
+#include "epoch_gc.h"
+
+thread_local epoch_gc_thread_t *thread_local_epoch_gc[EPOCH_GC_OBJECT_TYPE_MAX] = { 0 };
+static epoch_gc_staged_object_destructor_cb_t* epoch_gc_staged_object_destructor_cb[] = { 0 };
+
+epoch_gc_t *epoch_gc_init(
+        epoch_gc_object_type_t object_type) {
+    epoch_gc_t *epoch_gc = xalloc_alloc_zero(sizeof(epoch_gc_t));
+    if (!epoch_gc) {
+        return NULL;
+    }
+
+    epoch_gc->object_type = object_type;
+    epoch_gc->thread_list = double_linked_list_init();
+    if (!epoch_gc->thread_list) {
+        xalloc_free(epoch_gc);
+        return NULL;
+    }
+
+    spinlock_init(&epoch_gc->thread_list_spinlock);
+
+    return epoch_gc;
+}
+
+void epoch_gc_free(
+        epoch_gc_t *epoch_gc) {
+    // TODO
+}
+
+void epoch_gc_register_object_type_destructor_cb(
+        epoch_gc_object_type_t object_type,
+        epoch_gc_staged_object_destructor_cb_t *destructor_cb) {
+    epoch_gc_staged_object_destructor_cb[object_type] = destructor_cb;
+}
+
+bool epoch_gc_thread_append_new_staged_objects_ring(
+        epoch_gc_thread_t *epoch_gc_thread) {
+    ring_bounded_spsc_t *rb = ring_bounded_spsc_init(EPOCH_GC_STAGED_OBJECTS_RING_SIZE);
+    if (!rb) {
+        return false;
+    }
+
+    double_linked_list_item_t *rb_item = double_linked_list_item_init();
+    if (!rb_item) {
+        ring_bounded_spsc_free(rb);
+        return false;
+    }
+
+    // Update the last ring to be used
+    epoch_gc_thread->staged_objects_ring_last = rb;
+
+    // Append the ring to the ring list
+    rb_item->data = rb;
+    double_linked_list_push_item(epoch_gc_thread->staged_objects_ring_list, rb_item);
+
+    return true;
+}
+
+bool epoch_gc_register_thread(
+        epoch_gc_t *epoch_gc) {
+    epoch_gc_thread_t *epoch_gc_thread = NULL;
+    double_linked_list_item_t *epoch_gc_thread_item = NULL;
+
+    epoch_gc_thread = xalloc_alloc_zero(sizeof(epoch_gc_thread_t));
+    if (!epoch_gc_thread) {
+        goto fail;
+    }
+
+    epoch_gc_thread->epoch = 0;
+    epoch_gc_thread->epoch_gc = epoch_gc;
+
+    epoch_gc_thread->staged_objects_ring_list = double_linked_list_init();
+    if (!epoch_gc_thread->staged_objects_ring_list) {
+        goto fail;
+    }
+
+    epoch_gc_thread->staged_objects_ring_last = ring_bounded_spsc_init(EPOCH_GC_STAGED_OBJECTS_RING_SIZE);
+    if (!epoch_gc_thread->staged_objects_ring_last) {
+        goto fail;
+    }
+
+    epoch_gc_thread_item = double_linked_list_item_init();
+    if (!epoch_gc_thread_item) {
+        goto fail;
+    }
+
+    if (!epoch_gc_thread_append_new_staged_objects_ring(epoch_gc_thread)) {
+        goto fail;
+    }
+
+    // Add the thread registration to the list of registered threads
+    epoch_gc_thread_item->data = epoch_gc_thread;
+
+    spinlock_lock(&epoch_gc->thread_list_spinlock);
+    double_linked_list_push_item(epoch_gc->thread_list, epoch_gc_thread_item);
+    spinlock_unlock(&epoch_gc->thread_list_spinlock);
+
+    // Store a reference in the thread local store
+    thread_local_epoch_gc[epoch_gc->object_type] = epoch_gc_thread;
+
+    return true;
+
+    fail:
+    if (epoch_gc_thread && epoch_gc_thread->staged_objects_ring_list) {
+        double_linked_list_free(epoch_gc_thread->staged_objects_ring_list);
+    }
+
+    if (epoch_gc_thread && epoch_gc_thread->staged_objects_ring_last) {
+        ring_bounded_spsc_free(epoch_gc_thread->staged_objects_ring_last);
+    }
+
+    if (epoch_gc_thread) {
+        xalloc_free(epoch_gc_thread);
+    }
+
+    if (epoch_gc_thread_item) {
+        double_linked_list_item_free(epoch_gc_thread_item);
+    }
+
+    return false;
+}
+
+void epoch_gc_thread_get_instance(
+        epoch_gc_object_type_t object_type,
+        epoch_gc_t **epoch_gc,
+        epoch_gc_thread_t **epoch_gc_thread) {
+    *epoch_gc_thread = thread_local_epoch_gc[object_type];
+    assert(*epoch_gc_thread);
+
+    *epoch_gc = (*epoch_gc_thread)->epoch_gc;
+    assert((*epoch_gc)->object_type == object_type);
+}
+
+bool epoch_gc_thread_is_terminated(
+        epoch_gc_object_type_t object_type) {
+    epoch_gc_t *epoch_gc = NULL;
+    epoch_gc_thread_t *epoch_gc_thread = NULL;
+
+    epoch_gc_thread_get_instance(object_type, &epoch_gc, &epoch_gc_thread);
+
+    MEMORY_FENCE_STORE();
+
+    return epoch_gc_thread->thread_terminated;
+}
+
+void epoch_gc_thread_terminate(
+        epoch_gc_object_type_t object_type) {
+    epoch_gc_t *epoch_gc = NULL;
+    epoch_gc_thread_t *epoch_gc_thread = NULL;
+
+    // Tries to collect all before
+    epoch_gc_thread_collect_all(object_type);
+
+    epoch_gc_thread_get_instance(object_type, &epoch_gc, &epoch_gc_thread);
+
+    epoch_gc_thread->thread_terminated = true;
+    MEMORY_FENCE_STORE();
+}
+
+void epoch_gc_thread_advance_epoch(
+        epoch_gc_object_type_t object_type) {
+    epoch_gc_t *epoch_gc = NULL;
+    epoch_gc_thread_t *epoch_gc_thread = NULL;
+
+    epoch_gc_thread_get_instance(object_type, &epoch_gc, &epoch_gc_thread);
+
+    epoch_gc_thread->epoch = intrinsics_tsc();
+    MEMORY_FENCE_STORE();
+}
+
+void epoch_gc_thread_destruct_staged_objects_batch(
+        epoch_gc_staged_object_destructor_cb_t *destructor_cb,
+        uint8_t staged_objects_counter,
+        epoch_gc_staged_object_t *staged_objects[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE]) {
+    destructor_cb(staged_objects_counter, staged_objects);
+
+    for(
+            uint8_t staged_object_index = 0;
+            staged_object_index < staged_objects_counter;
+            staged_object_index++) {
+        ffma_mem_free(staged_objects[staged_object_index]);
+    }
+}
+
+uint32_t epoch_gc_thread_collect(
+        epoch_gc_object_type_t object_type,
+        uint32_t max_items) {
+    uint32_t deleted_counter = 0;
+    epoch_gc_staged_object_t *staged_objects[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE];
+    uint8_t staged_objects_counter = 0;
+    epoch_gc_t *epoch_gc = NULL;
+    epoch_gc_thread_t *epoch_gc_thread = NULL;
+
+    epoch_gc_thread_get_instance(object_type, &epoch_gc, &epoch_gc_thread);
+
+    // Get the lowest epoch among all the threads registered for this object type
+    uint64_t epoch = UINT64_MAX;
+    double_linked_list_item_t* epoch_gc_thread_item = NULL;
+
+    // Critical section operating on the thread list
+    spinlock_lock(&epoch_gc->thread_list_spinlock);
+    while((epoch_gc_thread_item = double_linked_list_iter_next(
+            epoch_gc->thread_list, epoch_gc_thread_item)) != NULL) {
+        MEMORY_FENCE_LOAD();
+        uint64_t thread_epoch = epoch_gc_thread->epoch;
+
+        if (thread_epoch < epoch) {
+            epoch = thread_epoch;
+        }
+    }
+    spinlock_unlock(&epoch_gc->thread_list_spinlock);
+
+    // Can't iterate over the double linked list normally as items can be deleted as part of the process
+    double_linked_list_t *list = epoch_gc_thread->staged_objects_ring_list;
+    double_linked_list_item_t* item = list->head;
+    while(item != NULL) {
+        epoch_gc_staged_object_t *staged_object;
+        bool stop = false;
+        ring_bounded_spsc_t *staged_objects_ring = item->data;
+
+        // Peek, instead of dequeue, to avoid fetching an item that can't be destroyed as potentially it's in use
+        while(likely((staged_object = ring_bounded_spsc_peek(staged_objects_ring)) != NULL)) {
+            if (epoch <= staged_object->epoch || deleted_counter > max_items) {
+                stop = true;
+                break;
+            }
+
+            // Remove the fetched object from the queue
+            ring_bounded_spsc_dequeue(staged_objects_ring);
+
+            staged_objects[staged_objects_counter] = staged_object;
+            staged_objects_counter++;
+            if (staged_objects_counter == ARRAY_SIZE(staged_objects)) {
+                epoch_gc_thread_destruct_staged_objects_batch(
+                        epoch_gc_staged_object_destructor_cb[object_type],
+                        staged_objects_counter,
+                        staged_objects);
+
+                deleted_counter += staged_objects_counter;
+                staged_objects_counter = 0;
+            }
+
+            deleted_counter++;
+        }
+
+        if (stop) {
+            break;
+        }
+
+        // Before checking if the ring can be removed store the current item in a new variable and get the next one
+        double_linked_list_item_t *old_item = item;
+        item = item->next;
+
+        // TODO: the check on the ring useless as the only way to get to this point is if the ring is empty but needs
+        //       testing, so better to leave this check around. The part of the if that checks if there is only one
+        //       ring is required as if it's the last one we don't really want to remove it.
+        //       It's not necessary to update staged_objects_ring_last as that's always point to the last one and, per
+        //       definition, when processing the double linked list of rings if the code get to the last one the check
+        //       will avoid removing it.
+        if (list->count > 1 && ring_bounded_spsc_is_empty(staged_objects_ring)) {
+            double_linked_list_remove_item(list, old_item);
+            double_linked_list_item_free(old_item);
+            ring_bounded_spsc_free(staged_objects_ring);
+        }
+    }
+
+    if (staged_objects_counter > 0) {
+        epoch_gc_thread_destruct_staged_objects_batch(
+                epoch_gc_staged_object_destructor_cb[object_type],
+                staged_objects_counter,
+                staged_objects);
+
+        deleted_counter += staged_objects_counter;
+    }
+
+    return deleted_counter;
+}
+
+uint32_t epoch_gc_thread_collect_all(
+        epoch_gc_object_type_t object_type) {
+    return epoch_gc_thread_collect(object_type, UINT32_MAX);
+}
+
+bool epoch_gc_stage_object(
+        epoch_gc_object_type_t object_type,
+        void* object) {
+    epoch_gc_t *epoch_gc = NULL;
+    epoch_gc_thread_t *epoch_gc_thread = NULL;
+
+    epoch_gc_thread_get_instance(object_type, &epoch_gc, &epoch_gc_thread);
+
+    // Allocate the staged pointer
+    epoch_gc_staged_object_t *staged_object = ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+    staged_object->epoch = intrinsics_tsc();
+    staged_object->object = object;
+
+    // Try to insert the pointer into the last available ring
+    if (unlikely(!ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, staged_object))) {
+        // If the operation fails a new ring has to be appended and the operation retried
+        if (unlikely(!epoch_gc_thread_append_new_staged_objects_ring(epoch_gc_thread))) {
+            return false;
+        }
+
+        if (unlikely(!ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, staged_object))) {
+            // Can't really happen as the ring is brand new and therefore empty, but better to always check the return
+            // values. This is also the slow path so an additional branch is not a particular problem.
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/epoch_gc.h
+++ b/src/epoch_gc.h
@@ -1,0 +1,95 @@
+#ifndef CACHEGRAND_EPOCH_GC_H
+#define CACHEGRAND_EPOCH_GC_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EPOCH_GC_STAGED_OBJECTS_RING_SIZE (8 * 1024)
+#define EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE (16)
+
+enum epoch_gc_object_type {
+    EPOCH_GC_OBJECT_TYPE_HASHTABLE_KEY_VALUE,
+    EPOCH_GC_OBJECT_TYPE_KVDB_ENTRY_INDEX,
+    EPOCH_GC_OBJECT_TYPE_MAX,
+};
+typedef enum epoch_gc_object_type epoch_gc_object_type_t;
+
+typedef struct epoch_gc epoch_gc_t;
+struct epoch_gc {
+    spinlock_lock_volatile_t thread_list_spinlock;
+    double_linked_list_t *thread_list;
+    epoch_gc_object_type_t object_type;
+};
+
+typedef struct epoch_gc_thread epoch_gc_thread_t;
+struct epoch_gc_thread {
+    ring_bounded_spsc_t *staged_objects_ring_last;
+    double_linked_list_t *staged_objects_ring_list;
+    uint64_t epoch;
+    epoch_gc_t *epoch_gc;
+    bool thread_terminated;
+};
+
+typedef struct epoch_gc_staged_object epoch_gc_staged_object_t;
+struct epoch_gc_staged_object {
+    uint64_t epoch;
+    void *object;
+};
+
+typedef bool (epoch_gc_staged_object_destructor_cb_t)(
+        uint8_t,
+        epoch_gc_staged_object_t*[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE]);
+
+epoch_gc_t *epoch_gc_init(
+        epoch_gc_object_type_t object_type);
+
+void epoch_gc_free(
+        epoch_gc_t *epoch_gc);
+
+void epoch_gc_register_object_type_destructor_cb(
+        epoch_gc_object_type_t object_type,
+        epoch_gc_staged_object_destructor_cb_t *destructor_cb);
+
+bool epoch_gc_thread_append_new_staged_objects_ring(
+        epoch_gc_thread_t *epoch_gc_thread);
+
+bool epoch_gc_register_thread(
+        epoch_gc_t *epoch_gc);
+
+void epoch_gc_thread_get_instance(
+        epoch_gc_object_type_t object_type,
+        epoch_gc_t **epoch_gc,
+        epoch_gc_thread_t **epoch_gc_thread);
+
+bool epoch_gc_thread_is_terminated(
+        epoch_gc_object_type_t object_type);
+
+void epoch_gc_thread_terminate(
+        epoch_gc_object_type_t object_type);
+
+void epoch_gc_thread_advance_epoch(
+        epoch_gc_object_type_t object_type);
+
+void epoch_gc_thread_destruct_staged_objects_batch(
+        epoch_gc_staged_object_destructor_cb_t *destructor_cb,
+        uint8_t staged_objects_counter,
+        epoch_gc_staged_object_t *staged_objects[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE]);
+
+uint32_t epoch_gc_thread_collect(
+        epoch_gc_object_type_t object_type, uint32_t max_items);
+
+uint32_t epoch_gc_thread_collect_all(
+        epoch_gc_object_type_t object_type);
+
+bool epoch_gc_stage_object(
+        epoch_gc_object_type_t object_type,
+        void* object);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_EPOCH_GC_H

--- a/src/epoch_gc.h
+++ b/src/epoch_gc.h
@@ -1,7 +1,6 @@
 #ifndef CACHEGRAND_EPOCH_GC_H
 #define CACHEGRAND_EPOCH_GC_H
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -86,7 +85,6 @@ uint32_t epoch_gc_thread_collect_all(
 bool epoch_gc_stage_object(
         epoch_gc_object_type_t object_type,
         void* object);
-
 
 #ifdef __cplusplus
 }

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -9,21 +9,3 @@
 #include <stdint.h>
 
 #include "intrinsics.h"
-
-uint64_t intrinsics_tsc() {
-#if defined(__x86_64__)
-    uint64_t rax, rdx;
-    __asm__ __volatile__ (
-            "rdtsc"
-            : "=a" (rax), "=d" (rdx));
-    return (rdx << 32) + rax;
-#elif defined(__aarch64__)
-    int64_t tsc;
-    asm volatile (
-            "mrs %0, cntvct_el0"
-            : "=r"(tsc));
-    return (uint64_t) tsc;
-#else
-#error "unsupported platform"
-#endif
-}

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -12,11 +12,10 @@
 
 uint64_t intrinsic_tsc() {
 #if defined(__x86_64__)
-    uint32_t aux;
     uint64_t rax, rdx;
-    asm volatile (
-            "rdtscp\n"
-            : "=a" (rax), "=d" (rdx), "=c" (aux) : : );
+    __asm__ __volatile__ (
+            "rdtsc"
+            : "=a" (rax), "=d" (rdx));
     return (rdx << 32) + rax;
 #elif defined(__aarch64__)
     int64_t tsc;

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -10,7 +10,7 @@
 
 #include "intrinsics.h"
 
-uint64_t intrinsic_tsc() {
+uint64_t intrinsics_tsc() {
 #if defined(__x86_64__)
     uint64_t rax, rdx;
     __asm__ __volatile__ (

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-uint64_t intrinsic_tsc();
+uint64_t intrinsics_tsc();
 
 #ifdef __cplusplus
 }

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -5,7 +5,23 @@
 extern "C" {
 #endif
 
-uint64_t intrinsics_tsc();
+static inline uint64_t intrinsics_tsc() {
+#if defined(__x86_64__)
+    uint64_t rax, rdx;
+    __asm__ __volatile__ (
+            "rdtsc"
+            : "=a" (rax), "=d" (rdx));
+    return (rdx << 32) + rax;
+#elif defined(__aarch64__)
+    int64_t tsc;
+    asm volatile (
+            "mrs %0, cntvct_el0"
+            : "=r"(tsc));
+    return (uint64_t) tsc;
+#else
+#error "unsupported platform"
+#endif
+}
 
 #ifdef __cplusplus
 }

--- a/tests/unit_tests/test-epoch-gc.cpp
+++ b/tests/unit_tests/test-epoch-gc.cpp
@@ -1,0 +1,603 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch.hpp>
+
+#include <cstdint>
+#include <cstdbool>
+#include <csignal>
+#include <csetjmp>
+
+#include "spinlock.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/ring_bounded_spsc/ring_bounded_spsc.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "memory_allocator/ffma.h"
+#include "xalloc.h"
+#include "signals_support.h"
+
+#include "epoch_gc.h"
+
+sigjmp_buf test_epoch_gc_jump_fp;
+void test_epoch_gc_signal_sigabrt_and_sigsegv_handler_longjmp(int) {
+    siglongjmp(test_epoch_gc_jump_fp, 1);
+}
+
+void test_epoch_gc_signal_sigabrt_and_sigsegv_handler_setup() {
+    signals_support_register_signal_handler(
+            SIGABRT,
+            test_epoch_gc_signal_sigabrt_and_sigsegv_handler_longjmp,
+            nullptr);
+
+    signals_support_register_signal_handler(
+            SIGSEGV,
+            test_epoch_gc_signal_sigabrt_and_sigsegv_handler_longjmp,
+            nullptr);
+}
+
+static uint8_t test_epoch_gc_object_destructor_cb_params_staged_objects_count = 0;
+static epoch_gc_staged_object_t **test_epoch_gc_object_destructor_cb_params_staged_objects;
+void test_epoch_gc_object_destructor_cb(
+        uint8_t staged_objects_count,
+        epoch_gc_staged_object_t *staged_objects[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE]) {
+    test_epoch_gc_object_destructor_cb_params_staged_objects_count = staged_objects_count;
+    test_epoch_gc_object_destructor_cb_params_staged_objects = staged_objects;
+
+    for(uint64_t i = 0; i < EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE; i++) {
+        REQUIRE(staged_objects[i]->object == (void*)i);
+    }
+}
+
+TEST_CASE("epoch_gc.c", "[epoch-gc]") {
+    SECTION("epoch_gc_init") {
+        SECTION("valid object type") {
+            epoch_gc_t *epoch_gc = epoch_gc_init(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX);
+
+            REQUIRE(epoch_gc->object_type == EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX);
+            REQUIRE(spinlock_is_locked(&epoch_gc->thread_list_spinlock) == false);
+            REQUIRE(epoch_gc->thread_list != NULL);
+
+            double_linked_list_free(epoch_gc->thread_list);
+            xalloc_free(epoch_gc);
+        }
+
+#if DEBUG == 1
+        SECTION("invalid object type") {
+            bool fatal_caught = false;
+            if (sigsetjmp(test_epoch_gc_jump_fp, 1) == 0) {
+                test_epoch_gc_signal_sigabrt_and_sigsegv_handler_setup();
+                epoch_gc_init((epoch_gc_object_type_t)UINT32_MAX);
+            } else {
+                fatal_caught = true;
+            }
+
+            // The fatal_caught variable has to be set to true as sigsetjmp on the second execution will return a value
+            // different from zero.
+            // A sigsegv raised by the kernel because of the memory protection means that the stack overflow protection
+            // is working as intended
+            REQUIRE(fatal_caught);
+        }
+#endif
+    }
+
+    SECTION("epoch_gc_register_object_type_destructor_cb") {
+        SECTION("valid object type and valid function pointer") {
+            epoch_gc_register_object_type_destructor_cb(
+                    EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+                    test_epoch_gc_object_destructor_cb);
+
+            REQUIRE(epoch_gc_staged_object_destructor_cb[EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX] ==
+                test_epoch_gc_object_destructor_cb);
+
+            epoch_gc_staged_object_destructor_cb[EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX] = nullptr;
+        }
+
+#if DEBUG == 1
+        SECTION("invalid object type") {
+            bool fatal_caught = false;
+            if (sigsetjmp(test_epoch_gc_jump_fp, 1) == 0) {
+                test_epoch_gc_signal_sigabrt_and_sigsegv_handler_setup();
+                epoch_gc_register_object_type_destructor_cb(
+                        (epoch_gc_object_type_t)UINT32_MAX,
+                        test_epoch_gc_object_destructor_cb);
+            } else {
+                fatal_caught = true;
+            }
+
+            // The fatal_caught variable has to be set to true as sigsetjmp on the second execution will return a value
+            // different from zero.
+            // A sigsegv raised by the kernel because of the memory protection means that the stack overflow protection
+            // is working as intended
+            REQUIRE(fatal_caught);
+        }
+#endif
+    }
+
+    SECTION("epoch_gc_thread_append_new_staged_objects_ring") {
+        epoch_gc_thread_t epoch_gc_thread = { nullptr };
+        epoch_gc_thread.staged_objects_ring_list = double_linked_list_init();
+
+        SECTION("append 1 new ring") {
+            epoch_gc_thread_append_new_staged_objects_ring(&epoch_gc_thread);
+
+            REQUIRE(epoch_gc_thread.staged_objects_ring_list->count == 1);
+            REQUIRE(epoch_gc_thread.staged_objects_ring_list->tail->data == epoch_gc_thread.staged_objects_ring_last);
+            REQUIRE(ring_bounded_spsc_get_length(epoch_gc_thread.staged_objects_ring_last) == 0);
+        }
+
+        SECTION("append 2 new rings") {
+            epoch_gc_thread_append_new_staged_objects_ring(&epoch_gc_thread);
+
+            REQUIRE(epoch_gc_thread.staged_objects_ring_list->count == 2);
+            REQUIRE(epoch_gc_thread.staged_objects_ring_list->tail->data == epoch_gc_thread.staged_objects_ring_last);
+            REQUIRE(ring_bounded_spsc_get_length(epoch_gc_thread.staged_objects_ring_last) == 0);
+        }
+
+        SECTION("append multiple new rings") {
+            for(int i = 0; i < 64; i++) {
+                epoch_gc_thread_append_new_staged_objects_ring(&epoch_gc_thread);
+            }
+
+            REQUIRE(epoch_gc_thread.staged_objects_ring_list->count == 64);
+            REQUIRE(epoch_gc_thread.staged_objects_ring_list->tail->data == epoch_gc_thread.staged_objects_ring_last);
+            REQUIRE(ring_bounded_spsc_get_length(epoch_gc_thread.staged_objects_ring_last) == 0);
+        }
+
+        double_linked_list_item_t *rb_item = epoch_gc_thread.staged_objects_ring_list->head;
+        while(rb_item != nullptr) {
+            double_linked_list_item_t *current = rb_item;
+            rb_item = rb_item->next;
+
+            ring_bounded_spsc_free((ring_bounded_spsc_t*)current->data);
+            double_linked_list_item_free(current);
+        }
+
+        double_linked_list_free(epoch_gc_thread.staged_objects_ring_list);
+    }
+
+    SECTION("epoch_gc_thread_init") {
+        epoch_gc_t epoch_gc = { 0 };
+        epoch_gc.thread_list = double_linked_list_init();
+        epoch_gc.object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX;
+        spinlock_init(&epoch_gc.thread_list_spinlock);
+
+        SECTION("create one thread") {
+            auto epoch_gc_thread = epoch_gc_thread_init(&epoch_gc);
+
+            REQUIRE(epoch_gc_thread != nullptr);
+            REQUIRE(epoch_gc_thread->epoch == 0);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_list->count == 1);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_list->tail->data == epoch_gc_thread->staged_objects_ring_last);
+            REQUIRE(ring_bounded_spsc_get_length(epoch_gc_thread->staged_objects_ring_last) == 0);
+        }
+
+        // Free the thread list
+        double_linked_list_free(epoch_gc.thread_list);
+    }
+
+    SECTION("epoch_gc_thread_register_global") {
+        epoch_gc_t epoch_gc = { 0 };
+        epoch_gc.thread_list = double_linked_list_init();
+        epoch_gc.object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX;
+        spinlock_init(&epoch_gc.thread_list_spinlock);
+
+        epoch_gc_thread_t *epoch_gc_thread_1 = epoch_gc_thread_init(&epoch_gc);
+        epoch_gc_thread_t *epoch_gc_thread_2 = epoch_gc_thread_init(&epoch_gc);
+        epoch_gc_thread_t *epoch_gc_thread_3 = epoch_gc_thread_init(&epoch_gc);
+
+        SECTION("register one thread") {
+            epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread_1);
+
+            REQUIRE(epoch_gc_thread_1->epoch_gc == &epoch_gc);
+            REQUIRE(epoch_gc.thread_list->count == 1);
+            REQUIRE(epoch_gc.thread_list->tail->data == epoch_gc_thread_1);
+        }
+
+        SECTION("register two thread") {
+            epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread_1);
+            epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread_2);
+
+            REQUIRE(epoch_gc_thread_1->epoch_gc == &epoch_gc);
+            REQUIRE(epoch_gc_thread_2->epoch_gc == &epoch_gc);
+            REQUIRE(epoch_gc.thread_list->count == 2);
+            REQUIRE(epoch_gc.thread_list->tail->data == epoch_gc_thread_2);
+        }
+
+        SECTION("register multiple threads") {
+            epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread_1);
+            epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread_2);
+            epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread_3);
+
+            REQUIRE(epoch_gc_thread_1->epoch_gc == &epoch_gc);
+            REQUIRE(epoch_gc_thread_2->epoch_gc == &epoch_gc);
+            REQUIRE(epoch_gc_thread_3->epoch_gc == &epoch_gc);
+            REQUIRE(epoch_gc.thread_list->count == 3);
+            REQUIRE(epoch_gc.thread_list->tail->data == epoch_gc_thread_3);
+        }
+
+        // Free up the list of threads and the related data
+        double_linked_list_item_t *item = epoch_gc.thread_list->head;
+        while(item != nullptr) {
+            double_linked_list_item_t *current = item;
+            item = item->next;
+
+            epoch_gc_thread_free((epoch_gc_thread_t*)current->data);
+            double_linked_list_item_free(current);
+        }
+
+        // Free the thread list
+        double_linked_list_free(epoch_gc.thread_list);
+    }
+
+    SECTION("epoch_gc_thread_register_local") {
+        epoch_gc_t epoch_gc = {
+                .object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+        };
+
+        epoch_gc_thread_t epoch_gc_thread = {
+                .epoch_gc = &epoch_gc,
+        };
+
+        epoch_gc_thread_register_local(&epoch_gc_thread);
+
+        REQUIRE(thread_local_epoch_gc[epoch_gc.object_type] == &epoch_gc_thread);
+
+        thread_local_epoch_gc[epoch_gc.object_type] = nullptr;
+    }
+
+    SECTION("epoch_gc_thread_get_instance") {
+        epoch_gc_t epoch_gc = {
+                .object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+        };
+
+        epoch_gc_thread_t epoch_gc_thread = { nullptr };
+
+        epoch_gc_thread_register_local(&epoch_gc_thread);
+
+        epoch_gc_t *epoch_gc_new = nullptr;
+        epoch_gc_thread_t *epoch_gc_thread_new = nullptr;
+
+        epoch_gc_thread_get_instance(
+                EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+                &epoch_gc_new,
+                &epoch_gc_thread_new);
+
+        REQUIRE(&epoch_gc == epoch_gc_new);
+        REQUIRE(&epoch_gc_thread == epoch_gc_thread_new);
+
+        thread_local_epoch_gc[epoch_gc.object_type] = nullptr;
+    }
+
+    SECTION("epoch_gc_thread_is_terminated") {
+        epoch_gc_t epoch_gc = {
+                .object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+        };
+
+        epoch_gc_thread_t epoch_gc_thread = {
+                .epoch_gc = &epoch_gc,
+        };
+
+        epoch_gc_thread_register_local(&epoch_gc_thread);
+
+        SECTION("true") {
+            epoch_gc_thread.thread_terminated = true;
+            REQUIRE(epoch_gc_thread_is_terminated(&epoch_gc_thread) == true);
+        }
+
+        SECTION("false") {
+            epoch_gc_thread.thread_terminated = false;
+            REQUIRE(epoch_gc_thread_is_terminated(&epoch_gc_thread) == false);
+        }
+    }
+
+    SECTION("epoch_gc_thread_terminate") {
+        epoch_gc_t epoch_gc = {
+                .object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+        };
+
+        epoch_gc_thread_t epoch_gc_thread = {
+                .epoch_gc = &epoch_gc,
+                .thread_terminated = false,
+        };
+
+        SECTION("terminate") {
+            epoch_gc_thread_terminate(&epoch_gc_thread);
+            REQUIRE(epoch_gc_thread_is_terminated(&epoch_gc_thread) == true);
+        }
+    }
+
+    SECTION("epoch_gc_thread_advance_epoch") {
+        epoch_gc_t epoch_gc = {
+                .object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+        };
+
+        epoch_gc_thread_t epoch_gc_thread = {
+                .epoch = 0,
+                .epoch_gc = &epoch_gc,
+        };
+
+        SECTION("advance once") {
+            epoch_gc_thread_advance_epoch(&epoch_gc_thread);
+            REQUIRE(epoch_gc_thread.epoch > 0);
+        }
+
+        SECTION("advance twice") {
+            epoch_gc_thread_advance_epoch(&epoch_gc_thread);
+            uint64_t epoch_temp = epoch_gc_thread.epoch;
+            usleep(10000);
+            epoch_gc_thread_advance_epoch(&epoch_gc_thread);
+            REQUIRE(epoch_gc_thread.epoch > epoch_temp);
+        }
+    }
+
+    SECTION("epoch_gc_thread_destruct_staged_objects_batch") {
+        epoch_gc_staged_object_t *staged_objects[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE];
+
+        for(uint64_t i = 0; i < EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE; i++) {
+            staged_objects[i] = (epoch_gc_staged_object_t*)ffma_mem_alloc(16);
+            staged_objects[i]->object = (void*)i;
+        }
+
+        epoch_gc_thread_destruct_staged_objects_batch(
+                test_epoch_gc_object_destructor_cb,
+                EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE,
+                staged_objects);
+
+        REQUIRE(test_epoch_gc_object_destructor_cb_params_staged_objects_count ==
+            EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE);
+        REQUIRE(test_epoch_gc_object_destructor_cb_params_staged_objects ==
+            staged_objects);
+    }
+
+    SECTION("epoch_gc_thread_collect") {
+        epoch_gc_t epoch_gc = { 0 };
+        epoch_gc.thread_list = double_linked_list_init();
+        epoch_gc.object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX;
+        spinlock_init(&epoch_gc.thread_list_spinlock);
+
+        epoch_gc_thread_t *epoch_gc_thread = epoch_gc_thread_init(&epoch_gc);
+
+        epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread);
+
+        auto epoch_gc_staged_object_1 =
+                (epoch_gc_staged_object_t*)ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+        auto epoch_gc_staged_object_2 =
+                (epoch_gc_staged_object_t*)ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+
+        epoch_gc_staged_object_1->epoch = 100;
+        epoch_gc_staged_object_1->object = (void*)1;
+
+        epoch_gc_staged_object_2->epoch = 200;
+        epoch_gc_staged_object_2->object = (void*)2;
+
+        ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, epoch_gc_staged_object_1);
+        ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, epoch_gc_staged_object_2);
+
+        SECTION("two pointers, collect 2, no collection because of epoch") {
+
+            epoch_gc_thread->epoch = 100;
+
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 2) == 0);
+        }
+
+        SECTION("two pointers, collect 2, 1 collected because of epoch") {
+            epoch_gc_thread->epoch = 101;
+
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 2) == 1);
+
+            epoch_gc_staged_object_1 = nullptr;
+        }
+
+        SECTION("two pointers, collect 2, 2 collected because of epoch") {
+            epoch_gc_thread->epoch = 201;
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 2) == 2);
+
+            epoch_gc_staged_object_1 = nullptr;
+            epoch_gc_staged_object_2 = nullptr;
+        }
+
+        SECTION("two pointers, collect 2, 2 collected because of epoch in two rounds") {
+            epoch_gc_thread->epoch = 201;
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 1) == 1);
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 1) == 1);
+
+            epoch_gc_staged_object_1 = nullptr;
+            epoch_gc_staged_object_2 = nullptr;
+        }
+
+        SECTION("test empty ring removal") {
+            auto epoch_gc_staged_object_3 =
+                    (epoch_gc_staged_object_t*)ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+            epoch_gc_staged_object_3->epoch = 300;
+            epoch_gc_staged_object_3->object = (void*)1;
+
+            epoch_gc_thread_append_new_staged_objects_ring(epoch_gc_thread);
+            ring_bounded_spsc_t *ring_initial = epoch_gc_thread->staged_objects_ring_last;
+            ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, epoch_gc_staged_object_3);
+
+            epoch_gc_thread->epoch = 301;
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 1) == 1);
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 1) == 1);
+            REQUIRE(epoch_gc_thread_collect(epoch_gc_thread, 1) == 1);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_last != ring_initial);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_list->count == 1);
+
+            epoch_gc_staged_object_1 = nullptr;
+            epoch_gc_staged_object_2 = nullptr;
+        }
+
+        if (epoch_gc_staged_object_1) {
+            ffma_mem_free(epoch_gc_staged_object_1);
+        }
+
+        if (epoch_gc_staged_object_2) {
+            ffma_mem_free(epoch_gc_staged_object_2);
+        }
+
+        epoch_gc_thread_unregister_global(epoch_gc_thread);
+    }
+
+    SECTION("epoch_gc_thread_collect_all") {
+        epoch_gc_t epoch_gc = { 0 };
+        epoch_gc.thread_list = double_linked_list_init();
+        epoch_gc.object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX;
+        spinlock_init(&epoch_gc.thread_list_spinlock);
+
+        epoch_gc_thread_t *epoch_gc_thread = epoch_gc_thread_init(&epoch_gc);
+
+        epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread);
+
+        auto epoch_gc_staged_object_1 =
+                (epoch_gc_staged_object_t*)ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+        auto epoch_gc_staged_object_2 =
+                (epoch_gc_staged_object_t*)ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+
+        epoch_gc_staged_object_1->epoch = 100;
+        epoch_gc_staged_object_1->object = (void*)1;
+
+        epoch_gc_staged_object_2->epoch = 200;
+        epoch_gc_staged_object_2->object = (void*)2;
+
+        ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, epoch_gc_staged_object_1);
+        ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, epoch_gc_staged_object_2);
+
+        SECTION("two pointers, collect 2, no collection because of epoch") {
+
+            epoch_gc_thread->epoch = 100;
+
+            REQUIRE(epoch_gc_thread_collect_all(epoch_gc_thread) == 0);
+        }
+
+        SECTION("two pointers, collect 2, 1 collected because of epoch") {
+            epoch_gc_thread->epoch = 101;
+
+            REQUIRE(epoch_gc_thread_collect_all(epoch_gc_thread) == 1);
+
+            epoch_gc_staged_object_1 = nullptr;
+        }
+
+        SECTION("two pointers, collect 2, 2 collected because of epoch") {
+            epoch_gc_thread->epoch = 201;
+            REQUIRE(epoch_gc_thread_collect_all(epoch_gc_thread) == 2);
+
+            epoch_gc_staged_object_1 = nullptr;
+            epoch_gc_staged_object_2 = nullptr;
+        }
+
+        SECTION("test empty ring removal") {
+            auto epoch_gc_staged_object_3 =
+                    (epoch_gc_staged_object_t*)ffma_mem_alloc(sizeof(epoch_gc_staged_object_t));
+            epoch_gc_staged_object_3->epoch = 300;
+            epoch_gc_staged_object_3->object = (void*)1;
+
+            epoch_gc_thread_append_new_staged_objects_ring(epoch_gc_thread);
+            ring_bounded_spsc_t *ring_initial = epoch_gc_thread->staged_objects_ring_last;
+            ring_bounded_spsc_enqueue(epoch_gc_thread->staged_objects_ring_last, epoch_gc_staged_object_3);
+
+            epoch_gc_thread->epoch = 301;
+            REQUIRE(epoch_gc_thread_collect_all(epoch_gc_thread) == 3);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_last != ring_initial);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_list->count == 1);
+
+            epoch_gc_staged_object_1 = nullptr;
+            epoch_gc_staged_object_2 = nullptr;
+        }
+
+        if (epoch_gc_staged_object_1) {
+            ffma_mem_free(epoch_gc_staged_object_1);
+        }
+
+        if (epoch_gc_staged_object_2) {
+            ffma_mem_free(epoch_gc_staged_object_2);
+        }
+
+        epoch_gc_thread_unregister_global(epoch_gc_thread);
+    }
+
+    SECTION("epoch_gc_stage_object") {
+        epoch_gc_register_object_type_destructor_cb(
+                EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+                test_epoch_gc_object_destructor_cb);
+
+        epoch_gc_t epoch_gc = { 0 };
+        epoch_gc.thread_list = double_linked_list_init();
+        epoch_gc.object_type = EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX;
+        spinlock_init(&epoch_gc.thread_list_spinlock);
+
+        epoch_gc_thread_t *epoch_gc_thread = epoch_gc_thread_init(&epoch_gc);
+
+        epoch_gc_thread_register_global(&epoch_gc, epoch_gc_thread);
+        epoch_gc_thread_register_local(epoch_gc_thread);
+
+        SECTION("stage 1 object") {
+            REQUIRE(epoch_gc_stage_object(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX, (void*)1) == true);
+
+            REQUIRE(ring_bounded_spsc_get_length(epoch_gc_thread->staged_objects_ring_last) == 1);
+            REQUIRE(((epoch_gc_staged_object_t*)ring_bounded_spsc_dequeue(
+                    epoch_gc_thread->staged_objects_ring_last))->object == (void*)1);
+        }
+
+        SECTION("stage 2 objects") {
+            REQUIRE(epoch_gc_stage_object(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX, (void*)1) == true);
+            usleep(10000);
+            REQUIRE(epoch_gc_stage_object(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX, (void*)2) == true);
+
+            REQUIRE(ring_bounded_spsc_get_length(epoch_gc_thread->staged_objects_ring_last) == 2);
+
+            auto* staged_object_1 =
+                    (epoch_gc_staged_object_t*)ring_bounded_spsc_dequeue(epoch_gc_thread->staged_objects_ring_last);
+            auto* staged_object_2 =
+                    (epoch_gc_staged_object_t*)ring_bounded_spsc_dequeue(epoch_gc_thread->staged_objects_ring_last);
+
+            REQUIRE(staged_object_1->object == (void*)1);
+            REQUIRE(staged_object_2->object == (void*)2);
+            REQUIRE(staged_object_2->epoch > staged_object_1->epoch);
+        }
+
+        SECTION("fill one ring") {
+            ring_bounded_spsc_t *ring_initial = epoch_gc_thread->staged_objects_ring_last;
+
+            for(uint64_t i = 0; i < EPOCH_GC_STAGED_OBJECTS_RING_SIZE + 1; i++) {
+                REQUIRE(epoch_gc_stage_object(
+                        EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX, (void*)i) == true);
+            }
+
+            REQUIRE(ring_bounded_spsc_get_length(
+                    (ring_bounded_spsc_t*)epoch_gc_thread->staged_objects_ring_list->head
+                    ) == EPOCH_GC_STAGED_OBJECTS_RING_SIZE);
+            REQUIRE(ring_bounded_spsc_get_length(
+                    (ring_bounded_spsc_t*)epoch_gc_thread->staged_objects_ring_list->tail) == 1);
+
+            REQUIRE(epoch_gc_thread->staged_objects_ring_last != ring_initial);
+            REQUIRE(epoch_gc_thread->staged_objects_ring_list->count == 2);
+        }
+
+        // Free up the staged objects
+        double_linked_list_item_t *item = epoch_gc_thread->staged_objects_ring_list->head;
+        while(item != nullptr) {
+            double_linked_list_item_t *current = item;
+            auto *ring = (ring_bounded_spsc_t*)current->data;
+            item = item->next;
+
+            // When freeing the epoch_gc_thread structure there should NEVER be staged objects in the ring
+            epoch_gc_staged_object_t *staged_object = nullptr;
+            while((staged_object = (epoch_gc_staged_object_t*)ring_bounded_spsc_dequeue(ring)) != nullptr) {
+                ffma_mem_free(staged_object);
+            }
+
+            ring_bounded_spsc_free(ring);
+            double_linked_list_item_free(current);
+        }
+
+        double_linked_list_free(epoch_gc_thread->staged_objects_ring_list);
+
+        epoch_gc_thread_unregister_global(epoch_gc_thread);
+
+        epoch_gc_staged_object_destructor_cb[EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX] = nullptr;
+    }
+}


### PR DESCRIPTION
This PR introduces an initial version of an epoch garbage collector [1], which is a corner stone for the new iteration of the internal KeyValue database.

The epoch garbage collector works on a very simple principle:
- data can be staged for deletion by any thread
- any thread wanting to use the garbage collector has to register
- when a pointer is staged is associated with an object type and with the epoch of the staging
- for each object type a destructor is registered
- threads have to advance their own epoch (and will use a queue of operations to track the operations, will be introduced in a future PR)
- threads can stage pointers only in their own queue
- an ad-hoc thread for the gc is required, when the collection runs the lowest epoch is selected among the threads and all the staged pointers that have an older epoch are batched together and submitted for collection.

There are currently 4 different object types but this might change down the line.

The epoch gc uses a double linked list for the threads, that requires a spinlock when is used, and uses a double linked list of ring bounded spsc to stage the pointers to clean up, the list is expanded only when the current ring is full of staged pointers that can't be deleted.

Pointers are traced only when they are submitted for deletion, not before, to avoid overloading the system for no reason.

[1] https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)