### PR TITLE
Switch from atomic loads to memory fences in new hashtable

### DIFF
--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
@@ -576,6 +576,8 @@ hashtable_mpmc_result_t hashtable_mpmc_support_acquire_empty_bucket_for_insert(
         }
     }
 
+    assert(found != HASHTABLE_MPMC_RESULT_FALSE);
+
     return found;
 }
 

--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
@@ -166,7 +166,7 @@ void hashtable_mpmc_data_free(
 hashtable_mpmc_t *hashtable_mpmc_init(
         uint64_t buckets_count,
         uint64_t buckets_count_max,
-        uint16_t upsize_preferred_block_size) {
+        uint64_t upsize_preferred_block_size) {
     hashtable_mpmc_t *hashtable_mpmc = (hashtable_mpmc_t *)xalloc_alloc_zero(sizeof(hashtable_mpmc_t));
 
     hashtable_mpmc->data = hashtable_mpmc_data_init(buckets_count);
@@ -219,9 +219,9 @@ bool hashtable_mpmc_upsize_prepare(
     // Recalculate the size of the blocks to ensure that the last one will be always include all the buckets, although
     // for the last block it might be greater, so it has always to ensure it's not going to try to read data outside the
     // size of buckets (defined via buckets_count_real).
-    uint32_t total_blocks =
+    int64_t total_blocks =
             ceil((double)hashtable_mpmc->data->buckets_count_real / (double)hashtable_mpmc->upsize_preferred_block_size);
-    uint32_t new_block_size = ceil((double)hashtable_mpmc->data->buckets_count_real / (double)total_blocks);
+    int64_t new_block_size = ceil((double)hashtable_mpmc->data->buckets_count_real / (double)total_blocks);
 
     // As buckets count uses the current one plus one as hashtable_mpmc_data_init will calculate the next power of 2
     // and use that as size.

--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
@@ -253,7 +253,7 @@ bool hashtable_mpmc_upsize_migrate_bucket(
         hashtable_mpmc_data_t *from,
         hashtable_mpmc_data_t *to,
         hashtable_mpmc_bucket_index_t bucket_to_migrate_index) {
-    hashtable_mpmc_bucket_t bucket_to_migrate, found_bucket, bucket_to_overwrite, new_bucket_value, deleted_bucket;
+    hashtable_mpmc_bucket_t bucket_to_migrate, bucket_to_overwrite, new_bucket_value, deleted_bucket;
     hashtable_mpmc_bucket_index_t found_bucket_index;
 
     // The bucket has been processed, so it can be set to deleted (not zero as it would break all the get and delete
@@ -304,26 +304,8 @@ bool hashtable_mpmc_upsize_migrate_bucket(
             ? key_value->key.embedded.key_length
             : key_value->key.external.key_length;
 
-    // Check if the key has already been inserted in the new hashtable, temporary values are allowed to be returned as
+    hashtable_mpmc_result_t found_empty_result;
     while ((found_empty_result = hashtable_mpmc_support_acquire_empty_bucket_for_insert(
-    hashtable_mpmc_result_t find_bucket_result;
-    while ((find_bucket_result = hashtable_mpmc_support_find_bucket_and_key_value(
-                to,
-                key_value->hash,
-                bucket_to_migrate.data.hash_half,
-                key,
-                key_length,
-                true,
-                &found_bucket,
-                &found_bucket_index)) == HASHTABLE_MPMC_RESULT_TRUE) {
-
-        // If the key is found in the destination wait and retry
-        usleep(1000);
-    };
-
-    assert(find_bucket_result == HASHTABLE_MPMC_RESULT_FALSE);
-
-    hashtable_mpmc_result_t found_empty_result = hashtable_mpmc_support_acquire_empty_bucket_for_insert(
             to,
             key_value->hash,
             bucket_to_migrate.data.hash_half,

--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.h
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.h
@@ -114,7 +114,7 @@ typedef struct hashtable_mpmc hashtable_mpmc_t;
 struct hashtable_mpmc {
     hashtable_mpmc_data_t *data;
     uint64_t buckets_count_max;
-    uint16_t upsize_preferred_block_size;
+    uint64_t upsize_preferred_block_size;
     hashtable_mpmc_upsize_info_t upsize;
 };
 
@@ -163,7 +163,7 @@ void hashtable_mpmc_data_free(
 hashtable_mpmc_t *hashtable_mpmc_init(
         uint64_t buckets_count,
         uint64_t buckets_count_max,
-        uint16_t upsize_preferred_block_size);
+        uint64_t upsize_preferred_block_size);
 
 void hashtable_mpmc_free(
         hashtable_mpmc_t *hashtable_mpmc);


### PR DESCRIPTION
This PR changes how the data are read from the hashtable buckets, switching from atomic loads to load memory fences and plain loads.

In the process of ensuring that there were no more weird sync bugs between the threads the code was switched to use atomic loads but the algorithm doesn't need them.
The code uses then an atomic compare & exchange to ensure that the value that is going to be swapped is actually the value in memory, the code will simply retry the operation as it needs to do anyway in case another atomic compare & exchange is performed in between by another thread.

The difference between plain memory fences and loads VS atomic loads is a lot, using load memory fences and plain loads provides a ~30% performance gain.

The main reason is that an atomic operation, to ensure the atomicity, does always a full memory barrier before and afterwards, sync between all the CPU cores and numa nodes and then lock on the cacheline, .

But in the new hashtable this is stricly necessary, infact all the data are set using atomic compare & exchange, which always ensure that the value being written will replace the value that the code expects to be there.