### PR TITLE
Refactor hashtable mpmc op set

### DIFF
--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
@@ -103,7 +103,7 @@ uint64_t hashtable_mpmc_thread_epoch_operation_queue_hashtable_data_get_latest_e
             thread_local_epoch_operation_queue_hashtable_data);
 }
 
-hashtable_mpmc_hash_t hashtable_mcmp_support_hash_calculate(
+hashtable_mpmc_hash_t hashtable_mpmc_support_hash_calculate(
         hashtable_mpmc_key_t *key,
         hashtable_mpmc_key_length_t key_length) {
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
@@ -657,7 +657,7 @@ hashtable_mpmc_result_t hashtable_mpmc_op_get(
     }
 
     epoch_operation_queue_operation_t *operation_kv, *operation_ht_data = NULL;
-    hashtable_mpmc_hash_t hash = hashtable_mcmp_support_hash_calculate(key, key_length);
+    hashtable_mpmc_hash_t hash = hashtable_mpmc_support_hash_calculate(key, key_length);
 
     // Start to track the operation to avoid trying to access freed memory
     operation_kv = epoch_operation_queue_enqueue(
@@ -746,7 +746,7 @@ hashtable_mpmc_result_t hashtable_mpmc_op_delete(
     hashtable_mpmc_bucket_index_t found_bucket_index;
     hashtable_mpmc_data_t *hashtable_mpmc_data_upsize, *hashtable_mpmc_data_current;
     epoch_operation_queue_operation_t *operation_kv, *operation_ht_data = NULL;
-    hashtable_mpmc_hash_t hash = hashtable_mcmp_support_hash_calculate(key, key_length);
+    hashtable_mpmc_hash_t hash = hashtable_mpmc_support_hash_calculate(key, key_length);
 
     MEMORY_FENCE_LOAD();
     if (unlikely(hashtable_mpmc->upsize.status == HASHTABLE_MPMC_STATUS_PREPARE_FOR_UPSIZE)) {
@@ -955,7 +955,7 @@ hashtable_mpmc_result_t hashtable_mpmc_op_set(
     hashtable_mpmc_data_t *hashtable_mpmc_data_upsize, *hashtable_mpmc_data_current;
     epoch_operation_queue_operation_t *operation_ht_data = NULL;
     hashtable_mpmc_data_key_value_t *new_key_value = NULL;
-    hashtable_mpmc_hash_t hash = hashtable_mcmp_support_hash_calculate(key, key_length);
+    hashtable_mpmc_hash_t hash = hashtable_mpmc_support_hash_calculate(key, key_length);
     hashtable_mpmc_hash_half_t hash_half = hashtable_mpmc_support_hash_half(hash);
 
     *return_created_new = false;

--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
@@ -947,7 +947,6 @@ hashtable_mpmc_result_t hashtable_mpmc_op_set(
         hashtable_mpmc_key_length_t key_length,
         uintptr_t value,
         bool *return_created_new,
-        bool *return_value_updated,
         uintptr_t *return_previous_value) {
     hashtable_mpmc_result_t return_result;
     hashtable_mpmc_bucket_t found_bucket, bucket_to_overwrite;
@@ -959,7 +958,6 @@ hashtable_mpmc_result_t hashtable_mpmc_op_set(
     hashtable_mpmc_hash_half_t hash_half = hashtable_mpmc_support_hash_half(hash);
 
     *return_created_new = false;
-    *return_value_updated = false;
     *return_previous_value = 0;
 
     MEMORY_FENCE_LOAD();
@@ -1162,7 +1160,6 @@ hashtable_mpmc_result_t hashtable_mpmc_op_set(
 
     // Operation successful, set the result to true and update the status variables
     *return_created_new = true;
-    *return_value_updated = true;
     return_result = HASHTABLE_MPMC_RESULT_TRUE;
 
 end:

--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.h
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.h
@@ -146,7 +146,7 @@ void hashtable_mpmc_thread_epoch_operation_queue_hashtable_data_free();
 
 uint64_t hashtable_mpmc_thread_epoch_operation_queue_hashtable_data_get_latest_epoch();
 
-hashtable_mpmc_hash_t hashtable_mcmp_support_hash_calculate(
+hashtable_mpmc_hash_t hashtable_mpmc_support_hash_calculate(
         hashtable_mpmc_key_t *key,
         hashtable_mpmc_key_length_t key_length);
 

--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.h
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.h
@@ -231,7 +231,6 @@ hashtable_mpmc_result_t hashtable_mpmc_op_set(
         hashtable_mpmc_key_length_t key_length,
         uintptr_t value,
         bool *return_created_new,
-        bool *return_value_updated,
         uintptr_t *return_previous_value);
 
 #ifdef __cplusplus

--- a/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
@@ -304,7 +304,6 @@ void* test_hashtable_mpmc_fuzzy_testing_thread_func(
             // Try to insert or update
             char *key_copy = mi_strdup(key);
             bool return_created_new = false;
-            bool return_value_updated = false;
             uintptr_t return_previous_value = 0;
 
             result = hashtable_mpmc_op_set(
@@ -355,7 +354,6 @@ void* test_hashtable_mpmc_fuzzy_testing_thread_func(
                     }
 
                     assert(return_created_new == true);
-                    assert(return_value_updated == true);
                     assert(return_previous_value == 0);
                 } else {
                     if (return_created_new != false) {
@@ -373,7 +371,6 @@ void* test_hashtable_mpmc_fuzzy_testing_thread_func(
                     }
 
                     assert(return_created_new == false);
-                    assert(return_value_updated == true);
                     assert(return_previous_value == test_hashtable_mpmc_fuzzy_testing_calc_value_from_key_index(key_index));
                 }
 
@@ -1083,7 +1080,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
         char *key_embed_copy = mi_strdup(key_embed);
         char *key2_copy = mi_strdup(key2);
         bool return_created_new = false;
-        bool return_value_updated = false;
         uintptr_t return_previous_value = 0;
 
         hashtable_mpmc_t *hashtable = hashtable_mpmc_init(16, 32, HASHTABLE_MPMC_UPSIZE_BLOCK_SIZE);
@@ -1115,7 +1111,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(return_created_new);
-            REQUIRE(return_value_updated);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index]._packed != 0);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index].data.key_value != nullptr);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index].data.hash_half == key_hash_half);
@@ -1140,7 +1135,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(return_created_new);
-            REQUIRE(return_value_updated);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index]._packed != 0);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index].data.key_value != nullptr);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index].data.hash_half == key_hash_half);
@@ -1162,7 +1156,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(return_created_new);
-            REQUIRE(return_value_updated);
             REQUIRE(hashtable->data->buckets[hashtable_key_embed_bucket_index]._packed != 0);
             REQUIRE(hashtable->data->buckets[hashtable_key_embed_bucket_index].data.key_value != nullptr);
             REQUIRE(hashtable->data->buckets[hashtable_key_embed_bucket_index].data.hash_half == key_embed_hash_half);
