### PR TITLE
Disable FFMA and switch to use xalloc (mimalloc)

### DIFF
--- a/benches/bench-ffma.cpp
+++ b/benches/bench-ffma.cpp
@@ -22,7 +22,7 @@
 #include "hugepages.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "xalloc.h"
 
 #include "benchmark-program.hpp"

--- a/benches/bench-hashtable-mpmc-old-op-get.cpp
+++ b/benches/bench-hashtable-mpmc-old-op-get.cpp
@@ -28,7 +28,7 @@
 #include "fiber/fiber_scheduler.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "worker/worker_stats.h"

--- a/benches/bench-hashtable-mpmc-old-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-old-op-set.cpp
@@ -27,7 +27,7 @@
 #include "fiber/fiber_scheduler.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "worker/worker_stats.h"

--- a/benches/bench-storage-db-op-get.cpp
+++ b/benches/bench-storage-db-op-get.cpp
@@ -22,7 +22,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "storage/io/storage_io_common.h"
 #include "storage/channel/storage_channel.h"
 #include "storage/db/storage_db.h"

--- a/benches/bench-storage-db-op-set.cpp
+++ b/benches/bench-storage-db-op-set.cpp
@@ -23,7 +23,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "storage/io/storage_io_common.h"
 #include "storage/channel/storage_channel.h"
 #include "storage/db/storage_db.h"

--- a/benches/benchmark-program.hpp
+++ b/benches/benchmark-program.hpp
@@ -20,7 +20,7 @@
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "thread.h"
 #include "hugepage_cache.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "log/log.h"
 #include "log/sink/log_sink.h"
 #include "log/sink/log_sink_console.h"

--- a/src/config.c
+++ b/src/config.c
@@ -29,7 +29,7 @@
 #include "utils_cpu.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/simple_file_io.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"
@@ -463,14 +463,14 @@ bool config_validate_after_load_modules_redis(
         return true;
     }
 
-    if (module->redis->max_key_length > FFMA_OBJECT_SIZE_MAX - 1) {
-        LOG_E(
-                TAG,
-                "In module <%s>, the allowed maximum value of max_key_length is <%u>",
-                config_module_type_schema_strings[module->type].str,
-                FFMA_OBJECT_SIZE_MAX - 1);
-        return_result = false;
-    }
+//    if (module->redis->max_key_length > FFMA_OBJECT_SIZE_MAX - 1) {
+//        LOG_E(
+//                TAG,
+//                "In module <%s>, the allowed maximum value of max_key_length is <%u>",
+//                config_module_type_schema_strings[module->type].str,
+//                FFMA_OBJECT_SIZE_MAX - 1);
+//        return_result = false;
+//    }
 
     return return_result;
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_data.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.c
@@ -23,7 +23,7 @@
 #include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "hashtable.h"
 #include "hashtable_data.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
@@ -24,7 +24,7 @@
 #include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "hashtable.h"
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.c
@@ -22,7 +22,7 @@
 #include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_data.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_get_key.h"

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -20,7 +20,7 @@
 #include "transaction_spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "hashtable.h"
 #include "hashtable_data.h"
 

--- a/src/data_structures/hashtable/spsc/hashtable_spsc.c
+++ b/src/data_structures/hashtable/spsc/hashtable_spsc.c
@@ -17,7 +17,7 @@
 #include "pow2.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "hashtable_spsc.h"
 
@@ -66,7 +66,7 @@ void hashtable_spsc_free(
                 continue;
             }
 
-            ffma_mem_free((void*)buckets[bucket_index].key);
+            xalloc_free((void*)buckets[bucket_index].key);
         }
     }
 
