### PR TITLE
Add a default config file to docker image and enable Redis over SSL by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,18 +161,52 @@ for any corresponding short options.
 
 #### Start it locally
 
+Once cachegrand has been [built from the sources](#build-from-source), it's possible to run it with the following command
+
 ```shell
-/path/to/cachegrand-server -c /path/to/cachegrand.yaml
-[2022-06-05T10:26:08Z][INFO       ][program] cachegrand-server version v0.1.0 (built on 2022-07-05T10:26:07Z)
-[2022-06-05T10:26:08Z][INFO       ][program] > Release build, compiled using GCC v10.3.0
-[2022-06-05T10:26:08Z][INFO       ][program] > Hashing algorithm in use t1ha2
-[2022-06-05T10:26:08Z][INFO       ][config] Loading the configuration from ../../etc/cachegrand.yaml
-[2022-06-05T10:26:08Z][INFO       ][program] Ready to accept connections
+/path/to/cachegrand-server -c /path/to/cachegrand.yaml.skel
+[2023-00-30T23:36:53Z][INFO       ][config] Loading the configuration from /etc/cachegrand/cachegrand.yaml
+[2023-00-30T23:36:53Z][INFO       ][program] cachegrand-server version v0.1.5-5-g70d8425 (built on 2023-01-30T23:19:48Z)
+[2023-00-30T23:36:53Z][INFO       ][program] > Release build, compiled using gcc v11.3.0
+[2023-00-30T23:36:53Z][INFO       ][program] > Hashing algorithm in use t1ha2
+[2023-00-30T23:36:53Z][INFO       ][program] > TLS: mbed TLS 2.28.0 (kernel offloading enabled)
+[2023-00-30T23:36:53Z][INFO       ][program] > Clock resolution: 4 ms
+[2023-00-30T23:36:53Z][INFO       ][program] Starting <32> workers
 ```
 
 #### Docker
 
-Download the example config file
+Simply run
+
+```shell
+docker run \
+  --ulimit memlock=-1:-1 \
+  --ulimit nofile=262144:262144 \
+  -p 6379:6379 \
+  -p 6380:6380 \
+  --rm \
+  cachegrand/cachegrand-server:latest
+```
+
+it comes with a default config file with redis on port 6379 and ssl for redis enabled on port 6380.
+
+The certificate will be generated on each start, to use an ad-hoc SSL certificate, instead of the auto-generated one,
+it's possible to mount the required certificate and key using the following command
+
+```shell
+docker run \
+  -v /path/to/certificate.pem:/etc/cachegrand/cachegrand.pem \
+  -v /path/to/certificate.key:/etc/cachegrand/cachegrand.key \
+  -v /path/to/cachegrand.yaml:/etc/cachegrand/cachegrand.yaml \
+  --ulimit memlock=-1:-1 \
+  --ulimit nofile=262144:262144 \
+  -p 6379:6379 \
+  -p 6380:6380 \
+  --rm \
+  cachegrand/cachegrand-server:latest
+```
+
+if you want to enable prometheus or change other parameters you can download the example config file
 
 ```shell
 curl https://raw.githubusercontent.com/danielealbano/cachegrand/main/etc/cachegrand.yaml.skel -o /path/to/cachegrand.yaml
@@ -186,6 +220,7 @@ docker run \
   --ulimit memlock=-1:-1 \
   --ulimit nofile=262144:262144 \
   -p 6379:6379 \
+  -p 6380:6380 \
   --rm \
   cachegrand/cachegrand-server:latest
 ```

--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -20,7 +20,7 @@ use_huge_pages: false
 
 network:
   backend: io_uring
-  max_clients: 250
+  max_clients: 100
   listen_backlog: 100
 
 modules:

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2022 Daniele Salvatore Albano
+# Copyright (C) 2018-2023 Daniele Salvatore Albano
 # All rights reserved.
 #
 # This software may be modified and distributed under the terms
@@ -50,7 +50,6 @@ RUN cd /root \
     && make cachegrand-server
 
 FROM ubuntu:22.04
-
 LABEL maintainer="d.albano@cachegrand.io"
 
 # General dpkg and packages settings

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -66,14 +66,33 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         apt-utils \
     && apt-get install -y --no-install-recommends \
-        libnuma1 libyaml-0-2 libcurl4 libmbedtls14 libatomic1 \
+        libnuma1 libyaml-0-2 libcurl4 libmbedtls14 libatomic1 openssl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /opt/cachegrand
+RUN \
+    mkdir /etc/cachegrand \
+    && mkdir /var/run/cachegrand/
 
 COPY --from=builder /root/build/cachegrand/cmake-build-release/src/cachegrand-server /usr/bin
+COPY --from=builder /root/build/cachegrand/etc/cachegrand.yaml.skel /etc/cachegrand/cachegrand.yaml.skel
+COPY --from=builder /root/build/cachegrand/tools/docker/release/self-signed-ssl-cert-gen.sh /self-signed-ssl-cert-gen.sh
+COPY --from=builder /root/build/cachegrand/tools/docker/release/startup.sh /startup.sh
+
+RUN \
+    cat /etc/cachegrand/cachegrand.yaml.skel \
+        | sed -e 's/\#\(\s\+tls\:\)/\1/' \
+        | sed -e 's/\#\(\s\+certificate_path\:\)/\1/' \
+        | sed -e 's/\#\(\s\+private_key_path\:\)/\1/' \
+        | sed -e "/^\s\- type\: file$/ s|^|//|; /^\s*\- type\: file/, /);$/ s|^|#|" \
+        | sed -e 's/^           tls: true/          tls: true/' \
+        | sed -e 's/^           tls: false/          tls: false/' \
+        > /etc/cachegrand/cachegrand.yaml \
+    && rm /etc/cachegrand/cachegrand.yaml.skel \
+    && chmod 700 /self-signed-ssl-cert-gen.sh \
+    && chmod 700 /startup.sh
 
 EXPOSE 6379
+EXPOSE 6380
 
-CMD ["/usr/bin/cachegrand-server", "-c" ,"/etc/cachegrand/cachegrand.yaml"]
+CMD [ "/startup.sh" ]

--- a/tools/docker/release/build.sh
+++ b/tools/docker/release/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Requires docker buildx plugin to run
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx rm cachegrand-server
+docker buildx create --use --name cachegrand-server --bootstrap
+docker buildx build --pull --push --platform linux/amd64,linux/arm64/v8 --tag cachegrand/cachegrand-server:latest --tag cachegrand/cachegrand-server:v0.1.5 .
+docker buildx rm cachegrand-server

--- a/tools/docker/release/self-signed-ssl-cert-gen.sh
+++ b/tools/docker/release/self-signed-ssl-cert-gen.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Forked from https://github.com/stakater/dockerfile-ssl-certs-generator/blob/master/generate-certs
+
+echo "> Generating SSL certificate"
+
+export OPENSSL_CA_KEY=${OPENSSL_CA_KEY-"/etc/cachegrand/ca.key"}
+export OPENSSL_CA_CERT=${OPENSSL_CA_CERT-"/etc/cachegrand/ca.pem"}
+export OPENSSL_CA_SUBJECT=${OPENSSL_CA_SUBJECT:-"cachegrand-selfsigned-ca"}
+export OPENSSL_CA_EXPIRE=${OPENSSL_CA_EXPIRE:-"365"}
+export OPENSSL_CA_SIZE=${OPENSSL_CA_SIZE:-"2048"}
+
+export OPENSSL_CERT_CONFIG=${OPENSSL_CERT_CONFIG:-"openssl.cnf"}
+export OPENSSL_CERT_KEY=${OPENSSL_CERT_KEY:-"/etc/cachegrand/certificate.key"}
+export OPENSSL_CERT_CSR=${OPENSSL_CERT_CSR:-"/etc/cachegrand/certificate.csr"}
+export OPENSSL_CERT_CERT=${OPENSSL_CERT_CERT:-"/etc/cachegrand/certificate.pem"}
+export OPENSSL_CERT_SIZE=${OPENSSL_CERT_SIZE:-"2048"}
+export OPENSSL_CERT_EXPIRE=${OPENSSL_CERT_EXPIRE:-"365"}
+export OPENSSL_CERT_SUBJECT=${OPENSSL_CERT_SUBJECT:-"cachegrand"}
+
+echo "--> Certificate Authority"
+
+if [[ -e "${OPENSSL_CA_KEY}" ]]; then
+    echo "====> Using existing CA Key ${OPENSSL_CA_KEY}"
+else
+    echo "====> Generating new CA key ${OPENSSL_CA_KEY}"
+    openssl genrsa -out \
+      "${OPENSSL_CA_KEY}" \
+      ${OPENSSL_CA_SIZE} \
+      >/dev/null 2>&1 \
+      || exit 1
+fi
+
+if [[ -e "${OPENSSL_CA_CERT}" ]]; then
+    echo "====> Using existing CA Certificate ${OPENSSL_CA_CERT}"
+else
+    echo "====> Generating new CA Certificate ${OPENSSL_CA_CERT}"
+    openssl req -x509 -new -nodes \
+      -key "${OPENSSL_CA_KEY}" \
+      -days ${OPENSSL_CA_EXPIRE} \
+      -out "${OPENSSL_CA_CERT}"\
+      -subj "/CN=${OPENSSL_CA_SUBJECT}" \
+      >/dev/null 2>&1 \
+      || exit 1
+fi
+
+echo "====> Generating new config file ${OPENSSL_CERT_CONFIG}"
+cat > ${OPENSSL_CERT_CONFIG} <<EOM
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, serverAuth
+EOM
+
+echo "--> Certificate"
+
+echo "====> Generating new SSL KEY ${OPENSSL_CERT_KEY}"
+openssl genrsa -out \
+  "${OPENSSL_CERT_KEY}" \
+  ${OPENSSL_CERT_SIZE} \
+  >/dev/null 2>&1 \
+  || exit 1
+
+echo "====> Generating new SSL CSR ${OPENSSL_CERT_CSR}"
+openssl req -new \
+  -key "${OPENSSL_CERT_KEY}" \
+  -out "${OPENSSL_CERT_CSR}" \
+  -subj "/CN=${OPENSSL_CERT_SUBJECT}" \
+  -config ${OPENSSL_CERT_CONFIG} \
+  >/dev/null 2>&1 \
+  || exit 1
+
+echo "====> Generating new SSL CERT ${OPENSSL_CERT_CERT}"
+openssl x509 -req \
+  -in "${OPENSSL_CERT_CSR}" \
+  -CA "${OPENSSL_CA_CERT}" \
+  -CAkey "${OPENSSL_CA_KEY}" \
+  -CAcreateserial \
+  -out ${OPENSSL_CERT_CERT} \
+  -days ${OPENSSL_CERT_EXPIRE} \
+  -extensions v3_req \
+  -extfile ${OPENSSL_CERT_CONFIG} \
+  >/dev/null 2>&1 \
+  || exit 1

--- a/tools/docker/release/startup.sh
+++ b/tools/docker/release/startup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Generates the self signed certificate at bootstrap if they don't exist already
+/self-signed-ssl-cert-gen.sh
+
+# Starts cachegrand
+/usr/bin/cachegrand-server -c /etc/cachegrand/cachegrand.yaml


### PR DESCRIPTION
This PR modifies the build process for the release of the docker image to include a default config file.

It also adds the automatic SSL certificate generation, when the ssl certificate is not manually mounted, to make Redis available over SSL.