### PR TITLE
Ensure that ExternalProject_Add makes cmake aware of the target(s) (built librarie(s)) it can produce

### DIFF
--- a/3rdparty/libcyaml.cmake
+++ b/3rdparty/libcyaml.cmake
@@ -16,6 +16,7 @@ ExternalProject_Add(
         GIT_TAG           227bbe04581541d8e97b7306a81c05fa2894841b # tag v1.2.0
         PREFIX ${CMAKE_BINARY_DIR}/_deps
         CONFIGURE_COMMAND ""
+        BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/_deps/src/cyaml/build/release/libcyaml.so.1
         BUILD_COMMAND
         sed -e "s/VERSION_DEVEL = 1/VERSION_DEVEL = 0/" -i ${LIBCYAML_SRC_PATH}/Makefile &&
         CFLAGS="-fPIC" make -C ${LIBCYAML_SRC_PATH} ${LIBCYAML_BUILD_PATH_REL}/libcyaml.a ${LIBCYAML_BUILD_PATH_REL}/libcyaml.so.1

--- a/benches/CMakeLists.txt
+++ b/benches/CMakeLists.txt
@@ -14,6 +14,7 @@ if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER_EQUAL 3.24)
             DOWNLOAD_EXTRACT_TIMESTAMP true
             INSTALL_DIR ${CMAKE_BINARY_DIR}/benchmark-install
             URL https://github.com/google/benchmark/archive/v1.6.1.tar.gz
+            BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/benchmark-install/lib/libbenchmark.a
             CMAKE_CACHE_ARGS
             -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
             -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
@@ -27,6 +28,7 @@ else()
             PREFIX benchmark-sources
             INSTALL_DIR ${CMAKE_BINARY_DIR}/benchmark-install
             URL https://github.com/google/benchmark/archive/v1.6.1.tar.gz
+            BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/benchmark-install/lib/libbenchmark.a
             CMAKE_CACHE_ARGS
             -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
             -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
@@ -36,8 +38,6 @@ else()
             -DBENCHMARK_ENABLE_TESTING:BOOL=OFF
             -DBENCHMARK_DOWNLOAD_DEPENDENCIES:BOOL=ON)
 endif()
-
-
 
 add_library(benchmark::benchmark STATIC IMPORTED)
 add_dependencies(benchmark::benchmark benchmark-install)


### PR DESCRIPTION
Ninja works slightly differently than name and it needs to be aware of all the targets being used, doesn't just rely on the high level dependency tree defined via cmake itself.

This PR adds the BUILD_BYPRODUCTS to make cmake aware of the targets generated by the external components built via ExternalProject_Add so that ninja can follow up the dependency tree as needed.