### PR TITLE
Implement epoch based gc worker

### DIFF
--- a/src/epoch_gc_worker.c
+++ b/src/epoch_gc_worker.c
@@ -1,0 +1,262 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#define _GNU_SOURCE
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdatomic.h>
+#include <pthread.h>
+
+#include "misc.h"
+#include "log/log.h"
+#include "xalloc.h"
+#include "memory_fences.h"
+#include "spinlock.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
+#include "epoch_gc.h"
+
+#include "epoch_gc_worker.h"
+
+#define TAG "epoch_gc_worker"
+
+bool epoch_gc_worker_should_terminate(
+        epoch_gc_worker_context_t *context) {
+    MEMORY_FENCE_LOAD();
+    return *context->terminate_event_loop;
+}
+
+char* epoch_gc_worker_log_producer_set_early_prefix_thread(
+        epoch_gc_worker_context_t *context) {
+    size_t prefix_size = snprintf(
+            NULL,
+            0,
+            EPOCH_GC_THREAD_LOG_PRODUCER_PREFIX_TEMPLATE,
+            context->epoch_gc->object_type) + 1;
+    char *prefix = xalloc_alloc_zero(prefix_size);
+
+    snprintf(
+            prefix,
+            prefix_size,
+            EPOCH_GC_THREAD_LOG_PRODUCER_PREFIX_TEMPLATE,
+            context->epoch_gc->object_type);
+    log_set_early_prefix_thread(prefix);
+
+    return prefix;
+}
+
+char *epoch_gc_worker_set_thread_name(
+        epoch_gc_worker_context_t *context) {
+    size_t thread_name_size = snprintf(
+            NULL,
+            0,
+            EPOCH_GC_THREAD_NAME_TEMPLATE,
+            context->epoch_gc->object_type) + 1;
+
+    // The thread name can be long max 16 chars including the nul terminator
+    if (thread_name_size > 16) {
+        thread_name_size = 16;
+    }
+
+    char *thread_name = xalloc_alloc_zero(thread_name_size);
+    snprintf(
+            thread_name,
+            thread_name_size,
+            EPOCH_GC_THREAD_NAME_TEMPLATE,
+            context->epoch_gc->object_type);
+    thread_name[thread_name_size - 1] = 0;
+
+    if (pthread_setname_np(
+            pthread_self(),
+            thread_name) != 0) {
+        LOG_E(TAG, "Unable to set name of the signal handler thread");
+        LOG_E_OS_ERROR(TAG);
+    }
+
+    return thread_name;
+}
+
+void epoch_gc_worker_free_thread_list_cache(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache) {
+    if (epoch_gc_thread_list_cache == NULL) {
+        return;
+    }
+
+    xalloc_free(epoch_gc_thread_list_cache);
+}
+
+void epoch_gc_worker_build_thread_list_cache(
+        epoch_gc_t *epoch_gc,
+        epoch_gc_thread_t ***epoch_gc_thread_list_cache,
+        uint64_t *epoch_gc_thread_list_change_epoch,
+        uint32_t *epoch_gc_thread_list_length) {
+    uint32_t epoch_gc_thread_list_index;
+
+    // Lock the thread list
+    spinlock_lock(&epoch_gc->thread_list_spinlock);
+
+    // Fetch the length and build the array of cached threads
+    *epoch_gc_thread_list_length = epoch_gc->thread_list->count;
+    *epoch_gc_thread_list_cache = (epoch_gc_thread_t**)xalloc_alloc(
+            *epoch_gc_thread_list_length * sizeof(epoch_gc_thread_t*));
+
+    // Iterate over the double linked list
+    epoch_gc_thread_list_index = 0;
+    double_linked_list_item_t *item = NULL;
+    while((item = double_linked_list_iter_next(epoch_gc->thread_list, item)) != NULL) {
+        (*epoch_gc_thread_list_cache)[epoch_gc_thread_list_index] = (epoch_gc_thread_t*)item->data;
+        epoch_gc_thread_list_index++;
+    }
+
+    // Fetch the epoch of the last change
+    *epoch_gc_thread_list_change_epoch = epoch_gc->thread_list_change_epoch;
+
+    // Unlock the thread list
+    spinlock_unlock(&epoch_gc->thread_list_spinlock);
+}
+
+uint32_t epoch_gc_worker_collect_staged_objects(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache,
+        uint32_t epoch_gc_thread_list_length,
+        bool force) {
+    uint32_t collected_objects = 0;
+
+    // Iterate over the cached epoch gc threads
+    for(
+            uint32_t epoch_gc_thread_list_index = 0;
+            epoch_gc_thread_list_index < epoch_gc_thread_list_length;
+            epoch_gc_thread_list_index++) {
+        if (unlikely(force)) {
+            // Force an epoch advance to be able to collect everything
+            epoch_gc_thread_advance_epoch_tsc(epoch_gc_thread_list_cache[epoch_gc_thread_list_index]);
+        }
+
+        collected_objects += epoch_gc_thread_collect_all(
+                epoch_gc_thread_list_cache[epoch_gc_thread_list_index]);
+    }
+
+    return collected_objects;
+}
+
+void epoch_gc_worker_wait_for_epoch_gc_threads_termination(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache,
+        uint32_t epoch_gc_thread_list_length) {
+    // Wait for all the threads using this gc to be marked as terminated
+    bool epoch_gc_all_terminated;
+    do {
+        epoch_gc_all_terminated = true;
+        for(
+                uint32_t epoch_gc_thread_list_index = 0;
+                epoch_gc_thread_list_index < epoch_gc_thread_list_length;
+                epoch_gc_thread_list_index++) {
+            if (!epoch_gc_thread_is_terminated(epoch_gc_thread_list_cache[epoch_gc_thread_list_index])) {
+                epoch_gc_all_terminated = false;
+                break;
+            }
+        }
+    } while(!epoch_gc_all_terminated);
+}
+
+void epoch_gc_worker_free_epoch_gc_thread(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache,
+        uint32_t epoch_gc_thread_list_length) {
+    for(
+            uint32_t epoch_gc_thread_list_index = 0;
+            epoch_gc_thread_list_index < epoch_gc_thread_list_length;
+            epoch_gc_thread_list_index++) {
+        epoch_gc_thread_unregister_global(epoch_gc_thread_list_cache[epoch_gc_thread_list_index]);
+        epoch_gc_thread_free(epoch_gc_thread_list_cache[epoch_gc_thread_list_index]);
+    }
+}
+
+void epoch_gc_worker_main_loop(
+        epoch_gc_worker_context_t *epoch_gc_worker_context) {
+    epoch_gc_t *epoch_gc = epoch_gc_worker_context->epoch_gc;
+    epoch_gc_thread_t **epoch_gc_thread_list_cache = NULL;
+    uint32_t epoch_gc_thread_list_index = 0;
+    uint64_t epoch_gc_thread_list_change_epoch = 0;
+
+    do {
+        usleep(EPOCH_GC_THREAD_LOOP_WAIT_TIME_MS * 1000);
+
+        // Check if the cache of threads for the epoch_gc needs to be rebuilt
+        MEMORY_FENCE_LOAD();
+        if (epoch_gc_thread_list_change_epoch == 0 ||
+            epoch_gc_thread_list_change_epoch != epoch_gc->thread_list_change_epoch) {
+            epoch_gc_worker_free_thread_list_cache(epoch_gc_thread_list_cache);
+            epoch_gc_worker_build_thread_list_cache(
+                    epoch_gc,
+                    &epoch_gc_thread_list_cache,
+                    &epoch_gc_thread_list_change_epoch,
+                    &epoch_gc_thread_list_index);
+        }
+
+        epoch_gc_worker_context->stats.collected_objects += epoch_gc_worker_collect_staged_objects(
+                epoch_gc_thread_list_cache,
+                epoch_gc_thread_list_index,
+                false);
+        MEMORY_FENCE_STORE();
+    } while(!epoch_gc_worker_should_terminate(epoch_gc_worker_context));
+
+    // Wait for all the thread attached to the current epoch gc to terminate before moving on
+    epoch_gc_worker_wait_for_epoch_gc_threads_termination(
+            epoch_gc_thread_list_cache,
+            epoch_gc_thread_list_index);
+
+    // All the threads are terminated, advance the epoch on the epoch_gc_thread, trigger a collect_all and at the end
+    // free the structure
+    epoch_gc_worker_context->stats.collected_objects += epoch_gc_worker_collect_staged_objects(
+            epoch_gc_thread_list_cache,
+            epoch_gc_thread_list_index,
+            true);
+    MEMORY_FENCE_STORE();
+
+    // Unregister and free all the epoch_gc_thread
+    epoch_gc_worker_free_epoch_gc_thread(
+            epoch_gc_thread_list_cache,
+            epoch_gc_thread_list_index);
+
+    // Free up the cache
+    epoch_gc_worker_free_thread_list_cache(epoch_gc_thread_list_cache);
+}
+
+bool epoch_gc_worker_teardown(
+        char *log_producer_early_prefix_thread,
+        char *thread_name) {
+    bool res = true;
+
+    LOG_V(TAG, "Tearing down signal handler thread");
+
+    xalloc_free(log_producer_early_prefix_thread);
+    xalloc_free(thread_name);
+    log_unset_early_prefix_thread();
+
+    return res;
+}
+
+void* epoch_gc_worker_func(
+        void* user_data) {
+    epoch_gc_worker_context_t *epoch_gc_worker_context = (epoch_gc_worker_context_t*)user_data;
+
+    // Initial setup
+    char *log_producer_early_prefix_thread =
+            epoch_gc_worker_log_producer_set_early_prefix_thread(epoch_gc_worker_context);
+    char *thread_name = epoch_gc_worker_set_thread_name(epoch_gc_worker_context);
+
+    // Thread main loop
+    epoch_gc_worker_main_loop(epoch_gc_worker_context);
+
+    // Teardown
+    epoch_gc_worker_teardown(
+            log_producer_early_prefix_thread,
+            thread_name);
+
+    return NULL;
+}

