### PR TITLE
Switch queue mpmc to mmap

### DIFF
--- a/src/data_structures/queue_mpmc/queue_mpmc.c
+++ b/src/data_structures/queue_mpmc/queue_mpmc.c
@@ -11,15 +11,44 @@
 #include <stdatomic.h>
 #include <assert.h>
 
+#include "misc.h"
 #include "exttypes.h"
 #include "memory_fences.h"
 #include "xalloc.h"
 
 #include "queue_mpmc.h"
 
+//#define mmap(size) calloc(1, size)
+//#define munmap(addr, size) free(addr)
+
+/**
+ * The queue_mpmc is basilar data structure, to avoid relying on the system (or mimalloc) memory allocator (as it's
+ * also used by FFMA) it internally uses mmap to allocate memory for the queue nodes.
+ *
+ * Each page allocated has a prev and next pointer to link the pages together, all the memory afterwards is used for the
+ * queue nodes.
+ */
+
+static int16_t queue_mpmc_os_page_size = 0;
+
+FUNCTION_CTOR(queue_mpmc_init_ctor, {
+    // Get the OS page size
+    queue_mpmc_os_page_size = xalloc_get_page_size();
+})
+
 queue_mpmc_t *queue_mpmc_init() {
-    // This queue is used by the fast fixed memory allocator, therefore the memory can't be allocated with it
-    return xalloc_alloc_zero(sizeof(queue_mpmc_t));
+    // Allocate the first page for the queue nodes and force the initialization setting the first byte to 0
+    queue_mpmc_page_volatile_t *nodes_page = xalloc_mmap_alloc(queue_mpmc_os_page_size);
+    nodes_page->prev = 0;
+
+    // Initialize the base structure and return set the nodes page pointer
+    queue_mpmc_t *queue_mpmc = xalloc_alloc_zero(sizeof(queue_mpmc_t));
+    queue_mpmc->head.data.nodes_page = nodes_page;
+    queue_mpmc->head.data.node_index = -1;
+    queue_mpmc->max_nodes_per_page =
+            (queue_mpmc_os_page_size - sizeof(nodes_page->prev)) / sizeof(nodes_page->nodes[0]);
+
+    return queue_mpmc;
 }
 
 void queue_mpmc_free_nodes(queue_mpmc_t *queue_mpmc) {
@@ -28,11 +57,11 @@ void queue_mpmc_free_nodes(queue_mpmc_t *queue_mpmc) {
     // cache is up-to-date with the changes carried out by the atomic ops if any.
     MEMORY_FENCE_LOAD();
 
-    queue_mpmc_node_t *node = (queue_mpmc_node_t*)queue_mpmc->head.data.node;
-    while(node != NULL) {
-        queue_mpmc_node_t *node_next = node->next;
-        xalloc_free(node);
-        node = node_next;
+    queue_mpmc_page_volatile_t *nodes_page = queue_mpmc->head.data.nodes_page;
+    while(nodes_page != NULL) {
+        queue_mpmc_page_volatile_t *current_page = nodes_page;
+        nodes_page = nodes_page->prev;
+        xalloc_mmap_free((void*)current_page, queue_mpmc_os_page_size);
     }
 }
 
@@ -44,34 +73,65 @@ void queue_mpmc_free(queue_mpmc_t *queue_mpmc) {
 bool queue_mpmc_push(
         queue_mpmc_t *queue_mpmc,
         void *data) {
+    queue_mpmc_versioned_head_t head_expected, head_new;
+    queue_mpmc_page_volatile_t *nodes_page_new = NULL, *nodes_page_to_write;
+    int16_t node_index_to_write;
+
+    assert(queue_mpmc != NULL);
     assert(data != NULL);
 
-    queue_mpmc_node_t *node = xalloc_alloc(sizeof(queue_mpmc_node_t));
-    if (!node) {
-        return false;
-    }
-    node->data = data;
-
-    queue_mpmc_versioned_head_t head_expected = {
-            ._packed = queue_mpmc->head._packed
-    };
-    queue_mpmc_versioned_head_t head_new = {
-            .data = {
-                    .node = node,
-            },
-    };
+    head_expected._packed = queue_mpmc->head._packed;
 
     do {
+        head_new._packed = head_expected._packed;
+
+        // Checks if the current page is full
+        if (unlikely(head_new.data.node_index == queue_mpmc->max_nodes_per_page - 1)) {
+            // Allocate a new page for the queue nodes and force the initialization setting the first byte to 0
+            if (likely(nodes_page_new == NULL)) {
+                nodes_page_new = xalloc_mmap_alloc(queue_mpmc_os_page_size);
+            }
+
+            // Set the previous page pointer
+            nodes_page_new->prev = head_expected.data.nodes_page;
+
+            // Update the head to point to the new page
+            head_new.data.nodes_page = nodes_page_new;
+            head_new.data.node_index = -1;
+        }
+
+        head_new.data.node_index++;
         head_new.data.length = head_expected.data.length + 1;
         head_new.data.version = head_expected.data.version + 1;
-        node->next = (queue_mpmc_node_t*)head_expected.data.node;
-    } while (!__atomic_compare_exchange_n(
+
+        node_index_to_write = head_new.data.node_index;
+        nodes_page_to_write = head_new.data.nodes_page;
+    } while (unlikely(!__atomic_compare_exchange_n(
             &queue_mpmc->head._packed,
             &head_expected._packed,
             head_new._packed,
             true,
             __ATOMIC_ACQ_REL,
-            __ATOMIC_ACQUIRE));
+            __ATOMIC_ACQUIRE)));
+
+    // Write the data to the slot in the page only if the slot it's set to 0, otherwise the slot is being used by
+    // another thread and it has to wait until the slot is free.
+    uintptr_t data_expected = 0;
+    uintptr_t data_new = (uintptr_t)data;
+    while(unlikely(!__atomic_compare_exchange_n(
+            &nodes_page_to_write->nodes[node_index_to_write],
+            &data_expected,
+            data_new,
+            false,
+            __ATOMIC_ACQ_REL,
+            __ATOMIC_ACQUIRE))) {
+        data_expected = 0;
+    }
+
+    // If there is a newly allocated page but at the end wasn't used, free it
+    if (unlikely(nodes_page_new != NULL && head_new.data.nodes_page != nodes_page_new)) {
+//        xalloc_mmap_free((void*)nodes_page_new, queue_mpmc_os_page_size);
+    }
 
     return true;
 }
@@ -79,57 +139,85 @@ bool queue_mpmc_push(
 void *queue_mpmc_pop(
         queue_mpmc_t *queue_mpmc) {
     queue_mpmc_versioned_head_t head_expected, head_new;
+    queue_mpmc_page_volatile_t *nodes_page_to_read = NULL, *nodes_page_to_free = NULL;
+    uint16_t node_index_to_read;
     void *data = NULL;
+
+    assert(queue_mpmc != NULL);
 
     head_expected._packed = queue_mpmc->head._packed;
 
-    while (head_expected.data.node != NULL) {
-        head_new.data.node = head_expected.data.node->next;
+    // The atomic operation will use memory fences so it's not necessary one ad-hoc just for head_expected.data.length
+    // once the code is in the loop, only at the beginning
+    MEMORY_FENCE_LOAD();
+    while (likely(head_expected.data.length > 0)) {
+        head_new._packed = queue_mpmc->head._packed;
+        node_index_to_read = head_new.data.node_index;
+        nodes_page_to_read = head_new.data.nodes_page;
+
+        nodes_page_to_free = NULL;
+        head_new.data.node_index--;
+
+        // Checks if the current page is full
+        if (unlikely(head_new.data.node_index == -1)) {
+            if (likely(head_new.data.nodes_page->prev)) {
+                // The current page has to be freed up after the data are read
+                nodes_page_to_free = head_new.data.nodes_page;
+
+                // The nodes page has to be updated to point to the previous one and node_index has to point at the end
+                // of the page.
+                head_new.data.nodes_page = head_new.data.nodes_page->prev;
+                head_new.data.node_index = queue_mpmc->max_nodes_per_page - 1;
+            }
+        }
+
         head_new.data.version = head_expected.data.version + 1;
         head_new.data.length = head_expected.data.length - 1;
 
-        if (__atomic_compare_exchange_n(
+        if (likely(__atomic_compare_exchange_n(
                 &queue_mpmc->head._packed,
                 &head_expected._packed,
                 head_new._packed,
                 true,
                 __ATOMIC_ACQ_REL,
-                __ATOMIC_ACQUIRE)) {
+                __ATOMIC_ACQUIRE))) {
             break;
         }
+
+        // If the compare exchange fails, the information needed by the code outside the loop is not valid anymore and
+        // has to be cleared up, potentially there will be nothing else to read and the loop will be interrupted.
+        nodes_page_to_read = NULL;
+        nodes_page_to_free = NULL;
     }
 
     assert(head_new.data.length >= 0);
 
-    if (head_expected.data.node != NULL) {
-        data = head_expected.data.node->data;
-        xalloc_free((queue_mpmc_node_t *) head_expected.data.node);
+    if (likely(nodes_page_to_read != NULL)) {
+        // Wait for a value in the slop of the page (non-zero) and then use a CAS operation to read it and at the same
+        // time set it to zero.
+        uintptr_t data_expected;
+        uintptr_t data_new = 0;
+        do {
+            // Wait for a value in the slot of the page (non-zero)
+            do {
+                MEMORY_FENCE_LOAD();
+                data_expected = nodes_page_to_read->nodes[node_index_to_read];
+            } while (likely(data_expected == 0));
+        } while(unlikely(!__atomic_compare_exchange_n(
+                &nodes_page_to_read->nodes[node_index_to_read],
+                &data_expected,
+                data_new,
+                false,
+                __ATOMIC_ACQ_REL,
+                __ATOMIC_ACQUIRE)));
+
+        data = (void*)data_expected;
+    }
+
+    // Free up the page if it empty but ensure that it's not the head
+    if (nodes_page_to_free != NULL && nodes_page_to_free->prev != NULL) {
+//        xalloc_mmap_free((void*)nodes_page_to_free, queue_mpmc_os_page_size);
     }
 
     return data;
-}
-
-uint32_t queue_mpmc_get_length(
-        queue_mpmc_t *queue_mpmc) {
-    MEMORY_FENCE_LOAD();
-    return (uint32_t)queue_mpmc->head.data.length;
-}
-
-queue_mpmc_node_t *queue_mpmc_peek(
-        queue_mpmc_t *queue_mpmc) {
-    MEMORY_FENCE_LOAD();
-
-    queue_mpmc_node_t *node = (queue_mpmc_node_t*)queue_mpmc->head.data.node;
-    if (node) {
-        // This can be potentially destructive and cause a crash, the caller should use it within a critical section
-        // (e.g. via a spinlock) or in a context where there is certainty or no multiple consumers
-        return node->data;
-    } else {
-        return NULL;
-    }
-}
-
-bool queue_mpmc_is_empty(
-        queue_mpmc_t *queue_mpmc) {
-    return queue_mpmc_get_length(queue_mpmc) == 0;
 }

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -5,8 +5,10 @@
 // so we need to include them here to avoid having to include them in every file that includes this header.
 #ifdef __cplusplus
 #include <cstring>
+#include <cassert>
 #else
 #include <string.h>
+#include <assert.h>
 #endif
 
 #ifdef __cplusplus

--- a/tests/unit_tests/test-ffma-page-cache.cpp
+++ b/tests/unit_tests/test-ffma-page-cache.cpp
@@ -67,8 +67,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
 
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 0);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                nullptr);
 
             xalloc_mmap_free(addr1, HUGEPAGE_SIZE_2MB);
         }
@@ -79,8 +77,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
 
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 0);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                nullptr);
 
             xalloc_mmap_free(addr1, HUGEPAGE_SIZE_2MB);
             xalloc_mmap_free(addr2, HUGEPAGE_SIZE_2MB);
@@ -93,8 +89,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
 
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 0);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                nullptr);
 
             xalloc_mmap_free(addr1, HUGEPAGE_SIZE_2MB);
             xalloc_mmap_free(addr2, HUGEPAGE_SIZE_2MB);
@@ -120,8 +114,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
 
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 1);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                addr);
         }
 
         SECTION("pop and push two pages from cache") {
@@ -132,8 +124,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
 
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 2);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                addr2);
         }
 
         SECTION("pop and push three pages from cache") {
@@ -146,8 +136,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
 
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 3);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                addr3);
         }
 
         SECTION("pop three and push two pages from/to cache") {
@@ -160,8 +148,6 @@ TEST_CASE("ffma_page_cache.c", "[ffma][ffma_page_cache]") {
             REQUIRE(page_cache->numa_nodes[numa_node_index].free_queue != nullptr);
             REQUIRE(queue_mpmc_get_length(page_cache->numa_nodes[numa_node_index].free_queue) ==
                 2);
-            REQUIRE(queue_mpmc_peek(page_cache->numa_nodes[numa_node_index].free_queue) ==
-                addr2);
 
             xalloc_mmap_free(addr3, HUGEPAGE_SIZE_2MB);
         }


### PR DESCRIPTION
This PR switches the queue_mpmc to use mmap instead of malloc (which internally relies on mimalloc) to help to reduce the impact on the memory fragmentation.

There are no direct performance changes between the previous implementation and the new one.

The PR contains updated tests as well.