@@ -134,7 +134,7 @@ bool hashtable_spsc_op_delete_ci(
 
     if (hashtable->free_keys_on_deallocation) {
         hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
-        ffma_mem_free((void*)buckets[bucket_index].key);
+        xalloc_free((void*)buckets[bucket_index].key);
     }
 
     return true;
@@ -201,7 +201,7 @@ bool hashtable_spsc_op_delete_cs(
 
     if (hashtable->free_keys_on_deallocation) {
         hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
-        ffma_mem_free((void*)buckets[bucket_index].key);
+        xalloc_free((void*)buckets[bucket_index].key);
     }
 
     return true;

--- a/src/data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.c
+++ b/src/data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.c
@@ -18,10 +18,7 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "memory_fences.h"
-#include "fatal.h"
-#include "data_structures/double_linked_list/double_linked_list.h"
-#include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "slots_bitmap_mpmc_first_free_bit_table.h"
 #include "slots_bitmap_mpmc.h"
@@ -49,7 +46,7 @@ slots_bitmap_mpmc_t *slots_bitmap_mpmc_init(
             (sizeof(slots_bitmap_mpmc_shard_t) * shards_count) +
             (sizeof(uint8_t) * shards_count);
 
-    slots_bitmap_mpmc_t *slots_bitmap = (slots_bitmap_mpmc_t *)ffma_mem_alloc(allocation_size);
+    slots_bitmap_mpmc_t *slots_bitmap = (slots_bitmap_mpmc_t *)xalloc_alloc(allocation_size);
 
     // If memory allocation fails, return NULL
     if (slots_bitmap == NULL) {
@@ -67,7 +64,7 @@ slots_bitmap_mpmc_t *slots_bitmap_mpmc_init(
 void slots_bitmap_mpmc_free(
         slots_bitmap_mpmc_t *bitmap) {
     // Free the memory allocated for the concurrent bitmap
-    ffma_mem_free(bitmap);
+    xalloc_free(bitmap);
 }
 
 uint64_t slots_bitmap_mpmc_iter(

--- a/src/data_structures/slots_bitmap_spsc/slots_bitmap_spsc.c
+++ b/src/data_structures/slots_bitmap_spsc/slots_bitmap_spsc.c
@@ -18,9 +18,7 @@
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "fatal.h"
-#include "data_structures/double_linked_list/double_linked_list.h"
-#include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "slots_bitmap_spsc_first_free_bit_table.h"
 #include "slots_bitmap_spsc.h"
@@ -53,7 +51,7 @@ slots_bitmap_spsc_t *slots_bitmap_spsc_init(
             (sizeof(uint8_t) * shards_count) +
             (sizeof(uint64_t) * (size_t)slots_bitmap_spsc_calculate_shard_full_count(shards_count));
 
-    slots_bitmap_spsc_t *slots_bitmap = (slots_bitmap_spsc_t *)ffma_mem_alloc(allocation_size);
+    slots_bitmap_spsc_t *slots_bitmap = (slots_bitmap_spsc_t *)xalloc_alloc(allocation_size);
 
     // If memory allocation fails, return NULL
     if (slots_bitmap == NULL) {
@@ -72,7 +70,7 @@ slots_bitmap_spsc_t *slots_bitmap_spsc_init(
 void slots_bitmap_spsc_free(
         slots_bitmap_spsc_t *slots_bitmap) {
     // Free the memory allocated for the bitmap
-    ffma_mem_free(slots_bitmap);
+    xalloc_free(slots_bitmap);
 }
 
 slots_bitmap_spsc_shard_t* slots_bitmap_spsc_get_shard_ptr(

--- a/src/fiber/fiber.c.old
+++ b/src/fiber/fiber.c.old
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "xalloc.h"
+#include "log/log.h"
+#include "fatal.h"
+
+#include "fiber.h"
+
+#define TAG "fiber"
+
+void fiber_stack_protection(
+        fiber_t *fiber,
+        bool enable) {
+    int stack_usage_flags = enable ? PROT_NONE : PROT_READ | PROT_WRITE;
+
+    if (mprotect(fiber->stack_base, xalloc_get_page_size(), stack_usage_flags) != 0) {
+        if (errno == ENOMEM) {
+            fatal(TAG, "Unable to protect/unprotect fiber stack, review the value of /proc/sys/vm/max_map_count");
+        }
+
+        fatal(TAG, "Unable to protect/unprotect fiber stack");
+    }
+}
+
+fiber_t *fiber_new(
+        char *name,
+        size_t name_len,
+        size_t stack_size,
+        fiber_start_fp_t *fiber_start_fp,
+        void *user_data) {
+    if (fiber_start_fp == NULL) {
+        return NULL;
+    }
+
+    size_t page_size = xalloc_get_page_size();
+
+    // The end (beginning) of the stack is "protected" to catch any undesired access that tries to read data past the
+    // end of the allocated stack memory (e.g. memory overflow). To protect the access a page is required therefore
+    // at least 2 pages have to be allocated, one minimum for the stack and one to protect the stack.
+    if (stack_size < page_size * 2) {
+        return NULL;
+    }
+
+    fiber_t *fiber = xalloc_alloc_zero(sizeof(fiber_t));
+    void *stack_base = xalloc_alloc_aligned_zero(page_size, stack_size);
+
+    // Align the stack_pointer to 16 bytes and add some padding as required by the ABI
+    void* stack_pointer = (void*)((uintptr_t)(stack_base + stack_size) & -16L);
+    
+    stack_pointer -= sizeof(void*) * 1;
+#if defined(__aarch64__)
+    stack_pointer -= sizeof(void*) * 1;
+#endif
+
+    LOG_D(
+            TAG,
+            "Initializing new fiber <%s> with a stack of <%lu> bytes starting at <%p>",
+            name,
+            stack_size,
+            stack_pointer);
+
+    fiber->start_fp = fiber_start_fp;
+    fiber->start_fp_user_data = user_data;
+    fiber->stack_size = stack_size;
+    fiber->stack_base = stack_base;
+    fiber->stack_pointer = stack_pointer;
+
+    // Set the fiber additional parameters
+    fiber->terminate = false;
+    fiber->name = (char*)xalloc_alloc_zero(name_len + 1);
+    strncpy(fiber->name, name, name_len);
+
+    // Set Stack Pointer
+#if defined(__x86_64__)
+    // Set the initial fp and rsp of the fiber
+    fiber->context.rip = fiber->start_fp;
+    fiber->context.rsp = fiber->stack_pointer;
+#elif defined(__aarch64__)
+    // 0xa0 in register matches the location of the registry X30 used as program counter
+    *((uintptr_t*)(fiber->context.ragisters + 0xa0)) = (uintptr_t)fiber->start_fp;
+    fiber->context.sp = fiber->stack_pointer;
+#else
+#error "unsupported architecture"
+#endif
+
+    fiber_stack_protection(fiber, true);
+
+    return fiber;
+}
+
+void fiber_free(
+        fiber_t *fiber) {
+    fiber_stack_protection(fiber, false);
+
+    xalloc_free(fiber->name);
+    xalloc_free(fiber->stack_base);
+    xalloc_free(fiber);
+}

--- a/src/fiber/fiber.h.old
+++ b/src/fiber/fiber.h.old
@@ -1,0 +1,88 @@
+#ifndef CACHEGRAND_FIBER_H
+#define CACHEGRAND_FIBER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__x86_64__)
+#include <fiber/arch/x86-64/fiber_context.h>
+#elif defined(__aarch64__)
+#include <fiber/arch/aarch64/fiber_context.h>
+#else
+#error "unsupported architecture"
+#endif
+
+typedef struct fiber fiber_t;
+typedef void (fiber_start_fp_t)(fiber_t* fiber_from, fiber_t* fiber_to);
+
+struct fiber {
+    // The context has to be held at the beginning of the structure and the field have to be specifically kept in this
+    // order as the assembly code in fiber.s access these fields by memory location and doesn't rely on the compiler
+    // to calculate the correct address.
+    // It is possible to implement build workarounds to get a mapping between the fields and their offsets but it is
+    // fairly clunky and as this code is not going to change (most likely) it's not worth to pollute the build system
+    // just for this.
+    // For reference, here a few links describing the workaround
+    // https://www.avrfreaks.net/forum/c-assembly-access-structure-fields-assembly
+    // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/kernel/asm-offsets.c
+    // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kbuild.h
+    // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Kbuild
+    fiber_context_t context;
+    void* stack_pointer;
+    void* stack_base;
+    size_t stack_size;
+    fiber_start_fp_t* start_fp;
+    void* start_fp_user_data;
+    char *name;
+    bool terminate;
+    int error_number;
+    union {
+        void* ptr_value;
+        int int_value;
+        long long_value;
+        bool bool_value;
+        size_t size_value;
+        uint32_t uint32_value;
+        uint64_t uint64_value;
+        int32_t int32_value;
+        int64_t int64_value;
+    } ret;
+#if DEBUG == 1
+    struct {
+        int line;
+        const char *file;
+        const char *func;
+    } switched_back_on;
+#endif
+} __attribute__((aligned(64)));
+
+extern void fiber_context_get(
+        fiber_t *fiber_context);
+
+extern void fiber_context_set(
+        fiber_t *fiber_context);
+
+extern void fiber_context_swap(
+        fiber_t *fiber_context_from,
+        fiber_t *fiber_context_to);
+
+void fiber_stack_protection(
+        fiber_t* fiber,
+        bool enable);
+
+fiber_t* fiber_new(
+        char *name,
+        size_t name_len,
+        size_t stack_size,
+        fiber_start_fp_t* fiber_start_fp,
+        void* user_data);
+
+void fiber_free(
+        fiber_t* fiber);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_FIBER_H

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -10,6 +10,9 @@ extern "C" {
 #endif
 
 #if FFMA_DEBUG_ALLOCS_FREES == 1
+#include <unistd.h>
+#include <sys/types.h>
+
 #warning "the fast fixed memory allocator built with allocs/frees debugging, will cause issues with valgrind and might hide bugs, use with caution!"
 #endif
 

--- a/src/module/prometheus/module_prometheus.c
+++ b/src/module/prometheus/module_prometheus.c
@@ -30,7 +30,7 @@
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "module/module.h"
@@ -100,7 +100,7 @@ void module_prometheus_client_new(
         module_prometheus_client_t *module_prometheus_client,
         config_module_t *config_module) {
     module_prometheus_client->read_buffer.data =
-            (char *)ffma_mem_alloc_zero(NETWORK_CHANNEL_RECV_BUFFER_SIZE);
+            (char *)xalloc_alloc_zero(NETWORK_CHANNEL_RECV_BUFFER_SIZE);
     module_prometheus_client->read_buffer.length = NETWORK_CHANNEL_RECV_BUFFER_SIZE;
 }
 
@@ -109,22 +109,22 @@ void module_prometheus_client_cleanup(
     client_http_request_data_t *http_request_data = &module_prometheus_client->http_request_data;
 
     if (http_request_data->url) {
-        ffma_mem_free(http_request_data->url);
+        xalloc_free(http_request_data->url);
     }
 
     if (http_request_data->headers.current_header_name) {
-        ffma_mem_free(http_request_data->headers.current_header_name);
+        xalloc_free(http_request_data->headers.current_header_name);
     }
 
     if (http_request_data->headers.list) {
         for(uint16_t index = 0; index < http_request_data->headers.count; index++) {
-            ffma_mem_free(http_request_data->headers.list[index].name);
-            ffma_mem_free(http_request_data->headers.list[index].value);
+            xalloc_free(http_request_data->headers.list[index].name);
+            xalloc_free(http_request_data->headers.list[index].value);
         }
-        ffma_mem_free(http_request_data->headers.list);
+        xalloc_free(http_request_data->headers.list);
     }
 
-    ffma_mem_free(module_prometheus_client->read_buffer.data);
+    xalloc_free(module_prometheus_client->read_buffer.data);
 }
 
 int module_prometheus_http_parser_on_message_complete(
@@ -146,7 +146,7 @@ int module_prometheus_http_parser_on_url(
         return -1;
     }
 
-    char *url = ffma_mem_alloc_zero(length + 1);
+    char *url = xalloc_alloc_zero(length + 1);
 
     if (url == NULL) {
         return -1;
@@ -171,7 +171,7 @@ int module_prometheus_http_parser_on_header_field(
         return -1;
     }
 
-    char *header_name = ffma_mem_alloc_zero(length + 1);
+    char *header_name = xalloc_alloc_zero(length + 1);
 
     if (header_name == NULL) {
         return -1;
@@ -204,16 +204,11 @@ int module_prometheus_http_parser_on_header_value(
         size_t headers_list_new_size =
                 headers_list_current_size +
                 (sizeof(client_http_header_t) * MODULE_PROMETHEUS_HTTP_HEADERS_SIZE_INCREASE);
-        http_request_data->headers.list =
-                ffma_mem_realloc(
-                        http_request_data->headers.list,
-                        headers_list_current_size,
-                        headers_list_new_size,
-                        true);
+        http_request_data->headers.list = xalloc_realloc(http_request_data->headers.list, headers_list_new_size);
         http_request_data->headers.size += MODULE_PROMETHEUS_HTTP_HEADERS_SIZE_INCREASE;
     }
 
-    char *header_value = ffma_mem_alloc_zero(length + 1);
+    char *header_value = xalloc_alloc_zero(length + 1);
 
     if (header_value == NULL) {
         return -1;
@@ -274,7 +269,7 @@ bool module_prometheus_http_send_response(
             CACHEGRAND_CMAKE_CONFIG_BUILD_DATE_TIME,
             content_length);
 
-    http_response = ffma_mem_alloc(http_response_len + 1);
+    http_response = xalloc_alloc(http_response_len + 1);
     if (!http_response) {
         goto end;
     }
@@ -301,7 +296,7 @@ bool module_prometheus_http_send_response(
 
 end:
     if (http_response) {
-        ffma_mem_free(http_response);
+        xalloc_free(http_response);
     }
 
     return result_ret;
@@ -332,7 +327,7 @@ bool module_prometheus_http_send_error(
     va_end(args_copy);
 
     // Build up the error message with the arguments
-    error_message_with_args = ffma_mem_alloc(error_message_with_args_len + 1);
+    error_message_with_args = xalloc_alloc(error_message_with_args_len + 1);
     if (!error_message_with_args) {
         va_end(args);
         goto end;
@@ -349,7 +344,7 @@ bool module_prometheus_http_send_error(
             error_title,
             error_message_with_args);
 
-    error_html_template = ffma_mem_alloc(error_html_template_len + 1);
+    error_html_template = xalloc_alloc(error_html_template_len + 1);
     if (!error_html_template) {
         goto end;
     }
@@ -370,11 +365,11 @@ bool module_prometheus_http_send_error(
 
 end:
     if (error_message_with_args) {
-        ffma_mem_free(error_message_with_args);
+        xalloc_free(error_message_with_args);
     }
 
     if (error_html_template) {
-        ffma_mem_free(error_html_template);
+        xalloc_free(error_html_template);
     }
 
     return result_ret;
@@ -407,11 +402,7 @@ char *module_prometheus_fetch_extra_metrics_from_env() {
                 env_separator);
 
         if (extra_env_content_length + metric_env_line_length + 1 > extra_env_content_size) {
-            extra_env_content = ffma_mem_realloc(
-                    extra_env_content,
-                    extra_env_content_size,
-                    extra_env_content_size + 512,
-                    false);
+            extra_env_content = xalloc_realloc(extra_env_content, extra_env_content_size + 512);
             if (!extra_env_content) {
                 break;
             }
@@ -478,11 +469,7 @@ bool module_prometheus_process_metrics_request_add_metric(
             value);
 
     if (*length + metric_length + 1 > *size) {
-        *buffer = ffma_mem_realloc(
-                *buffer,
-                *size,
-                *size + 128,
-                false);
+        *buffer = xalloc_realloc(*buffer, *size + 128);
 
         if (!*buffer) {
             return false;
@@ -553,7 +540,7 @@ bool module_prometheus_process_metrics_request(
     // Send out the stats for each worker plus the aggregated one
     do {
         size_t tags_len = (tags_from_env ? strlen(tags_from_env) : 0) + 128;
-        tags = ffma_mem_alloc(tags_len);
+        tags = xalloc_alloc(tags_len);
 
         // Try to fetch the stats for a worker, if it fails it builds up the aggregate, the while will later terminate
         // the loop
@@ -625,7 +612,7 @@ bool module_prometheus_process_metrics_request(
             }
         }
 
-        ffma_mem_free(tags);
+        xalloc_free(tags);
         tags = NULL;
         worker_index++;
     } while(found_worker);
@@ -639,15 +626,15 @@ bool module_prometheus_process_metrics_request(
 
 end:
     if (content) {
-        ffma_mem_free(content);
+        xalloc_free(content);
     }
 
     if (tags_from_env) {
-        ffma_mem_free(tags_from_env);
+        xalloc_free(tags_from_env);
     }
 
     if (tags) {
-        ffma_mem_free(tags);
+        xalloc_free(tags);
     }
 
     return result_ret;

--- a/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
+++ b/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
@@ -26,7 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "protocol/redis/protocol_redis.h"
@@ -173,7 +173,7 @@ bool module_redis_command_helper_incr_decr(
 end:
 
     if (allocated_new_buffer) {
-        ffma_mem_free(current_string);
+        xalloc_free(current_string);
     }
 
     if (unlikely(abort_rmw)) {
@@ -278,7 +278,7 @@ bool module_redis_command_helper_incr_decr_float(
 
         new_number_buffer_length = snprintf(NULL, 0, "%.17Lf", new_number);
         if (unlikely(new_number_buffer_length > sizeof(new_number_buffer_static))) {
-            new_number_buffer = ffma_mem_alloc(new_number_buffer_length + 1);
+            new_number_buffer = xalloc_alloc(new_number_buffer_length + 1);
             new_number_allocated_buffer = true;
         } else {
             new_number_buffer = (char*)new_number_buffer_static;
@@ -376,11 +376,11 @@ bool module_redis_command_helper_incr_decr_float(
 end:
 
     if (new_number_allocated_buffer) {
-        ffma_mem_free(new_number_buffer);
+        xalloc_free(new_number_buffer);
     }
 
     if (allocated_new_buffer) {
-        ffma_mem_free(current_string);
+        xalloc_free(current_string);
     }
 
     if (unlikely(abort_rmw)) {

--- a/src/module/redis/command/module_redis_command_append.c
+++ b/src/module/redis/command/module_redis_command_append.c
@@ -25,7 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_get.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
@@ -167,7 +167,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(append) {
             } while(buffer_length > 0);
 
             if (unlikely(allocated_new_buffer)) {
-                ffma_mem_free(source_buffer);
+                xalloc_free(source_buffer);
                 source_buffer = NULL;
                 allocated_new_buffer = false;
             }
@@ -201,7 +201,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(append) {
 end:
 
     if (unlikely(allocated_new_buffer)) {
-        ffma_mem_free(source_buffer);
+        xalloc_free(source_buffer);
         source_buffer = NULL;
         allocated_new_buffer = false;
     }

--- a/src/module/redis/command/module_redis_command_copy.c
+++ b/src/module/redis/command/module_redis_command_copy.c
@@ -25,7 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_set.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
@@ -179,7 +179,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(copy) {
         } while(source_chunk_written_data < source_chunk_info->chunk_length);
 
         if (unlikely(allocated_new_buffer)) {
-            ffma_mem_free(source_chunk_data);
+            xalloc_free(source_chunk_data);
             allocated_new_buffer = false;
         }
     }
@@ -221,7 +221,7 @@ end:
     }
 
     if (unlikely(allocated_new_buffer)) {
-        ffma_mem_free(source_chunk_data);
+        xalloc_free(source_chunk_data);
         allocated_new_buffer = false;
     }
 

--- a/src/module/redis/command/module_redis_command_hello.c
+++ b/src/module/redis/command/module_redis_command_hello.c
@@ -27,7 +27,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "protocol/redis/protocol_redis.h"
@@ -92,7 +92,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(hello) {
 
         if (context->setname_clientname.has_token) {
             connection_context->client_name =
-                    ffma_mem_alloc(context->setname_clientname.value.length + 1);
+                    xalloc_alloc(context->setname_clientname.value.length + 1);
             strncpy(
                     context->setname_clientname.value.short_string,
                     connection_context->client_name,

--- a/src/module/redis/command/module_redis_command_incr.c
+++ b/src/module/redis/command/module_redis_command_incr.c
@@ -26,7 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "protocol/redis/protocol_redis.h"

--- a/src/module/redis/command/module_redis_command_incrby.c
+++ b/src/module/redis/command/module_redis_command_incrby.c
@@ -26,7 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "protocol/redis/protocol_redis.h"

--- a/src/module/redis/command/module_redis_command_incrbyfloat.c
+++ b/src/module/redis/command/module_redis_command_incrbyfloat.c
@@ -26,7 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "protocol/redis/protocol_redis.h"

--- a/src/module/redis/command/module_redis_command_lcs.c
+++ b/src/module/redis/command/module_redis_command_lcs.c
@@ -28,7 +28,7 @@
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "protocol/redis/protocol_redis.h"
 #include "protocol/redis/protocol_redis_reader.h"
 #include "protocol/redis/protocol_redis_writer.h"
@@ -90,7 +90,7 @@ uint32_t *lcsmap_build(
         value_1_chunk_offset++;
         if (unlikely(value_1_chunk_index == -1 || value_1_chunk_offset >= value_1_chunk_info->chunk_length)) {
             if (unlikely(value_1_chunk_data_allocated_new)) {
-                ffma_mem_free(value_1_chunk_data);
+                xalloc_free(value_1_chunk_data);
                 value_1_chunk_data_allocated_new = false;
             }
 
@@ -114,7 +114,7 @@ uint32_t *lcsmap_build(
             value_2_chunk_offset++;
             if (unlikely(value_2_chunk_index == -1 || value_2_chunk_offset >= value_2_chunk_info->chunk_length)) {
                 if (unlikely(value_2_chunk_data_allocated_new)) {
-                    ffma_mem_free(value_2_chunk_data);
+                    xalloc_free(value_2_chunk_data);
                     value_2_chunk_data_allocated_new = false;
                 }
 
@@ -168,14 +168,14 @@ uint32_t *lcsmap_build(
 
     // Cleanup after building the tree
     if (unlikely(value_1_chunk_data_allocated_new)) {
-        ffma_mem_free(value_1_chunk_data);
+        xalloc_free(value_1_chunk_data);
         value_1_chunk_data_allocated_new = false;
     }
     value_1_chunk_data = NULL;
     value_1_chunk_info = NULL;
 
     if (unlikely(value_2_chunk_data_allocated_new)) {
-        ffma_mem_free(value_2_chunk_data);
+        xalloc_free(value_2_chunk_data);
         value_2_chunk_data_allocated_new = false;
     }
     value_2_chunk_data = NULL;
@@ -329,11 +329,11 @@ end:
     }
 
     if (value_1_chunk_data_allocated_new) {
-        ffma_mem_free(value_2_chunk_data);
+        xalloc_free(value_2_chunk_data);
     }
 
     if (value_2_chunk_data_allocated_new) {
-        ffma_mem_free(value_2_chunk_data);
+        xalloc_free(value_2_chunk_data);
     }
 
     if (entry_index_1) {

--- a/src/module/redis/command/module_redis_command_msetnx.c
+++ b/src/module/redis/command/module_redis_command_msetnx.c
@@ -23,7 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_set.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
@@ -53,7 +53,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(msetnx) {
     uint32_t rmw_statuses_processed_up_to = 0;
     module_redis_command_msetnx_context_t *context = connection_context->command.context;
 
-    rmw_statuses = ffma_mem_alloc_zero(sizeof(storage_db_op_rmw_status_t) * context->key_value.count);
+    rmw_statuses = xalloc_alloc_zero(sizeof(storage_db_op_rmw_status_t) * context->key_value.count);
 
     transaction_acquire(&transaction);
 

--- a/src/module/redis/command/module_redis_command_randomkey.c
+++ b/src/module/redis/command/module_redis_command_randomkey.c
@@ -24,7 +24,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_get.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -24,7 +24,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_op_get.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
@@ -177,7 +177,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
             if (unlikely(current_chunk_info == NULL)) {
                 // When the source is null, an empty chunk of memory has to be written
                 if (unlikely(padding_memory_zeroed == NULL)) {
-                    padding_memory_zeroed = ffma_mem_alloc_zero(STORAGE_DB_CHUNK_MAX_SIZE);
+                    padding_memory_zeroed = xalloc_alloc_zero(STORAGE_DB_CHUNK_MAX_SIZE);
                 }
 
                 // Calculate how much has to be written, if current_chunk_info is NULL there will be nothing to write
@@ -222,7 +222,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
                 data_to_write_buffer,
                 data_to_write_length))) {
             if (unlikely(allocated_new_buffer)) {
-                ffma_mem_free(allocated_buffer);
+                xalloc_free(allocated_buffer);
                 allocated_buffer = NULL;
                 allocated_new_buffer = false;
             }
@@ -234,7 +234,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
         }
 
         if (unlikely(allocated_new_buffer)) {
-            ffma_mem_free(allocated_buffer);
+            xalloc_free(allocated_buffer);
             allocated_buffer = NULL;
             allocated_new_buffer = false;
         }

--- a/src/module/redis/module_redis.c
+++ b/src/module/redis/module_redis.c
@@ -28,7 +28,7 @@
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "protocol/redis/protocol_redis.h"

--- a/src/module/redis/module_redis_command.c
+++ b/src/module/redis/module_redis_command.c
@@ -33,7 +33,7 @@
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "protocol/redis/protocol_redis.h"
 #include "protocol/redis/protocol_redis_reader.h"
 #include "protocol/redis/protocol_redis_writer.h"
@@ -56,7 +56,7 @@ bool module_redis_command_process_begin(
     module_redis_command_parser_context_t *command_parser_context = &connection_context->command.parser_context;
 
     if (connection_context->command.info->context_size > 0) {
-        if ((connection_context->command.context = ffma_mem_alloc_zero(
+        if ((connection_context->command.context = xalloc_alloc_zero(
                 connection_context->command.info->context_size)) == NULL) {
             LOG_D(TAG, "Unable to allocate the command context, terminating connection");
             return false;
@@ -146,14 +146,14 @@ void *module_redis_command_context_list_expand_and_get_new_entry(
 
     // If the list_count is zero it's not necessary to get the current pointer
     if (list_count == 0) {
-        list = ffma_mem_alloc_zero(list_count_new * argument->argument_context_member_size);
+        list = xalloc_alloc_zero(list_count_new * argument->argument_context_member_size);
     } else {
         list = module_redis_command_context_list_get_list(argument, base_addr);
-        list = ffma_mem_realloc(
-                list,
-                list_count * argument->argument_context_member_size,
-                list_count_new * argument->argument_context_member_size,
-                true);
+        list = xalloc_realloc(list, list_count_new * argument->argument_context_member_size);
+        memset(
+                (void *)((uintptr_t) list + (list_count * argument->argument_context_member_size)),
+                0,
+                (list_count_new - list_count) * argument->argument_context_member_size);
 
         if (!list) {
             return NULL;
@@ -293,12 +293,12 @@ bool module_redis_command_process_argument_begin(
     }
 
     if (expected_argument->type == MODULE_REDIS_COMMAND_ARGUMENT_TYPE_LONG_STRING) {
-        if (!storage_db_chunk_sequence_is_size_allowed(argument_length)) {
-            return module_redis_connection_error_message_printf_noncritical(
-                    connection_context,
-                    "ERR The argument length has exceeded the allowed size of '%lu'",
-                    storage_db_chunk_sequence_allowed_max_size());
-        }
+//        if (!storage_db_chunk_sequence_is_size_allowed(argument_length)) {
+//            return module_redis_connection_error_message_printf_noncritical(
+//                    connection_context,
+//                    "ERR The argument length has exceeded the allowed size of '%lu'",
+//                    storage_db_chunk_sequence_allowed_max_size());
+//        }
 
         command_parser_context->current_argument.member_context_addr =
                 module_redis_command_context_get_argument_member_context_addr(
@@ -916,7 +916,7 @@ bool module_redis_command_stream_entry_range_with_multiple_chunks(
                     buffer_to_send + sent_data,
                     data_to_send_length) != NETWORK_OP_RESULT_OK) {
                 if (allocated_new_buffer) {
-                    ffma_mem_free(buffer_to_send);
+                    xalloc_free(buffer_to_send);
                 }
 
                 return false;
@@ -929,7 +929,7 @@ bool module_redis_command_stream_entry_range_with_multiple_chunks(
         assert(sent_data == chunk_length_to_send);
 
         if (allocated_new_buffer) {
-            ffma_mem_free(buffer_to_send);
+            xalloc_free(buffer_to_send);
         }
 
         // Resets sent data at the end of the loop

--- a/src/module/redis/module_redis_command.h
+++ b/src/module/redis/module_redis_command.h
@@ -101,7 +101,7 @@ static inline __attribute__((always_inline)) void module_redis_command_process_f
     connection_context->command.info->command_free_funcptr(
             connection_context);
 
-    ffma_mem_free(connection_context->command.context);
+    xalloc_free(connection_context->command.context);
     connection_context->command.context = NULL;
 }
 

--- a/src/network/channel/network_channel.c
+++ b/src/network/channel/network_channel.c
@@ -28,7 +28,7 @@
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "network/channel/network_channel.h"
 
@@ -92,7 +92,7 @@ bool network_channel_init(
 
     if (channel->type == NETWORK_CHANNEL_TYPE_CLIENT) {
         channel->buffers.send.length = NETWORK_CHANNEL_SEND_BUFFER_SIZE;
-        channel->buffers.send.data = ffma_mem_alloc(channel->buffers.send.length);
+        channel->buffers.send.data = xalloc_alloc(channel->buffers.send.length);
     }
 
     return true;
@@ -101,7 +101,7 @@ bool network_channel_init(
 void network_channel_cleanup(
         network_channel_t *channel) {
     if (channel->type == NETWORK_CHANNEL_TYPE_CLIENT) {
-        ffma_mem_free(channel->buffers.send.data);
+        xalloc_free(channel->buffers.send.data);
         channel->buffers.send.data = NULL;
     }
 }

--- a/src/network/channel/network_channel_iouring.c
+++ b/src/network/channel/network_channel_iouring.c
@@ -18,7 +18,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "xalloc.h"
 #include "config.h"
 #include "module/module.h"
@@ -30,7 +30,7 @@
 network_channel_iouring_t* network_channel_iouring_new(
         network_channel_type_t type) {
     network_channel_iouring_t *channel =
-            (network_channel_iouring_t*)ffma_mem_alloc_zero(sizeof(network_channel_iouring_t));
+            (network_channel_iouring_t*)xalloc_alloc_zero(sizeof(network_channel_iouring_t));
 
     network_channel_init(type, &channel->wrapped_channel);
 
@@ -41,7 +41,7 @@ network_channel_iouring_t* network_channel_iouring_multi_new(
         network_channel_type_t type,
         uint32_t count) {
     network_channel_iouring_t *channels =
-            (network_channel_iouring_t*)ffma_mem_alloc_zero(sizeof(network_channel_iouring_t) * count);
+            (network_channel_iouring_t*)xalloc_alloc_zero(sizeof(network_channel_iouring_t) * count);
 
     for(int index = 0; index < count; index++) {
         network_channel_init(type, &channels[index].wrapped_channel);
@@ -53,5 +53,5 @@ network_channel_iouring_t* network_channel_iouring_multi_new(
 void network_channel_iouring_free(
         network_channel_iouring_t* network_channel) {
     network_channel_cleanup(&network_channel->wrapped_channel);
-    ffma_mem_free(network_channel);
+    xalloc_free(network_channel);
 }

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -26,7 +26,7 @@
 #include "spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "log/log.h"
@@ -88,7 +88,7 @@ bool network_channel_tls_init(
         network_channel_t *network_channel) {
     bool result_res = false;
 
-    network_channel->tls.context = ffma_mem_alloc(sizeof(mbedtls_ssl_context));
+    network_channel->tls.context = xalloc_alloc(sizeof(mbedtls_ssl_context));
     mbedtls_ssl_init(network_channel->tls.context);
 
     if (mbedtls_ssl_setup(
@@ -112,7 +112,7 @@ end:
 
     if (!result_res && network_channel->tls.context) {
         mbedtls_ssl_free(network_channel->tls.context);
-        ffma_mem_free(network_channel->tls.context);
+        xalloc_free(network_channel->tls.context);
 
         network_channel->tls.context = NULL;
     }
@@ -365,7 +365,7 @@ void network_channel_tls_free(
     }
 
     mbedtls_ssl_free(network_channel->tls.context);
-    ffma_mem_free(network_channel->tls.context);
+    xalloc_free(network_channel->tls.context);
 
     network_channel->tls.context = NULL;
 }

--- a/src/network/network_tls.c
+++ b/src/network/network_tls.c
@@ -24,7 +24,7 @@
 #include "spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/simple_file_io.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"
@@ -168,7 +168,7 @@ int *network_tls_build_cipher_suites_from_names(
     }
 
     // There might be over allocation in case of invalid cipher suites
-    int *cipher_suites_ids = ffma_mem_alloc_zero(sizeof(int) * (cipher_suites_names_count + 1));
+    int *cipher_suites_ids = xalloc_alloc_zero(sizeof(int) * (cipher_suites_names_count + 1));
 
     int cipher_suite_id_index = 0;
     for(
@@ -199,7 +199,7 @@ int *network_tls_build_cipher_suites_from_names(
 
     // Check if all the ciphers specified are invalid
     if (cipher_suite_id_index == 0) {
-        ffma_mem_free(cipher_suites_ids);
+        xalloc_free(cipher_suites_ids);
         return NULL;
     }
 
@@ -218,7 +218,7 @@ network_tls_config_t *network_tls_config_init(
     network_tls_config_t *network_tls_config = NULL;
     bool return_res = false;
 
-    network_tls_config = ffma_mem_alloc(sizeof(network_tls_config_t) + cipher_suites_length);
+    network_tls_config = xalloc_alloc(sizeof(network_tls_config_t) + cipher_suites_length);
     if (network_tls_config == NULL) {
         goto end;
     }
@@ -317,7 +317,7 @@ end:
         mbedtls_entropy_free(&network_tls_config->entropy);
         mbedtls_ssl_config_free(&network_tls_config->config);
 
-        ffma_mem_free(network_tls_config);
+        xalloc_free(network_tls_config);
         network_tls_config = NULL;
     }
 
@@ -336,7 +336,7 @@ void network_tls_config_free(
     mbedtls_entropy_free(&network_tls_config->entropy);
     mbedtls_ssl_config_free(&network_tls_config->config);
 
-    ffma_mem_free(network_tls_config);
+    xalloc_free(network_tls_config);
 }
 
 network_op_result_t network_tls_close_internal(
@@ -507,7 +507,7 @@ network_tls_mbedtls_cipher_suite_info_t *network_tls_mbedtls_get_all_cipher_suit
     }
 
     // Fills up the data to be returned
-    cipher_suites = ffma_mem_alloc_zero(sizeof(network_tls_mbedtls_cipher_suite_info_t) * (count + 1));
+    cipher_suites = xalloc_alloc_zero(sizeof(network_tls_mbedtls_cipher_suite_info_t) * (count + 1));
     index = 0;
     for(
             const int *mbedtls_cipher_suite_id = mbedtls_cipher_suites_ids;

--- a/src/program.c
+++ b/src/program.c
@@ -60,7 +60,7 @@
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "thread.h"
 #include "hugepage_cache.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/sentry/sentry_support.h"
 #include "signal_handler_thread.h"
 #include "version.h"
@@ -522,12 +522,12 @@ bool program_use_huge_pages(
         LOG_W(TAG, "Fast fixed memory allocator disabled in config, performances will be degraded");
     }
 
-    if (use_huge_pages) {
-        hugepage_cache_init();
-        ffma_enable(use_huge_pages);
-    } else {
-        ffma_enable(false);
-    }
+//    if (use_huge_pages) {
+//        hugepage_cache_init();
+//        ffma_enable(use_huge_pages);
+//    } else {
+//        ffma_enable(false);
+//    }
 
     program_context->use_huge_pages = use_huge_pages;
 
@@ -894,6 +894,8 @@ end:
 #if FFMA_DEBUG_ALLOCS_FREES == 1
     ffma_debug_allocs_frees_end();
 #endif
+
+    mi_collect(true);
 
     return return_res;
 }

--- a/src/storage/channel/storage_channel.c
+++ b/src/storage/channel/storage_channel.c
@@ -16,7 +16,7 @@
 #include "spinlock.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "storage/io/storage_io_common.h"
 
 #include "storage_channel.h"
@@ -32,7 +32,7 @@ bool storage_channel_init(
 
 storage_channel_t* storage_channel_new() {
     storage_channel_t *channel =
-            (storage_channel_t*)ffma_mem_alloc_zero(sizeof(storage_channel_t));
+            (storage_channel_t*)xalloc_alloc_zero(sizeof(storage_channel_t));
 
     storage_channel_init(channel);
 
@@ -42,7 +42,7 @@ storage_channel_t* storage_channel_new() {
 storage_channel_t* storage_channel_multi_new(
         uint32_t count) {
     storage_channel_t *channels =
-            (storage_channel_t*)ffma_mem_alloc_zero(sizeof(storage_channel_t) * count);
+            (storage_channel_t*)xalloc_alloc_zero(sizeof(storage_channel_t) * count);
 
     for(int index = 0; index < count; index++) {
         storage_channel_init(&channels[index]);
@@ -53,5 +53,5 @@ storage_channel_t* storage_channel_multi_new(
 
 void storage_channel_free(
         storage_channel_t* storage_channel) {
-    ffma_mem_free(storage_channel);
+    xalloc_free(storage_channel);
 }

--- a/src/storage/channel/storage_channel_iouring.c
+++ b/src/storage/channel/storage_channel_iouring.c
@@ -9,18 +9,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <netinet/in.h>
-#include "exttypes.h"
-#include "spinlock.h"
-#include "data_structures/double_linked_list/double_linked_list.h"
-#include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "storage/io/storage_io_common.h"
 #include "storage/channel/storage_channel.h"
 #include "storage/channel/storage_channel_iouring.h"
 
 storage_channel_iouring_t* storage_channel_iouring_new() {
     storage_channel_iouring_t *channel =
-            (storage_channel_iouring_t*)ffma_mem_alloc_zero(sizeof(storage_channel_iouring_t));
+            (storage_channel_iouring_t*)xalloc_alloc_zero(sizeof(storage_channel_iouring_t));
 
     storage_channel_init(&channel->wrapped_channel);
 
@@ -30,7 +26,7 @@ storage_channel_iouring_t* storage_channel_iouring_new() {
 storage_channel_iouring_t* storage_channel_iouring_multi_new(
         uint32_t count) {
     storage_channel_iouring_t *channels =
-            (storage_channel_iouring_t*)ffma_mem_alloc_zero(sizeof(storage_channel_iouring_t) * count);
+            (storage_channel_iouring_t*)xalloc_alloc_zero(sizeof(storage_channel_iouring_t) * count);
 
     for(int index = 0; index < count; index++) {
         storage_channel_init(&channels[index].wrapped_channel);
@@ -41,5 +37,5 @@ storage_channel_iouring_t* storage_channel_iouring_multi_new(
 
 void storage_channel_iouring_free(
         storage_channel_iouring_t* storage_channel) {
-    ffma_mem_free(storage_channel);
+    xalloc_free(storage_channel);
 }

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -37,7 +37,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/io_uring/io_uring_support.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -34,7 +34,7 @@
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "config.h"
 #include "log/log.h"
 #include "fiber/fiber.h"
@@ -48,7 +48,7 @@
 #include "worker/worker_context.h"
 #include "worker/worker.h"
 #include "worker/worker_op.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/simple_file_io.h"
 #include "fiber/fiber_scheduler.h"
 #include "network/network.h"
@@ -81,7 +81,7 @@ worker_module_context_t *worker_module_contexts_initialize(
     worker_module_context_t *worker_module_context = NULL;
 
     worker_module_context =
-            ffma_mem_alloc_zero(sizeof(worker_module_context_t) * config->modules_count);
+            xalloc_alloc_zero(sizeof(worker_module_context_t) * config->modules_count);
     if (!worker_module_context) {
         goto end;
     }
@@ -108,7 +108,7 @@ worker_module_context_t *worker_module_contexts_initialize(
                 cipher_suites_ids_size);
 
         if (cipher_suites) {
-            ffma_mem_free(cipher_suites);
+            xalloc_free(cipher_suites);
         }
 
         if (!network_tls_config) {
@@ -130,7 +130,7 @@ end:
             network_tls_config_free(worker_module_context[module_index].network_tls_config);
         }
 
-        ffma_mem_free(worker_module_context);
+        xalloc_free(worker_module_context);
         worker_module_context = NULL;
     }
 
@@ -147,7 +147,7 @@ void worker_module_context_free(
         network_tls_config_free(worker_module_context[module_index].network_tls_config);
     }
 
-    ffma_mem_free(worker_module_context);
+    xalloc_free(worker_module_context);
 }
 
 // TODO: the listener and accept operations should be refactored to split them in an user frontend operation and in an

--- a/src/worker/storage/worker_storage_iouring_op.c
+++ b/src/worker/storage/worker_storage_iouring_op.c
@@ -25,7 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/io_uring/io_uring_support.h"
 #include "config.h"
 #include "storage/io/storage_io_common.h"

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -67,7 +67,7 @@
 #include "worker/network/worker_network_iouring_op.h"
 #include "worker/storage/worker_storage_iouring_op.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "worker.h"
 
 #define TAG "worker"
@@ -251,7 +251,7 @@ void worker_cleanup_general(
     }
 
     if (worker_context->fibers.listeners_fibers) {
-        ffma_mem_free(worker_context->fibers.listeners_fibers);
+        xalloc_free(worker_context->fibers.listeners_fibers);
     }
 }
 
@@ -417,7 +417,7 @@ void* worker_thread_func(
             listeners_count);
 
     // TODO: cleanup implementation
-    worker_context->fibers.listeners_fibers = ffma_mem_alloc(sizeof(fiber_t*) * listeners_count);
+    worker_context->fibers.listeners_fibers = xalloc_alloc(sizeof(fiber_t*) * listeners_count);
     worker_network_listeners_listen(
             worker_context->fibers.listeners_fibers,
             listeners,

--- a/src/worker/worker_iouring.c
+++ b/src/worker/worker_iouring.c
@@ -35,7 +35,7 @@
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/io_uring/io_uring_support.h"
 #include "support/io_uring/io_uring_capabilities.h"
 #include "module/module.h"

--- a/src/worker/worker_iouring_op.c
+++ b/src/worker/worker_iouring_op.c
@@ -27,7 +27,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "support/io_uring/io_uring_support.h"
 #include "storage/io/storage_io_common.h"
 #include "storage/channel/storage_channel.h"

--- a/src/worker/worker_stats.c
+++ b/src/worker/worker_stats.c
@@ -27,7 +27,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -43,6 +43,15 @@
 
 #define TAG "xalloc"
 
+#if DISABLE_MIMALLOC == 0
+FUNCTION_CTOR(xalloc_init, {
+    mi_option_enable(mi_option_page_reset);
+    mi_option_enable(mi_option_allow_decommit);
+    mi_option_enable(mi_option_abandoned_page_decommit);
+    mi_option_set(mi_option_decommit_delay, 0);
+})
+#endif
+
 void* xalloc_alloc(
         size_t size) {
     void* memptr;

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-get.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-get.cpp
@@ -19,7 +19,7 @@
 #include "xalloc.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
 #include "clock.h"
@@ -85,7 +85,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("found - key external") {
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
 
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
@@ -113,8 +113,8 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("found - multiple chunks first slot") {
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key(s) is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
-                char *test_key_2_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
+                char *test_key_2_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
                 strcpy(test_key_2_copy, test_key_2);
 
@@ -162,7 +162,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("found - single chunk with first slot empty") {
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key(s) is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
 
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
@@ -289,7 +289,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("not found - deleted flag") {
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key(s) is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
 
                 HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
@@ -314,7 +314,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("not found - hash set but key_value not (edge case because of parallelism)") {
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key(s) is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
 
                 hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
@@ -345,8 +345,8 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("found - single bucket - get key after delete with hash still in hash_half (edge case because of parallelism)") {
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key(s) is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
-                char *test_key_2_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
+                char *test_key_2_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
                 strcpy(test_key_2_copy, test_key_1);
 

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-iter.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-iter.cpp
@@ -19,7 +19,7 @@
 #include "xalloc.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
 #include "clock.h"
@@ -58,7 +58,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
 
             HASHTABLE(0x7FFF, false, {
                 // Not necessary to free, the key(s) is owned by the hashtable
-                char *test_key_1_copy = (char*)ffma_mem_alloc(test_key_1_len + 1);
+                char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
 
                 hashtable_chunk_index_t chunk_index1 = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(

--- a/tests/unit_tests/modules/redis/test-module-redis-command.cpp
+++ b/tests/unit_tests/modules/redis/test-module-redis-command.cpp
@@ -25,7 +25,7 @@
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"
 #include "network/channel/network_channel.h"
@@ -90,6 +90,6 @@ TEST_CASE("module/redis/module_redis_command.c", "[module][redis][module_redis_c
 //        module_redis_command_context_t *command_context = module_redis_command_process_begin(
 //                &test_module_redis_command_sort_command_info);
 //
-//        ffma_mem_free(command_context);
+//        xalloc_free(command_context);
 //    }
 }

--- a/tests/unit_tests/network/test-network-tls.cpp
+++ b/tests/unit_tests/network/test-network-tls.cpp
@@ -31,7 +31,7 @@
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "config.h"
 #include "support/simple_file_io.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"
 #include "network/channel/network_channel.h"
@@ -275,7 +275,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
         }
 
         if (!cipher_suites_ids) {
-            ffma_mem_free(cipher_suites_ids);
+            xalloc_free(cipher_suites_ids);
         }
     }
 
@@ -499,7 +499,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
 
             REQUIRE(network_tls_config);
 
-            ffma_mem_free(cipher_suites_ids);
+            xalloc_free(cipher_suites_ids);
         }
 
         SECTION("invalid certificate file") {
@@ -557,7 +557,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
             mbedtls_entropy_free(&network_tls_config->entropy);
             mbedtls_ssl_config_free(&network_tls_config->config);
 
-            ffma_mem_free(network_tls_config);
+            xalloc_free(network_tls_config);
         }
     }
 
@@ -645,7 +645,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
         REQUIRE(cipher_suites_info[0].offloading ==
             network_tls_does_ulp_tls_support_mbedtls_cipher_suite(mbedtls_ssl_ciphersuite_first->cipher));
 
-        ffma_mem_free(cipher_suites_info);
+        xalloc_free(cipher_suites_info);
     }
 
     SECTION("network_tls_min_version_to_string") {

--- a/tests/unit_tests/support.c
+++ b/tests/unit_tests/support.c
@@ -45,7 +45,7 @@
 #include "support/simple_file_io.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
+#include "xalloc.h"
 
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_config.h"

--- a/tests/unit_tests/test-config.cpp
+++ b/tests/unit_tests/test-config.cpp
@@ -973,10 +973,10 @@ TEST_CASE("config.c", "[config]") {
             REQUIRE(config_validate_after_load(config) == true);
         }
 
-        SECTION("broken - network redis max_key_length > object size max") {
-            config->modules[0].redis->max_key_length = 64 * 1024 + 1;
-            REQUIRE(config_validate_after_load(config) == false);
-        }
+//        SECTION("broken - network redis max_key_length > object size max") {
+//            config->modules[0].redis->max_key_length = 64 * 1024 + 1;
+//            REQUIRE(config_validate_after_load(config) == false);
+//        }
 
         SECTION("broken - network.timeout.read_ms < -1") {
             config->modules[0].network->timeout->read_ms = -2;

--- a/tests/unit_tests/test-fiber-scheduler.cpp
+++ b/tests/unit_tests/test-fiber-scheduler.cpp
@@ -1,10 +1,400 @@
-/**
- * Copyright (C) 2018-2022 Daniele Salvatore Albano
- * All rights reserved.
- *
- * This software may be modified and distributed under the terms
- * of the BSD license.  See the LICENSE file for details.
- **/
+///**
+// * Copyright (C) 2018-2022 Daniele Salvatore Albano
+// * All rights reserved.
+// *
+// * This software may be modified and distributed under the terms
+// * of the BSD license.  See the LICENSE file for details.
+// **/
+//
+//#include <catch2/catch.hpp>
+//#include <unistd.h>
+//#include <sys/mman.h>
+//#include <xalloc.h>
+//#include <string.h>
+//#include <signal.h>
+//#include <setjmp.h>
+//
+//#include "signals_support.h"
+//#include "fiber/fiber.h"
+//#include "fiber/fiber_scheduler.h"
+//
+//char test_fiber_scheduler_fixture_fiber_name[] = "test-fiber";
+//size_t test_fiber_scheduler_fixture_fiber_name_leb = sizeof(test_fiber_scheduler_fixture_fiber_name);
+//long test_fiber_scheduler_fixture_user_data = 42;
+//
+//extern thread_local fiber_scheduler_stack_t fiber_scheduler_stack;
+//
+//bool test_fiber_scheduler_switched_to_fiber = false;
+//void *test_fiber_scheduler_caller_user_data = NULL;
+//int8_t test_fiber_scheduler_fiber_scheduler_stack_index = -1;
+//int8_t test_fiber_scheduler_fiber_scheduler_stack_size = 0;
+//fiber_t *test_fiber_scheduler_fiber_scheduler_stack_current_fiber = NULL;
+//
+//
+//sigjmp_buf test_fiber_scheduler_jump_fp;
+//void test_fiber_scheduler_memory_stack_protection_signal_sigabrt_and_sigsegv_handler_longjmp(int signal_number) {
+//    siglongjmp(test_fiber_scheduler_jump_fp, 1);
+//}
+//
+//void test_fiber_scheduler_memory_stack_protection_setup_sigabrt_and_sigsegv_signal_handler() {
+//    signals_support_register_signal_handler(
+//            SIGABRT,
+//            test_fiber_scheduler_memory_stack_protection_signal_sigabrt_and_sigsegv_handler_longjmp,
+//            NULL);
+//
+//    signals_support_register_signal_handler(
+//            SIGSEGV,
+//            test_fiber_scheduler_memory_stack_protection_signal_sigabrt_and_sigsegv_handler_longjmp,
+//            NULL);
+//}
+//
+//void test_fiber_scheduler_fiber_do_nothing(void *user_data) {
+//    test_fiber_scheduler_switched_to_fiber = true;
+//    test_fiber_scheduler_caller_user_data = user_data;
+//}
+//
+//void test_fiber_scheduler_fiber_get_userdata_entrypoint(void *user_data) {
+//    test_fiber_scheduler_switched_to_fiber = true;
+//    test_fiber_scheduler_caller_user_data = user_data;
+//
+//    fiber_scheduler_switch_back();
+//}
+//
+//void test_fiber_scheduler_fiber_switch_to_test_entrypoint(fiber_t *from, fiber_t *to) {
+//    test_fiber_scheduler_switched_to_fiber = true;
+//
+//    test_fiber_scheduler_fiber_scheduler_stack_index = fiber_scheduler_stack.index;
+//    test_fiber_scheduler_fiber_scheduler_stack_size = fiber_scheduler_stack.size;
+//    test_fiber_scheduler_fiber_scheduler_stack_current_fiber =
+//            fiber_scheduler_stack.list[test_fiber_scheduler_fiber_scheduler_stack_index];
+//
+//    fiber_scheduler_switch_back();
+//}
+//
+//TEST_CASE("fiber_scheduler.c", "[fiber_scheduler]") {
+//    size_t page_size = getpagesize();
+//    size_t stack_size = page_size * 8;
+//    test_fiber_scheduler_caller_user_data = NULL;
+//    test_fiber_scheduler_switched_to_fiber = false;
+//
+//    SECTION("fiber_scheduler_get_current") {
+//        fiber_t fiber = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//                .terminate = false,
+//        };
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 1);
+//        fiber_scheduler_stack.index = 0;
+//        fiber_scheduler_stack.size = 1;
+//
+//        fiber_scheduler_stack.list[0] = &fiber;
+//
+//        REQUIRE(fiber_scheduler_get_current() == &fiber);
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_terminate_current_fiber") {
+//        fiber_t fiber = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//                .terminate = false,
+//        };
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 1);
+//        fiber_scheduler_stack.index = 0;
+//        fiber_scheduler_stack.size = 1;
+//
+//        fiber_scheduler_stack.list[0] = &fiber;
+//        fiber_scheduler_terminate_current_fiber();
+//
+//        REQUIRE(fiber.terminate);
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_stack_needs_growth") {
+//        SECTION("needs growth") {
+//            fiber_scheduler_stack.index = -1;
+//            fiber_scheduler_stack.size = 0;
+//
+//            REQUIRE(fiber_scheduler_stack_needs_growth());
+//        }
+//
+//        SECTION("don't need growth") {
+//            fiber_scheduler_stack.index = -1;
+//            fiber_scheduler_stack.size = 2;
+//
+//            REQUIRE(!fiber_scheduler_stack_needs_growth());
+//        }
+//
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_grow_stack") {
+//        SECTION("grow stack") {
+//            fiber_scheduler_grow_stack();
+//
+//            REQUIRE(fiber_scheduler_stack.index == -1);
+//            REQUIRE(fiber_scheduler_stack.size == 1);
+//        }
+//
+//        SECTION("grow stack twice") {
+//            fiber_scheduler_grow_stack();
+//            fiber_scheduler_grow_stack();
+//
+//            REQUIRE(fiber_scheduler_stack.index == -1);
+//            REQUIRE(fiber_scheduler_stack.size == 2);
+//        }
+//
+//        SECTION("reached max limit") {
+//            fiber_scheduler_stack.index = 4;
+//            fiber_scheduler_stack.size = 5;
+//
+//            bool fatal_catched = false;
+//            if (sigsetjmp(test_fiber_scheduler_jump_fp, 1) == 0) {
+//                test_fiber_scheduler_memory_stack_protection_setup_sigabrt_and_sigsegv_signal_handler();
+//                fiber_scheduler_grow_stack();
+//            } else {
+//                fatal_catched = true;
+//            }
+//
+//            // The fatal_catched variable has to be set to true as sigsetjmp on the second execution will return a value
+//            // different from zero.
+//            // A sigsegv raised by the kernel because of the memory protection means that the stack overflow protection
+//            // is working as intended
+//            REQUIRE(fatal_catched);
+//        }
+//
+//        if (fiber_scheduler_stack.list != NULL) {
+//            xalloc_free(fiber_scheduler_stack.list);
+//            fiber_scheduler_stack.list = NULL;
+//        }
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_new_fiber_entrypoint") {
+//        fiber_scheduler_new_fiber_user_data_t fiber_scheduler_new_fiber_entrypoint_user_data = {
+//                .caller_entrypoint_fp = test_fiber_scheduler_fiber_do_nothing,
+//                .caller_user_data = NULL,
+//        };
+//        fiber_t fiber_1 = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//        };
+//        fiber_t *fiber_2 = fiber_new(
+//                test_fiber_scheduler_fixture_fiber_name,
+//                strlen(test_fiber_scheduler_fixture_fiber_name),
+//                stack_size,
+//                fiber_scheduler_new_fiber_entrypoint,
+//                &fiber_scheduler_new_fiber_entrypoint_user_data);
+//
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 2);
+//        fiber_scheduler_stack.index = 1;
+//        fiber_scheduler_stack.size = 2;
+//
+//        fiber_scheduler_stack.list[0] = &fiber_1;
+//        fiber_scheduler_stack.list[1] = fiber_2;
+//
+//        SECTION("test entrypoint invocation") {
+//            fiber_context_swap(&fiber_1, fiber_2);
+//
+//            REQUIRE(test_fiber_scheduler_switched_to_fiber);
+//            REQUIRE(fiber_2->terminate == true);
+//        }
+//
+//        SECTION("test failure on switching to a terminated fiber") {
+//            fiber_context_swap(&fiber_1, fiber_2);
+//
+//            // Context switching to a terminated fiber should NEVER happen as the memory will be automatically free
+//            // and therefore may become garbage right after the context is switched back but to test out the expected
+//            // behaviour of the fiber scheduler entrypoint the test does it ANYWAY.
+//            // The signal handler needs to handle not only the SIGABRT, as triggered by the FATAL when th terminated
+//            // fiber is switched back, but also the SIGSEGV as some CI/CD agents/environments (e.g. GitHub) don't really
+//            // like this operation.
+//            // Intercepting the SIGSEGV will let the test to pass even if the fiber doesn't get to invoke FATAL, can't
+//            // really be avoided as the memory gets freed.
+//            bool fatal_catched = false;
+//            if (sigsetjmp(test_fiber_scheduler_jump_fp, 1) == 0) {
+//                test_fiber_scheduler_memory_stack_protection_setup_sigabrt_and_sigsegv_signal_handler();
+//                fiber_context_swap(&fiber_1, fiber_2);
+//            } else {
+//                fatal_catched = true;
+//            }
+//
+//            REQUIRE(fatal_catched);
+//        }
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//
+//        fiber_free(fiber_2);
+//    }
+//
+//    SECTION("fiber_scheduler_switch_to") {
+//        fiber_t *fiber = fiber_new(
+//                test_fiber_scheduler_fixture_fiber_name,
+//                test_fiber_scheduler_fixture_fiber_name_leb,
+//                stack_size,
+//                test_fiber_scheduler_fiber_switch_to_test_entrypoint,
+//                NULL);
+//
+//        fiber_scheduler_switch_to(fiber);
+//
+//        REQUIRE(test_fiber_scheduler_switched_to_fiber);
+//        REQUIRE(fiber_scheduler_stack.list != NULL);
+//        REQUIRE(test_fiber_scheduler_fiber_scheduler_stack_index == 1);
+//        REQUIRE(test_fiber_scheduler_fiber_scheduler_stack_size == 2);
+//        REQUIRE(test_fiber_scheduler_fiber_scheduler_stack_current_fiber == fiber);
+//        REQUIRE(fiber_scheduler_stack.index == 0);
+//        REQUIRE(fiber_scheduler_stack.size == 2);
+//        REQUIRE(strcmp(fiber_scheduler_stack.list[0]->name, FIBER_SCHEDULER_FIBER_NAME) == 0);
+//
+//#if DEBUG == 1
+//        REQUIRE(strcmp(fiber->switched_back_on.file, CACHEGRAND_SRC_PATH) == 0);
+//        REQUIRE(strcmp(fiber->switched_back_on.func, "test_fiber_scheduler_fiber_switch_to_test_entrypoint") == 0);
+//#endif
+//
+//        fiber_free(fiber);
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_new_fiber") {
+//        SECTION("new fiber") {
+//            fiber_t *fiber = fiber_scheduler_new_fiber(
+//                    test_fiber_scheduler_fixture_fiber_name,
+//                    test_fiber_scheduler_fixture_fiber_name_leb,
+//                    test_fiber_scheduler_fiber_get_userdata_entrypoint,
+//                    (void *) &test_fiber_scheduler_fixture_user_data);
+//
+//            REQUIRE(strncmp(fiber->name, test_fiber_scheduler_fixture_fiber_name, strlen(test_fiber_scheduler_fixture_fiber_name)) == 0);
+//            REQUIRE(fiber->start_fp == fiber_scheduler_new_fiber_entrypoint);
+//            REQUIRE(test_fiber_scheduler_switched_to_fiber);
+//            REQUIRE(test_fiber_scheduler_caller_user_data == (void*)&test_fiber_scheduler_fixture_user_data);
+//
+//            fiber_free(fiber);
+//        }
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_set_error") {
+//        fiber_t fiber = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//                .error_number = 0,
+//        };
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 1);
+//        fiber_scheduler_stack.index = 0;
+//        fiber_scheduler_stack.size = 1;
+//
+//        fiber_scheduler_stack.list[0] = &fiber;
+//
+//        fiber_scheduler_set_error(123);
+//
+//        REQUIRE(fiber.error_number == 123);
+//        REQUIRE(errno == 123);
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_get_error") {
+//        fiber_t fiber = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//                .error_number = 123,
+//        };
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 1);
+//        fiber_scheduler_stack.index = 0;
+//        fiber_scheduler_stack.size = 1;
+//
+//        fiber_scheduler_stack.list[0] = &fiber;
+//
+//        REQUIRE(fiber_scheduler_get_error() == 123);
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_has_error") {
+//        fiber_t fiber = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//        };
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 1);
+//        fiber_scheduler_stack.index = 0;
+//        fiber_scheduler_stack.size = 1;
+//
+//        fiber_scheduler_stack.list[0] = &fiber;
+//
+//        SECTION("with error") {
+//            fiber.error_number = 123;
+//            REQUIRE(fiber_scheduler_has_error());
+//        }
+//
+//        SECTION("without error") {
+//            fiber.error_number = 0;
+//            REQUIRE(!fiber_scheduler_has_error());
+//        }
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//
+//    SECTION("fiber_scheduler_reset_error") {
+//        fiber_t fiber = {
+//                .start_fp = NULL,
+//                .start_fp_user_data = NULL,
+//                .name = test_fiber_scheduler_fixture_fiber_name,
+//                .error_number = 123,
+//        };
+//        fiber_scheduler_stack.list = (fiber_t**)xalloc_alloc(sizeof(fiber_t*) * 1);
+//        fiber_scheduler_stack.index = 0;
+//        fiber_scheduler_stack.size = 1;
+//
+//        fiber_scheduler_stack.list[0] = &fiber;
+//
+//        fiber_scheduler_reset_error();
+//
+//        REQUIRE(fiber.error_number == 0);
+//        REQUIRE(errno == 0);
+//
+//        xalloc_free(fiber_scheduler_stack.list);
+//        fiber_scheduler_stack.list = NULL;
+//        fiber_scheduler_stack.index = -1;
+//        fiber_scheduler_stack.size = 0;
+//    }
+//}
 
 #include <cstring>
 #include <csignal>

--- a/tests/unit_tests/test-fibers.cpp
+++ b/tests/unit_tests/test-fibers.cpp
@@ -1,10 +1,301 @@
-/**
- * Copyright (C) 2018-2022 Daniele Salvatore Albano
- * All rights reserved.
- *
- * This software may be modified and distributed under the terms
- * of the BSD license.  See the LICENSE file for details.
- **/
+///**
+// * Copyright (C) 2018-2022 Daniele Salvatore Albano
+// * All rights reserved.
+// *
+// * This software may be modified and distributed under the terms
+// * of the BSD license.  See the LICENSE file for details.
+// **/
+//
+//#include <catch2/catch.hpp>
+//#include <unistd.h>
+//#include <sys/mman.h>
+//#include <string.h>
+//#include <signal.h>
+//#include <setjmp.h>
+//
+//#include "xalloc.h"
+//#include "signals_support.h"
+//#include "fiber/fiber.h"
+//
+//char test_fiber_name[] = "test-fiber";
+//size_t test_fiber_name_len = sizeof(test_fiber_name);
+//
+//sigjmp_buf test_fiber_jump_fp;
+//void test_fiber_memory_stack_protection_signal_sigsegv_handler_longjmp(int signal_number) {
+//    siglongjmp(test_fiber_jump_fp, 1);
+//}
+//
+//void test_fiber_memory_stack_protection_setup_sigsegv_signal_handler() {
+//    signals_support_register_signal_handler(
+//            SIGSEGV,
+//            test_fiber_memory_stack_protection_signal_sigsegv_handler_longjmp,
+//            NULL);
+//}
+//
+//#pragma GCC diagnostic push
+//#pragma GCC diagnostic ignored "-Wreturn-local-addr"
+//void* fiber_context_get_test(fiber_t *fiber) {
+//    int test_fiber_context_get_sp_first_var = 0;
+//    void* test_fiber_context_get_sp_first_var_ptr = &test_fiber_context_get_sp_first_var;
+//    fiber_context_get(fiber);
+//
+//    return test_fiber_context_get_sp_first_var_ptr;
+//}
+//#pragma GCC diagnostic pop
+//
+//void test_fiber_new_empty(fiber_t *fiber_from, fiber_t *fiber_to) {
+//    // do nothing
+//}
+//
+//void test_fiber_context_swap_update_user_data_and_swap_back(fiber_t *fiber_from, fiber_t *fiber_to) {
+//    *(uint64_t*)fiber_from->start_fp_user_data = 1;
+//    *(uint64_t*)fiber_to->start_fp_user_data = 2;
+//
+//    fiber_context_swap(fiber_to, fiber_from);
+//}
+//
+//int test_fiber_stack_protection_find_memory_protection(void *start_address, void* end_address) {
+//    FILE *fp;
+//    int prot_return = -1;
+//    char line[1024], start_address_str[17] = { 0 }, end_address_str[17] = { 0 };
+//
+//    sprintf(start_address_str, "%lx", (uintptr_t)start_address);
+//    sprintf(end_address_str, "%lx", (uintptr_t)end_address);
+//
+//    fp = fopen("/proc/self/maps", "r");
+//    if (fp == NULL) {
+//        fprintf(stderr, "Failed to open /proc/self/maps\n");
+//        return 01;
+//    }
+//
+//    while (fgets(line, sizeof(line), fp) != NULL) {
+//        int cmp1 = strncmp(line, start_address_str, strlen(start_address_str));
+//        int cmp2 = strncmp(line + strlen(start_address_str) + 1, end_address_str, strlen(end_address_str));
+//
+//        if (cmp1 != 0 || cmp2 != 0) {
+//            continue;
+//        }
+//
+//        size_t prot_offset = strlen(start_address_str) + 1 + strlen(end_address_str) + 1;
+//        prot_return = 0;
+//        if (line[prot_offset + 0] == 'r') {
+//            prot_return |= PROT_READ;
+//        }
+//        if (line[prot_offset + 1] == 'w') {
+//            prot_return |= PROT_WRITE;
+//        }
+//        if (line[prot_offset + 2] == 'x') {
+//            prot_return |= PROT_EXEC;
+//        }
+//    }
+//
+//    fclose(fp);
+//
+//    return prot_return;
+//}
+//
+//TEST_CASE("fiber.c", "[fiber]") {
+//    size_t page_size = getpagesize();
+//    size_t stack_size = page_size * 8;
+//
+//    SECTION("fiber_stack_protection") {
+//        SECTION("test enabling the memory protection") {
+//            int protection_flags = -1;
+//            fiber_t fiber = { 0 };
+//            fiber.stack_base = aligned_alloc(page_size, page_size);
+//
+//            // Enable stack fiber protection
+//            fiber_stack_protection(&fiber, true);
+//
+//            // Retrieve the protection flags of the memory page
+//            protection_flags = test_fiber_stack_protection_find_memory_protection(
+//                    fiber.stack_base, (char*)fiber.stack_base + page_size);
+//
+//            REQUIRE(protection_flags == PROT_NONE);
+//
+//            mprotect(fiber.stack_base, page_size, PROT_READ | PROT_WRITE);
+//            free(fiber.stack_base);
+//        }
+//
+//        SECTION("test disabling the memory protection") {
+//            int protection_flags = -1;
+//            fiber_t fiber = { 0 };
+//            fiber.stack_base = aligned_alloc(page_size, page_size);
+//
+//            // Enable and disable the stack protection
+//            fiber_stack_protection(&fiber, true);
+//            fiber_stack_protection(&fiber, false);
+//
+//            // Check if the page is listed in /proc/self/maps
+//            protection_flags = test_fiber_stack_protection_find_memory_protection(
+//                    fiber.stack_base, (char*)fiber.stack_base + page_size);
+//
+//            // The protection flags for the allocated should be entirely missing as fiber_stack_protection resets them
+//            // to PROT_READ | PROT_WRITE that are the default ones.
+//            // This behaviour may change in the future as it's depends on the OS.
+//            REQUIRE(protection_flags == -1);
+//
+//            free(fiber.stack_base);
+//        }
+//    }
+//
+//    SECTION("fiber_new") {
+//        SECTION("allocate a new fiber") {
+//            int user_data = 0;
+//
+//            fiber_t *fiber = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    stack_size,
+//                    test_fiber_new_empty,
+//                    &user_data);
+//
+//            // Calculate the end of the stack to be 16 bytes aligned and with 128 bytes free for the red zone
+//            uintptr_t stack_pointer = (uintptr_t)fiber->stack_base + stack_size;
+//            stack_pointer &= -16L;
+//
+//            // Add room for the first push/pop
+//            stack_pointer -= sizeof(void*) * 1;
+//#if defined(__aarch64__)
+//            stack_pointer -= sizeof(void*) * 1;
+//#endif
+//
+//            REQUIRE(fiber);
+//            REQUIRE(fiber->stack_size == stack_size);
+//            REQUIRE(fiber->start_fp == test_fiber_new_empty);
+//            REQUIRE(fiber->start_fp_user_data == &user_data);
+//            REQUIRE((uintptr_t)fiber->stack_pointer == stack_pointer);
+//
+//            // The fiber memory is protected, the memory protection has to be disabled before freeing the memory
+//            mprotect(fiber->stack_base, page_size, PROT_READ | PROT_WRITE);
+//            xalloc_free(fiber->stack_base);
+//            xalloc_free(fiber);
+//        }
+//
+//        SECTION("fail to allocate a new fiber without an entrypoint") {
+//            fiber_t *fiber = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    stack_size,
+//                    NULL,
+//                    NULL);
+//            REQUIRE(fiber == NULL);
+//        }
+//
+//        SECTION("fail to allocate a new fiber without stack") {
+//            fiber_t *fiber = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    0,
+//                    test_fiber_new_empty,
+//                    NULL);
+//            REQUIRE(fiber == NULL);
+//        }
+//    }
+//
+//    SECTION("fiber_free") {
+//        // There is no REQUIRE for this test, fiber_free is run to ensure it's not triggering a failure (if mprotect
+//        // fails the system will throw an error for trying to access a memory protected area)
+//        SECTION("allocate a new fiber") {
+//            fiber_t *fiber = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    stack_size,
+//                    test_fiber_new_empty,
+//                    NULL);
+//            fiber_free(fiber);
+//        }
+//    }
+//
+//    SECTION("fiber_context_get") {
+//        SECTION("get fiber context from executing function") {
+//            fiber_t *fiber = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    stack_size,
+//                    test_fiber_new_empty,
+//                    NULL);
+//
+//            void* test_fiber_context_get_sp_first_var = fiber_context_get_test(fiber);
+//
+//#if DEBUG == 1
+//            // The code below calculates the position of the address saved in the stack pointer register specific of the
+//            // architecture when the context was read.
+//            // The magic value used is dependent on the ABI and the compiler, the ones defined in the code below are
+//            // GCC specific and are untested with LLVM.
+//
+//#if defined(__x86_64__)
+//            REQUIRE((char*)test_fiber_context_get_sp_first_var - 0x1C == fiber->context.rsp);
+//#elif defined(__aarch64__)
+//            REQUIRE((char*)test_fiber_context_get_sp_first_var - 0x2C == fiber->context.sp);
+//#else
+//#error "unsupported platform"
+//#endif
+//#endif
+//
+//            fiber_free(fiber);
+//        }
+//    }
+//
+//    SECTION("fiber_context_swap") {
+//        SECTION("test fiber context swap") {
+//            uint64_t user_data_current = 0;
+//            uint64_t user_data_to = 0;
+//            fiber_t *fiber_current = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    stack_size,
+//                    test_fiber_new_empty,
+//                    &user_data_current);
+//            fiber_t *fiber_to = fiber_new(
+//                    test_fiber_name,
+//                    test_fiber_name_len,
+//                    stack_size,
+//                    test_fiber_context_swap_update_user_data_and_swap_back,
+//                    &user_data_to);
+//
+//            // Swap from the current context to the newly allocated one, the function associated with the fiber
+//            // test_fiber_context_swap_update_user_data_and_swap_back, will take care of switching back after having
+//            // updated the user data for both the fibers to be able to test the proper switching
+//            fiber_context_swap(fiber_current, fiber_to);
+//
+//            REQUIRE(*(uint64_t*)fiber_current->start_fp_user_data == 1);
+//            REQUIRE(*(uint64_t*)fiber_to->start_fp_user_data == 2);
+//
+//            fiber_free(fiber_current);
+//            fiber_free(fiber_to);
+//        }
+//    }
+//
+//    SECTION("test stack protection") {
+//        fiber_t *fiber = fiber_new(test_fiber_name, test_fiber_name_len, stack_size, test_fiber_new_empty, NULL);
+//
+//        SECTION("alter non protected memory") {
+//            *(uint64_t*)fiber->stack_pointer = 0;
+//            *(uint64_t*)((char*)fiber->stack_base + page_size) = 0;
+//        }
+//
+//        // NOTE: Will trigger a sigsegv as expected
+//        SECTION("alter protected memory") {
+//            bool fatal_catched = false;
+//
+//            if (sigsetjmp(test_fiber_jump_fp, 1) == 0) {
+//                test_fiber_memory_stack_protection_setup_sigsegv_signal_handler();
+//                *(uint64_t*)fiber->stack_base = 0;
+//            } else {
+//                fatal_catched = true;
+//            }
+//
+//            // The fatal_catched variable has to be set to true as sigsetjmp on the second execution will return a value
+//            // different from zero.
+//            // A sigsegv raised by the kernel because of the memory protection means that the stack overflow protection
+//            // is working as intended
+//            REQUIRE(fatal_catched);
+//        }
+//
+//        fiber_free(fiber);
+//    }
+//}
 
 #include <catch2/catch.hpp>
 #include <unistd.h>

--- a/tests/unit_tests/test-transaction.cpp
+++ b/tests/unit_tests/test-transaction.cpp
@@ -18,11 +18,11 @@
 #include "thread.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
-#include "memory_allocator/ffma.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
 #include "clock.h"
 #include "config.h"
+#include "xalloc.h"
 
 #include "spinlock.h"
 #include "transaction.h"
@@ -44,7 +44,7 @@ TEST_CASE("transaction.c", "[transaction]") {
         transaction.locks.count = 0;
         transaction.locks.size = 8;
 
-        transaction_spinlock_lock_volatile_t** initial_list = (transaction_spinlock_lock_volatile_t**)ffma_mem_alloc(
+        transaction_spinlock_lock_volatile_t** initial_list = (transaction_spinlock_lock_volatile_t**)xalloc_alloc(
                 sizeof(void*) * transaction.locks.size);
         transaction.locks.list = initial_list;
 
@@ -67,7 +67,7 @@ TEST_CASE("transaction.c", "[transaction]") {
             REQUIRE(transaction.locks.list != interim_list);
         }
 
-        ffma_mem_free(transaction.locks.list);
+        xalloc_free(transaction.locks.list);
     }
 
     SECTION("transaction_needs_expand_locks_list") {
@@ -92,7 +92,7 @@ TEST_CASE("transaction.c", "[transaction]") {
         transaction_t transaction = { };
         transaction.locks.count = 0;
         transaction.locks.size = 8;
-        transaction.locks.list = (transaction_spinlock_lock_volatile_t**)ffma_mem_alloc(
+        transaction.locks.list = (transaction_spinlock_lock_volatile_t**)xalloc_alloc(
                 sizeof(void*) * transaction.locks.size);
 
         SECTION("Add one lock") {
@@ -129,7 +129,7 @@ TEST_CASE("transaction.c", "[transaction]") {
             REQUIRE(transaction.locks.list[ARRAY_SIZE(lock) - 1] == &lock[ARRAY_SIZE(lock) - 1]);
         }
 
-        ffma_mem_free(transaction.locks.list);
+        xalloc_free(transaction.locks.list);
     }
 
     SECTION("transaction_acquire") {
@@ -147,7 +147,7 @@ TEST_CASE("transaction.c", "[transaction]") {
             REQUIRE(transaction.locks.size == 8);
             REQUIRE(transaction.locks.list != nullptr);
 
-            ffma_mem_free(transaction.locks.list);
+            xalloc_free(transaction.locks.list);
         }
 
         SECTION("Acquire two") {
@@ -162,8 +162,8 @@ TEST_CASE("transaction.c", "[transaction]") {
             REQUIRE(transaction2.transaction_id.worker_index == UINT16_MAX);
             REQUIRE(transaction2.transaction_id.transaction_index == current_transaction_index + 2);
 
-            ffma_mem_free(transaction1.locks.list);
-            ffma_mem_free(transaction2.locks.list);
+            xalloc_free(transaction1.locks.list);
+            xalloc_free(transaction2.locks.list);
         }
     }
 

--- a/tools/redis-commands-scaffolding-generator/generate-commands-scaffolding.py
+++ b/tools/redis-commands-scaffolding-generator/generate-commands-scaffolding.py
@@ -483,7 +483,6 @@ class Program:
             "#include \"data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h\"",
             "#include \"data_structures/double_linked_list/double_linked_list.h\"",
             "#include \"data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h\"",
-            "#include \"memory_allocator/ffma.h\"",
             "#include \"data_structures/hashtable/spsc/hashtable_spsc.h\"",
             "#include \"data_structures/queue_mpmc/queue_mpmc.h\"",
             "#include \"data_structures/hashtable/mcmp/hashtable.h\"",
@@ -655,7 +654,7 @@ class Program:
                     lines.append("    for(int i = 0; i < context->{argument_name}.count; i++) {{")
                     lines.append("        {free_memory_func}(db, &context->{argument_name}.list[i]);")
                     lines.append("    }}")
-                    lines.append("    ffma_mem_free(context->{argument_name}.list);")
+                    lines.append("    xalloc_free(context->{argument_name}.list);")
                     lines.append("}}")
                 else:
                     lines.append("{free_memory_func}(db, &context->{argument_name}.value);")
@@ -670,7 +669,7 @@ class Program:
                     lines.append("            {free_memory_func}(db, &context->{argument_name}.list[i].chunk_sequence);")
                     lines.append("        }}")
                     lines.append("    }}")
-                    lines.append("    ffma_mem_free(context->{argument_name}.list);")
+                    lines.append("    xalloc_free(context->{argument_name}.list);")
                     lines.append("}}")
                 else:
                     lines.append("if (context->{argument_name}.value.chunk_sequence.sequence) {{")
@@ -694,7 +693,7 @@ class Program:
                     lines.append("            {free_memory_func}(context->{argument_name}.list[i].{field_name});")
                     lines.append("        }}")
                     lines.append("    }}")
-                    lines.append("    ffma_mem_free(context->{argument_name}.list);")
+                    lines.append("    xalloc_free(context->{argument_name}.list);")
                     lines.append("}}")
                 else:
                     lines.append("if (context->{argument_name}.value.{field_name}) {{")


### PR DESCRIPTION
This PR disables FFMA and switch the code to use only xalloc (mimalloc) in preparation to implement an algorithm to defrag the memory.

Implementing the memory defragmentation for both the memory allocator would be extremely time consuming and although FFMA performs better than mimalloc in certain cases it's not a general memory allocator and cachegrand can't rely only on it.

Down the line it will be re-enabled and a memory defrag algorithm will be implemented for it as well.