### PR TITLE
Add an .ignore file to exclude vendors, fixtures, various binary data from the SLOC

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,13 @@
+3rdparty/*
+!3rdparty/*.cmake
+
+tests/unit_tests/fixtures/*
+
+*.md
+*.txt
+*.json
+
+.venv
+cmake-build-*
+.ignore
+.git*


### PR DESCRIPTION
This PR add a .ignore file to exclude vendors source code, binary data and fixtures from the SLOC as the README is now displaying an extremely high number of lines of code and a crazy COCOMO because of 2 text files added as fixtures to test the Adaptive Radix Tree data structure.