@@ -1195,7 +1188,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(!return_created_new);
-            REQUIRE(return_value_updated);
             REQUIRE(return_previous_value == (uintptr_t) value1);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index]._packed != 0);
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index].data.key_value != nullptr);
@@ -1235,7 +1227,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index].data.key_value->value == (uintptr_t) value1);
 
             REQUIRE(return_created_new);
-            REQUIRE(return_value_updated);
             REQUIRE(hashtable->data->buckets[hashtable_key2_bucket_index]._packed != 0);
             REQUIRE(hashtable->data->buckets[hashtable_key2_bucket_index].data.key_value != nullptr);
             REQUIRE(hashtable->data->buckets[hashtable_key2_bucket_index].data.hash_half == key2_hash_half);
@@ -1480,7 +1471,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
         auto key_copy = mi_strdup(key);
         auto key2_copy = mi_strdup(key2);
         bool return_created_new = false;
-        bool return_value_updated = false;
         hashtable_mpmc_bucket_t return_bucket, return_bucket2, return_bucket_orig, return_bucket_orig2;
         hashtable_mpmc_bucket_index_t return_bucket_index, return_bucket_index2;
         uintptr_t return_previous_value = 0, return_value = 0;
@@ -1687,7 +1677,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
     SECTION("hashtable_mpmc_upsize_migrate_block") {
         char *key_temp = nullptr;
         bool return_created_new = false;
-        bool return_value_updated = false;
         hashtable_mpmc_bucket_t return_bucket;
         hashtable_mpmc_bucket_index_t return_bucket_index;
         uintptr_t return_previous_value = 0, return_value = 0;

--- a/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
@@ -313,7 +313,6 @@ void* test_hashtable_mpmc_fuzzy_testing_thread_func(
                     strlen(key_copy),
                     test_hashtable_mpmc_fuzzy_testing_calc_value_from_key_index(key_index),
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value);
 
             if (result == HASHTABLE_MPMC_RESULT_NEEDS_RESIZING || result == HASHTABLE_MPMC_RESULT_TRY_LATER) {
@@ -1113,7 +1112,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(return_created_new);
@@ -1139,7 +1137,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(return_created_new);
@@ -1162,7 +1159,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_embed_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(return_created_new);
@@ -1189,7 +1185,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
             REQUIRE(hashtable_mpmc_op_set(
                     hashtable,
@@ -1197,7 +1192,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value2,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(!return_created_new);
@@ -1221,7 +1215,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
             REQUIRE(hashtable_mpmc_op_set(
                     hashtable,
@@ -1229,7 +1222,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key2_length,
                     (uintptr_t) value2,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(hashtable->data->buckets[hashtable_key_bucket_index]._packed != 0);
@@ -1271,7 +1263,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_NEEDS_RESIZING);
 
             // Hashes have to be set back to zero before freeing up the hashtable
@@ -1518,7 +1509,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(hashtable_mpmc_support_find_bucket_and_key_value(
@@ -1559,7 +1549,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key_length,
                     (uintptr_t) value1,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
             REQUIRE(hashtable_mpmc_op_set(
                     hashtable,
@@ -1567,7 +1556,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                     key2_length,
                     (uintptr_t) value2,
                     &return_created_new,
-                    &return_value_updated,
                     &return_previous_value) == HASHTABLE_MPMC_RESULT_TRUE);
 
             REQUIRE(hashtable_mpmc_support_find_bucket_and_key_value(
@@ -1640,7 +1628,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                         key_temp_length,
                         (uintptr_t) index + 1,
                         &return_created_new,
-                        &return_value_updated,
                         &return_previous_value);
 
                 REQUIRE(result != HASHTABLE_MPMC_RESULT_FALSE);
@@ -1737,7 +1724,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                         key_temp_length,
                         (uintptr_t) index + 1,
                         &return_created_new,
-                        &return_value_updated,
                         &return_previous_value);
 
                 if (result == HASHTABLE_MPMC_RESULT_NEEDS_RESIZING) {
@@ -1808,7 +1794,6 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                         key_temp_length,
                         (uintptr_t) index + 1,
                         &return_created_new,
-                        &return_value_updated,
                         &return_previous_value);
 
                 if (result == HASHTABLE_MPMC_RESULT_NEEDS_RESIZING) {
@@ -1853,12 +1838,10 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
                         key_temp_length,
                         (uintptr_t) index + 1,
                         &return_created_new,
-                        &return_value_updated,
                         &return_previous_value);
 
                 REQUIRE(result == HASHTABLE_MPMC_RESULT_TRUE);
                 REQUIRE(return_created_new == false);
-                REQUIRE(return_value_updated == true);
                 REQUIRE(return_previous_value == (uintptr_t) index + 1);
 
                 epoch_gc_thread_set_epoch(

--- a/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
@@ -45,7 +45,7 @@
     '1','2','3','4','5','6','7','8','9','0', '1','2','3','4','5','6','7','8','9','0', \
     '.',',','/','|','\'',';',']','[','<','>','?',':','"','{','}','!','@','$','%','^','&','*','(',')','_','-','=','+','#'
 
-hashtable_mpmc_hash_t test_hashtable_mcmp_support_hash_calculate(
+hashtable_mpmc_hash_t test_hashtable_mpmc_support_hash_calculate(
         hashtable_mpmc_key_t *key,
         hashtable_mpmc_key_length_t key_length) {
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
@@ -625,17 +625,17 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
     char *key = "This Is A Key - not embedded";
     char *key_different_case = "THIS IS A KEY - NOT EMBEDDED";
     hashtable_mpmc_key_length_t key_length = strlen(key);
-    hashtable_mpmc_hash_t key_hash = test_hashtable_mcmp_support_hash_calculate(key, key_length);
+    hashtable_mpmc_hash_t key_hash = test_hashtable_mpmc_support_hash_calculate(key, key_length);
     hashtable_mpmc_hash_half_t key_hash_half = key_hash & 0XFFFFFFFF;
 
     char *key2 = "This Is Another Key - not embedded";
     hashtable_mpmc_key_length_t key2_length = strlen(key2);
-    hashtable_mpmc_hash_t key2_hash = test_hashtable_mcmp_support_hash_calculate(key2, key2_length);
+    hashtable_mpmc_hash_t key2_hash = test_hashtable_mpmc_support_hash_calculate(key2, key2_length);
     hashtable_mpmc_hash_half_t key2_hash_half = key2_hash & 0XFFFFFFFF;
 
     char *key_embed = "embedded key";
     hashtable_mpmc_key_length_t key_embed_length = strlen(key_embed);
-    hashtable_mpmc_hash_t key_embed_hash = test_hashtable_mcmp_support_hash_calculate(
+    hashtable_mpmc_hash_t key_embed_hash = test_hashtable_mpmc_support_hash_calculate(
             key_embed,
             key_embed_length);
     hashtable_mpmc_hash_half_t key_embed_hash_half = key_embed_hash & 0XFFFFFFFF;


### PR DESCRIPTION
The PR includes a refactor of the hashtable_mpmc_op_set function:
- a new function called hashtable_mpmc_op_set_update_value_if_key_exists has been extracted to update a value in the hashtable if the hash and the key are found and match, this is useful has the update code was being executed twce.
- refactor the function to use the extracted code

In addition the PR contains some very minor changes to fix the name of a support function and to improve some comments.

The main code changes will improve not only the readability but also the performances as less ICACHE will be occupied to run this code.