### PR TITLE
Fix codeql security alerts (part 2)

### DIFF
--- a/src/log/sink/log_sink.h
+++ b/src/log/sink/log_sink.h
@@ -25,7 +25,7 @@ union log_sink_settings {
     struct {
         char* path;
         struct {
-            FILE* fp;
+            int fd;
         } internal;
     } file;
 };

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -38,7 +38,6 @@
 #define TAG "module_redis_command_expiretime"
 
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
-    bool return_res = false;
     storage_db_entry_index_t *current_entry_index = NULL;
     transaction_t transaction = { 0 };
     storage_db_op_rmw_status_t rmw_status = { 0 };

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -39,7 +39,6 @@
 #define TAG "module_redis_command_pexpiretime"
 
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
-    bool return_res = false;
     storage_db_entry_index_t *current_entry_index = NULL;
     int64_t expiry_time;
     transaction_t transaction = { 0 };

--- a/src/module/redis/command/module_redis_command_pttl.c
+++ b/src/module/redis/command/module_redis_command_pttl.c
@@ -39,8 +39,6 @@
 #define TAG "module_redis_command_pttl"
 
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pttl) {
-    network_channel_buffer_data_t *send_buffer, *send_buffer_start;
-    size_t slice_length = 48;
     int64_t response = -2;
     storage_db_entry_index_t *entry_index = NULL;
     module_redis_command_pttl_context_t *context = connection_context->command.context;

--- a/src/module/redis/module_redis.c
+++ b/src/module/redis/module_redis.c
@@ -150,8 +150,6 @@ bool module_redis_process_data(
     protocol_redis_reader_op_t ops[8] = { 0 };
     uint8_t ops_size = (sizeof(ops) / sizeof(protocol_redis_reader_op_t));
 
-    worker_context_t *worker_context = worker_context_get();
-
     // The loops below terminate if data_size is equals to zero, it should never happen that this function is invoked
     // with the read buffer empty.
     assert(read_buffer->data_size > 0);

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -198,7 +198,7 @@ void worker_cleanup_network(
         uint8_t listeners_count) {
     // TODO: should use a struct with fp pointers, not ifs
     if (worker_context->config->network->backend == CONFIG_NETWORK_BACKEND_IO_URING) {
-        worker_network_iouring_cleanup(listeners, listeners_count); // lgtm [cpp/useless-expression]
+        worker_network_iouring_cleanup(listeners, listeners_count);
     }
 
     for(

--- a/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-mpmc.cpp
@@ -2061,7 +2061,7 @@ TEST_CASE("data_structures/hashtable_mpmc/hashtable_mpmc.c", "[data_structures][
         SECTION("random key count and multiple test runs") {
             uint32_t test_runs = 10;
             uint32_t test_duration = 5;
-            uint32_t test_threads = utils_cpu_count() * 4;
+            uint32_t test_threads = utils_cpu_count();
             uint32_t test_hashtable_initial_size = 128 * 1024;
             uint32_t test_hashtable_upsize_block_size = HASHTABLE_MPMC_UPSIZE_BLOCK_SIZE;
 

--- a/tests/unit_tests/log/sink/test-log-sink.cpp
+++ b/tests/unit_tests/log/sink/test-log-sink.cpp
@@ -307,9 +307,9 @@ TEST_CASE("log/sink/log_sink.c", "[log][sink][log_sink]") {
             REQUIRE(sink->type == LOG_SINK_TYPE_FILE);
             REQUIRE(sink->levels == LOG_LEVEL_INFO);
             REQUIRE(sink->settings.file.path == settings.file.path);
-            REQUIRE(sink->settings.file.internal.fp != NULL);
+            REQUIRE(sink->settings.file.internal.fd != 0);
 
-            int fd = fileno(sink->settings.file.internal.fp);
+            int fd = sink->settings.file.internal.fd;
 
             snprintf(fd_link_buf, sizeof(fd_link_buf), "/proc/self/fd/%d", fd);
             REQUIRE(readlink(fd_link_buf, fd_link_resolved_buf, sizeof(fd_link_resolved_buf)) > 0);

--- a/tests/unit_tests/support/io_uring/test-io-uring-support.cpp
+++ b/tests/unit_tests/support/io_uring/test-io-uring-support.cpp
@@ -297,7 +297,7 @@ TEST_CASE("support/io_uring/io_uring_support.c", "[support][io_uring][io_uring_s
             io_uring_wait_cqe(ring, &cqe);
             REQUIRE(cqe != NULL);
             REQUIRE(cqe->flags == 0);
-            REQUIRE((cqe->res == -ECANCELED) || (cqe->res == -ETIME));
+            REQUIRE(((cqe->res == -ECANCELED) || (cqe->res == -ETIME)));
             REQUIRE(cqe->user_data == 1234);
             io_uring_cqe_seen(ring, cqe);
 

--- a/tests/unit_tests/support/io_uring/test-io-uring-support.cpp
+++ b/tests/unit_tests/support/io_uring/test-io-uring-support.cpp
@@ -297,7 +297,7 @@ TEST_CASE("support/io_uring/io_uring_support.c", "[support][io_uring][io_uring_s
             io_uring_wait_cqe(ring, &cqe);
             REQUIRE(cqe != NULL);
             REQUIRE(cqe->flags == 0);
-            REQUIRE(cqe->res == -ECANCELED);
+            REQUIRE((cqe->res == -ECANCELED) || (cqe->res == -ETIME));
             REQUIRE(cqe->user_data == 1234);
             io_uring_cqe_seen(ring, cqe);
 


### PR DESCRIPTION
This PR includes an additional number of code fixes to resolve the remaining security alerts generated by CodeQL, it also upgrades catch2 to the version 2.13.9.