### PR TITLE
Speed up CI allowing the usage of all the cores available

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Build cachegrand-tests
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --target cachegrand-tests -- -j 4
+        run: cmake --build . --target cachegrand-tests -- -j $(nproc)
 
       - name: Build cachegrand-server
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --target cachegrand-server -- -j 4
+        run: cmake --build . --target cachegrand-server -- -j $(nproc)
 
       - name: Tests - Unit Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build cpp
         run: |
           cd build
-          make cachegrand-server
+          make cachegrand-server -j $(nproc)
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Currently the build pipeline uses an hardcoded number of jobs for make, the codeql pipeline uses nothing at all.

This PR sets the number of jobs using `nproc` to leverage in full the resources available.