### PR TITLE
Add prometheus stats per worker

### DIFF
--- a/src/module/prometheus/module_prometheus.c
+++ b/src/module/prometheus/module_prometheus.c
@@ -530,7 +530,7 @@ bool module_prometheus_process_metrics_request(
         // Try to fetch the stats for a worker, if it fails it builds up the aggregate, the while will later terminate
         // the loop
         if ((found_worker = worker_stats_get_shared_by_index(
-                worker_index++,
+                worker_index,
                 &worker_stats)) == false) {
             // Aggregate the statistics
             worker_stats_aggregate(&worker_stats);
@@ -600,6 +600,7 @@ bool module_prometheus_process_metrics_request(
 
         ffma_mem_free(tags);
         tags = NULL;
+        worker_index++;
     } while(found_worker);
 
     result_ret = module_prometheus_http_send_response(

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -125,7 +125,7 @@ network_op_result_t network_receive(
         buffer->data_size += received_length;
 
         // Update stats
-        worker_stats_t *stats = worker_stats_get();
+        worker_stats_t *stats = worker_stats_get_internal_current();
         stats->network.per_minute.received_packets++;
         stats->network.total.received_packets++;
         stats->network.per_minute.received_data += received_length;
@@ -285,7 +285,7 @@ network_op_result_t network_send_direct_wrapper(
     }
 
     if (likely(res == NETWORK_OP_RESULT_OK)) {
-        worker_stats_t *stats = worker_stats_get();
+        worker_stats_t *stats = worker_stats_get_internal_current();
         stats->network.per_minute.sent_packets++;
         stats->network.total.sent_packets++;
         stats->network.per_minute.sent_data += sent_length;

--- a/src/storage/storage.c
+++ b/src/storage/storage.c
@@ -34,7 +34,7 @@ storage_channel_t* storage_open(
     storage_channel_t *res = worker_op_storage_open(path, flags, mode);
 
     if (likely(res)) {
-        worker_stats_t *stats = worker_stats_get();
+        worker_stats_t *stats = worker_stats_get_internal_current();
         stats->storage.total.open_files++;
     } else {
         int error_number = fiber_scheduler_get_error();
@@ -93,7 +93,7 @@ bool storage_readv(
             read_len,
             channel->path);
 
-    worker_stats_t *stats = worker_stats_get();
+    worker_stats_t *stats = worker_stats_get_internal_current();
     stats->storage.per_minute.read_data += read_len;
     stats->storage.total.read_data += read_len;
     stats->storage.per_minute.read_iops++;
@@ -159,7 +159,7 @@ bool storage_writev(
             write_len,
             channel->path);
 
-    worker_stats_t *stats = worker_stats_get();
+    worker_stats_t *stats = worker_stats_get_internal_current();
     stats->storage.per_minute.written_data += write_len;
     stats->storage.total.written_data += write_len;
     stats->storage.per_minute.write_iops++;
@@ -229,7 +229,7 @@ bool storage_close(
     bool res = worker_op_storage_close(channel);
 
     if (likely(res)) {
-        worker_stats_t *stats = worker_stats_get();
+        worker_stats_t *stats = worker_stats_get_internal_current();
         stats->storage.total.open_files--;
     } else {
         int error_number = fiber_scheduler_get_error();

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -87,7 +87,7 @@ network_channel_t* worker_network_iouring_op_network_accept_setup_new_channel(
     }
 
     worker_context_t *worker_context = worker_context_get();
-    worker_stats_t *stats = worker_stats_get();
+    worker_stats_t *stats = worker_stats_get_internal_current();
 
     // Setup the new channel
     new_channel->fd = new_channel->wrapped_channel.fd = cqe->res;

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -286,7 +286,7 @@ void worker_network_listeners_listen(
 
 void worker_network_new_client_fiber_entrypoint(
         void *user_data) {
-    worker_stats_t *stats = worker_stats_get();
+    worker_stats_t *stats = worker_stats_get_internal_current();
 
     network_channel_t *new_channel = user_data;
     bool tls_enabled = new_channel->tls.enabled;

--- a/src/worker/worker_stats.c
+++ b/src/worker/worker_stats.c
@@ -96,7 +96,7 @@ bool worker_stats_should_publish_after_interval(
     return res;
 }
 
-worker_stats_t *worker_stats_get() {
+worker_stats_t *worker_stats_get_internal_current() {
     worker_context_t *context = worker_context_get();
     return &context->stats.internal;
 }

--- a/src/worker/worker_stats.c
+++ b/src/worker/worker_stats.c
@@ -101,6 +101,23 @@ worker_stats_t *worker_stats_get_internal_current() {
     return &context->stats.internal;
 }
 
+bool worker_stats_get_shared_by_index(
+        uint32_t index,
+        worker_stats_t *return_worker_stats) {
+    program_context_t *program_context = program_get_context();
+
+    if (index >= program_context->workers_count) {
+        return false;
+    }
+
+    memcpy(
+            return_worker_stats,
+            (worker_stats_t *)&program_context->workers_context[index].stats.shared,
+            sizeof(worker_stats_t));
+
+    return true;
+}
+
 worker_stats_t *worker_stats_aggregate(
         worker_stats_t *aggregated_stats) {
     program_context_t *program_context = program_get_context();

--- a/src/worker/worker_stats.h
+++ b/src/worker/worker_stats.h
@@ -59,7 +59,11 @@ bool worker_stats_should_publish_after_interval(
         worker_stats_volatile_t* worker_stats_public,
         int interval);
 
-worker_stats_t *worker_stats_get();
+worker_stats_t *worker_stats_get_internal_current();
+
+bool worker_stats_get_shared_by_index(
+        uint32_t index,
+        worker_stats_t *return_worker_stats);
 
 worker_stats_t *worker_stats_aggregate(
         worker_stats_t *aggregated_stats);


### PR DESCRIPTION
To properly analyze and investigate the load the prometheus module now expose all the standard metrics per worker, not only the aggregated ones.

To differenciate between the metrics per worker and the aggregated ones a tag is added per metric to indicate the worker index which is set to "aggregated" for the aggregated metrics.

This change breaks compatibility with the previous behaviour and not filtering on the aggregated stats will cause to any software reading the prometheus metrics to provide incorrect values. The new setups should take this into account as well.