--- a/src/epoch_gc_worker.h
+++ b/src/epoch_gc_worker.h
@@ -1,0 +1,67 @@
+#ifndef CACHEGRAND_EPOCH_GC_WORKER_H
+#define CACHEGRAND_EPOCH_GC_WORKER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EPOCH_GC_THREAD_LOOP_WAIT_TIME_MS 5000
+#define EPOCH_GC_THREAD_LOG_PRODUCER_PREFIX_TEMPLATE "[epoch gc %d]"
+#define EPOCH_GC_THREAD_NAME_TEMPLATE "epoch_gc_%d"
+
+typedef struct epoch_gc_worker_context epoch_gc_worker_context_t;
+struct epoch_gc_worker_context {
+    pthread_t pthread;
+    epoch_gc_t *epoch_gc;
+    volatile bool *terminate_event_loop;
+    struct {
+        uint64_t collected_objects;
+    } stats;
+};
+
+bool epoch_gc_worker_should_terminate(
+        epoch_gc_worker_context_t *context);
+
+char *epoch_gc_worker_set_thread_name(
+        epoch_gc_worker_context_t *context);
+
+char* epoch_gc_worker_log_producer_set_early_prefix_thread(
+        epoch_gc_worker_context_t *context);
+
+void epoch_gc_worker_free_thread_list_cache(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache);
+
+void epoch_gc_worker_build_thread_list_cache(
+        epoch_gc_t *epoch_gc,
+        epoch_gc_thread_t ***epoch_gc_thread_list_cache,
+        uint64_t *epoch_gc_thread_list_change_epoch,
+        uint32_t *epoch_gc_thread_list_length);
+
+uint32_t epoch_gc_worker_collect_staged_objects(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache,
+        uint32_t epoch_gc_thread_list_length,
+        bool force);
+
+void epoch_gc_worker_wait_for_epoch_gc_threads_termination(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache,
+        uint32_t epoch_gc_thread_list_length);
+
+void epoch_gc_worker_free_epoch_gc_thread(
+        epoch_gc_thread_t **epoch_gc_thread_list_cache,
+        uint32_t epoch_gc_thread_list_length);
+
+void epoch_gc_worker_main_loop(
+        epoch_gc_worker_context_t *epoch_gc_worker_context);
+
+bool epoch_gc_worker_teardown(
+        char *log_producer_early_prefix_thread,
+        char *thread_name);
+
+void* epoch_gc_worker_func(
+        void* user_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_EPOCH_GC_WORKER_H

--- a/tests/unit_tests/test-epoch-gc-worker.cpp
+++ b/tests/unit_tests/test-epoch-gc-worker.cpp
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch.hpp>
+
+#include <cstdint>
+#include <cstdbool>
+#include <cstring>
+#include <pthread.h>
+
+#include "clock.h"
+#include "random.h"
+#include "spinlock.h"
+#include "xalloc.h"
+#include "utils_cpu.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
+#include "epoch_gc.h"
+
+#include "epoch_gc_worker.h"
+
+void test_epoch_gc_worker_object_destructor_cb_real(
+        uint8_t staged_objects_count,
+        epoch_gc_staged_object_t staged_objects[EPOCH_GC_STAGED_OBJECT_DESTRUCTOR_CB_BATCH_SIZE]) {
+    for(uint64_t i = 0; i < staged_objects_count; i++) {
+        free(staged_objects[i].data.object);
+    }
+}
+
+typedef struct test_epoch_gc_worker_fuzzy_separated_producer_consumer_thread_data
+    test_epoch_gc_worker_fuzzy_separated_producer_consumer_thread_data_t;
+struct test_epoch_gc_worker_fuzzy_separated_producer_consumer_thread_data {
+    bool *terminate;
+    epoch_gc_t *epoch_gc;
+    uint64_t staged_objects_counter;
+};
+
+void *test_epoch_gc_worker_fuzzy_separated_producer_consumer_producer_thread_func(
+        void *user_data) {
+    auto thread_data = (test_epoch_gc_worker_fuzzy_separated_producer_consumer_thread_data_t*)user_data;
+
+    epoch_gc_thread_t *epoch_gc_thread = epoch_gc_thread_init();
+
+    epoch_gc_thread_register_global(thread_data->epoch_gc, epoch_gc_thread);
+    epoch_gc_thread_register_local(epoch_gc_thread);
+
+    do {
+        usleep(random_generate() % 5);
+
+        void *mem_ptr = malloc(8);
+        REQUIRE(epoch_gc_stage_object(epoch_gc_thread->epoch_gc->object_type, mem_ptr));
+        __atomic_fetch_add(&thread_data->staged_objects_counter, 1, __ATOMIC_ACQ_REL);
+
+        if (random_generate() % 1000 > 500) {
+            epoch_gc_thread_advance_epoch_tsc(epoch_gc_thread);
+        }
+
+        MEMORY_FENCE_LOAD();
+    } while(*thread_data->terminate == false);
+
+    epoch_gc_thread_terminate(epoch_gc_thread);
+    epoch_gc_thread_unregister_local(epoch_gc_thread);
+
+    return nullptr;
+}
+
+void test_epoch_gc_worker_fuzzy_separated_producers_consumer(
+        epoch_gc_t *epoch_gc,
+        uint64_t duration,
+        uint32_t producers_count) {
+    timespec_t start_time, current_time, diff_time;
+    pthread_t *pthread_producers;
+    pthread_attr_t attr;
+
+    bool terminate = false;
+    test_epoch_gc_worker_fuzzy_separated_producer_consumer_thread_data_t thread_data = {
+            .terminate = &terminate,
+            .epoch_gc = epoch_gc,
+            .staged_objects_counter = 0,
+    };
+    epoch_gc_worker_context_t epoch_gc_worker_context = {
+            .epoch_gc = epoch_gc,
+            .terminate_event_loop = &terminate,
+            .stats = {
+                .collected_objects = 0,
+            }
+    };
+
+    REQUIRE(pthread_attr_init(&attr) == 0);
+
+    // Start the requested producers
+    pthread_producers = (pthread_t*)malloc(producers_count * sizeof(pthread_t));
+    for(uint32_t i = 0; i < producers_count; i++) {
+        REQUIRE(pthread_create(
+                &pthread_producers[i],
+                &attr,
+                &test_epoch_gc_worker_fuzzy_separated_producer_consumer_producer_thread_func,
+                (void *)&thread_data) == 0);
+    }
+
+    // Start the consumer
+    REQUIRE(pthread_create(
+            &epoch_gc_worker_context.pthread,
+            &attr,
+            &epoch_gc_worker_func,
+            (void *)&epoch_gc_worker_context) == 0);
+
+    clock_monotonic(&start_time);
+
+    do {
+        clock_monotonic(&current_time);
+        sched_yield();
+
+        clock_diff(&start_time, &current_time, &diff_time);
+    } while(diff_time.tv_sec < duration);
+
+    terminate = true;
+    MEMORY_FENCE_STORE();
+
+    // The producers will terminate before the consumer
+    for(uint32_t i = 0; i < producers_count; i++) {
+        pthread_join(pthread_producers[i], nullptr);
+    }
+    pthread_join(epoch_gc_worker_context.pthread, nullptr);
+
+    REQUIRE(thread_data.staged_objects_counter == epoch_gc_worker_context.stats.collected_objects);
+
+    free(pthread_producers);
+}
+
+TEST_CASE("epoch_gc_worker.c", "[epoch_gc_worker]") {
+    SECTION("epoch_gc_worker_should_terminate") {
+        bool terminate = false;
+        epoch_gc_worker_context_t epoch_gc_worker_context = { .terminate_event_loop = &terminate };
+
+        SECTION("should terminate") {
+            terminate = true;
+            REQUIRE(epoch_gc_worker_should_terminate(&epoch_gc_worker_context) == true);
+        }
+
+        SECTION("should not terminate") {
+            terminate = false;
+            REQUIRE(epoch_gc_worker_should_terminate(&epoch_gc_worker_context) == false);
+        }
+    }
+
+    SECTION("epoch_gc_worker_log_producer_set_early_prefix_thread") {
+        char early_prefix_cmp[] = "[epoch gc 4]";
+        epoch_gc_t *epoch_gc = epoch_gc_init(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX);
+        epoch_gc_worker_context_t epoch_gc_worker_context = { .epoch_gc = epoch_gc };
+
+        char *early_prefix = epoch_gc_worker_log_producer_set_early_prefix_thread(
+                &epoch_gc_worker_context);
+
+        REQUIRE(strcmp(early_prefix, early_prefix_cmp) == 0);
+
+        xalloc_free(early_prefix);
+        epoch_gc_free(epoch_gc);
+    }
+
+    SECTION("epoch_gc_worker_set_thread_name") {
+        char thread_name_current[16] = { 0 };
+        char thread_name_cmp[] = "epoch_gc_4";
+        epoch_gc_t *epoch_gc = epoch_gc_init(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX);
+        epoch_gc_worker_context_t epoch_gc_worker_context = { .epoch_gc = epoch_gc };
+
+        pthread_getname_np(pthread_self(), thread_name_current, sizeof(thread_name_current));
+
+        char *thread_name = epoch_gc_worker_set_thread_name(&epoch_gc_worker_context);
+
+        pthread_setname_np(pthread_self(), thread_name_current);
+
+        REQUIRE(strcmp(thread_name, thread_name_cmp) == 0);
+
+        xalloc_free(thread_name);
+        epoch_gc_free(epoch_gc);
+    }
+
+    SECTION("fuzzy staging/collecting") {
+        epoch_gc_register_object_type_destructor_cb(
+                EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX,
+                test_epoch_gc_worker_object_destructor_cb_real);
+
+        epoch_gc_t *epoch_gc = epoch_gc_init(EPOCH_GC_OBJECT_TYPE_STORAGEDB_ENTRY_INDEX);
+
+        SECTION("one producer / one consumer") {
+            test_epoch_gc_worker_fuzzy_separated_producers_consumer(
+                    epoch_gc,
+                    2,
+                    1);
+        }
+
+        SECTION("multiple producers / one consumer") {
+            test_epoch_gc_worker_fuzzy_separated_producers_consumer(
+                    epoch_gc,
+                    2,
+                    utils_cpu_count());
+        }
+
+        epoch_gc_free(epoch_gc);
+    }
+}


### PR DESCRIPTION
This PR implements an epoch-based garbage collector worker built upon the epoch-based garbage collector component.

The logic is pretty simple:
- sets up the worker
- every X ms tries to collect the staged objects
- once it's marked for termination waits for all the threads associated with the epoch gc to terminate
- once they terminate performs a forced collection moving forward the epoch of each thread and running a collection
- once the collections are completed, it unregisters and frees the epoch_gc_threads

This approach replicates the fuzzy testing in the epoch_gc as it was built, on purpose, in the same way to test the workflow end to end.