### PR TITLE
Point the SLOC and COCOMO badges to self hosted ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build & Test](https://github.com/danielealbano/cachegrand/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/danielealbano/cachegrand/actions/workflows/build_and_test.yml)
 [![codecov](https://codecov.io/gh/danielealbano/cachegrand/branch/main/graph/badge.svg?token=H4W0N0F7MT)](https://codecov.io/gh/danielealbano/cachegrand)
 [![LGTM Grade](https://img.shields.io/lgtm/grade/cpp/github/danielealbano/cachegrand?label=lgtm%20code%20quality)](https://lgtm.com/projects/g/danielealbano/cachegrand/context:cpp)
-![Lines of code](https://sloc.xyz/github/danielealbano/cachegrand)
-[![COCOMO](https://sloc.xyz/github/danielealbano/cachegrand?category=cocomo)](https://en.wikipedia.org/wiki/COCOMO)
+![Lines of code](https://badges.cachegrand.io/svg/ssc-total-lines.svg)
+[![COCOMO](https://badges.cachegrand.io/svg/ssc-cocomo.svg)](https://en.wikipedia.org/wiki/COCOMO)
 [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/danielealbano)
 
 <p align="center">


### PR DESCRIPTION
This PR contains a minor change to the readme to use self-generated badges for SLOC and COCOMO.

The badges are automatically generated when a new PR is merged onto master via a webhook using:
- scc ( https://github.com/boyter/scc )
- shields.io
 