### PR TITLE
Fix the "missing .note.GNU-stack section implies executable stack" warning

### DIFF
--- a/src/fiber/arch/aarch64/fiber_context.s
+++ b/src/fiber/arch/aarch64/fiber_context.s
@@ -4,7 +4,7 @@
  *
  * This software may be modified and distributed under the terms
  * of the BSD license.  See the LICENSE file for details.
-*/
+ **/
 
 .type fiber_context_get, @function
 .global fiber_context_get
@@ -94,3 +94,11 @@ fiber_context_swap:
     mov sp, x3
 
     ret x4
+
+/**
+ * The following section is added as the functions here don't require an executable stack, it's used to fix the
+ * following warning:
+ * /usr/bin/ld: warning: fiber_context.s.o: missing .note.GNU-stack section implies executable stack
+ * /usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
+ **/
+.section .note.GNU-stack,"",%progbits

--- a/src/fiber/arch/x86-64/fiber_context.s
+++ b/src/fiber/arch/x86-64/fiber_context.s
@@ -88,3 +88,11 @@ fiber_context_swap:
     # Return.
     xorl %eax, %eax
     ret
+
+/**
+ * The following section is added as the functions here don't require an executable stack, it's used to fix the
+ * following warning:
+ * /usr/bin/ld: warning: fiber_context.s.o: missing .note.GNU-stack section implies executable stack
+ * /usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
+ **/
+.section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
This PR adds the .note.GNU-stack section to the fiber-context assembly files for both AARCH64 (ARM64) and X86-64 (X64).