### PR TITLE
Disable redis integration tests temporarely

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -87,12 +87,12 @@ jobs:
           fail_ci_if_error: false
           verbose: false
 
-      - name: Tests - Integration Tests - Redis Server
-        working-directory: ${{github.workspace}}/build
-        shell: bash
-        run: ctest -R cachegrand-integration-tests-redis-server --verbose || true
+#      - name: Tests - Integration Tests - Redis Server
+#        working-directory: ${{github.workspace}}/build
+#        shell: bash
+#        run: ctest -R cachegrand-integration-tests-redis-server --verbose || true
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: tests-integration-tests-redis-server-results
-          path: ${{github.workspace}}/build/tests/integration_tests/redis_server/junit-report.xml
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: tests-integration-tests-redis-server-results
+#          path: ${{github.workspace}}/build/tests/integration_tests/redis_server/junit-report.xml

--- a/.github/workflows/report_integration_tests_redis_server.yml
+++ b/.github/workflows/report_integration_tests_redis_server.yml
@@ -1,23 +1,23 @@
-name: 'Tests - Integration Tests - Redis Server - Report'
-
-on:
-  workflow_run:
-    workflows: ['Build & Test']
-    types:
-      - completed
-
-permissions:
-    checks: write
-    contents: write
-    pull-requests: write
-
-jobs:
-  report:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dorny/test-reporter@v1
-        with:
-          artifact: tests-integration-tests-redis-server-results
-          name: Tests - Integration Tests - Redis Server
-          path: '*.xml'
-          reporter: java-junit
+#name: 'Tests - Integration Tests - Redis Server - Report'
+#
+#on:
+#  workflow_run:
+#    workflows: ['Build & Test']
+#    types:
+#      - completed
+#
+#permissions:
+#    checks: write
+#    contents: write
+#    pull-requests: write
+#
+#jobs:
+#  report:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: dorny/test-reporter@v1
+#        with:
+#          artifact: tests-integration-tests-redis-server-results
+#          name: Tests - Integration Tests - Redis Server
+#          path: '*.xml'
+#          reporter: java-junit


### PR DESCRIPTION
This PR disables the Redis integration tests, although on a temporary basis, to investigate the what's causing the failures.

Although extremely important, these results are currently not used as part of our validation process so they can be temporarely disabled.