### PR TITLE
Drop hashtable mpmc block size re-calculation when upsizing

### DIFF
--- a/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
+++ b/src/data_structures/hashtable_mpmc/hashtable_mpmc.c
@@ -216,12 +216,9 @@ bool hashtable_mpmc_upsize_prepare(
         return false;
     }
 
-    // Recalculate the size of the blocks to ensure that the last one will be always include all the buckets, although
-    // for the last block it might be greater, so it has always to ensure it's not going to try to read data outside the
-    // size of buckets (defined via buckets_count_real).
-    int64_t total_blocks =
-            ceil((double)hashtable_mpmc->data->buckets_count_real / (double)hashtable_mpmc->upsize_preferred_block_size);
-    int64_t new_block_size = ceil((double)hashtable_mpmc->data->buckets_count_real / (double)total_blocks);
+    // Calculate the amount of blox to migrate
+    int64_t total_blocks = ceil(
+            (double)hashtable_mpmc->data->buckets_count_real / (double)hashtable_mpmc->upsize_preferred_block_size);
 
     // As buckets count uses the current one plus one as hashtable_mpmc_data_init will calculate the next power of 2
     // and use that as size.
@@ -238,7 +235,7 @@ bool hashtable_mpmc_upsize_prepare(
     // well.
     hashtable_mpmc->upsize.total_blocks = total_blocks;
     hashtable_mpmc->upsize.remaining_blocks = total_blocks;
-    hashtable_mpmc->upsize.block_size = new_block_size;
+    hashtable_mpmc->upsize.block_size = hashtable_mpmc->upsize_preferred_block_size;
     hashtable_mpmc->upsize.from = hashtable_mpmc->data;
     hashtable_mpmc->data = new_hashtable_mpmc_data;
     MEMORY_FENCE_STORE();

--- a/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
@@ -1042,7 +1042,7 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
             REQUIRE(hashtable_small->upsize.remaining_blocks == 1);
             REQUIRE(hashtable_small->upsize.total_blocks == 1);
             REQUIRE(hashtable_small->upsize.threads_count == 0);
-            REQUIRE(hashtable_small->upsize.block_size == 272);
+            REQUIRE(hashtable_small->upsize.block_size == HASHTABLE_MPMC_UPSIZE_BLOCK_SIZE);
         };
 
         SECTION("preparation successful - multiple blocks") {
@@ -1053,7 +1053,7 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
             REQUIRE(hashtable_large->upsize.remaining_blocks == 17);
             REQUIRE(hashtable_large->upsize.total_blocks == 17);
             REQUIRE(hashtable_large->upsize.threads_count == 0);
-            REQUIRE(hashtable_large->upsize.block_size == 15436);
+            REQUIRE(hashtable_large->upsize.block_size == HASHTABLE_MPMC_UPSIZE_BLOCK_SIZE);
         };
 
         SECTION("preparation failed - already upsizing") {


### PR DESCRIPTION
This PR drops a recalculation of the size of the blocks to migrate when up-sizing, there is no reason or practical advantage in having it, the value should always be set to what has been requested when the hashtable is initialized.

As part of the PR tests are updated as well as necessary.