### PR TITLE
Impl reduce tests verbosity

### DIFF
--- a/tests/unit_tests/test-signals-support.cpp
+++ b/tests/unit_tests/test-signals-support.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <csignal>
 #include <csetjmp>
+#include <unistd.h>
 #include <fcntl.h>
 
 #include "signals_support.h"

--- a/tests/unit_tests/test-signals-support.cpp
+++ b/tests/unit_tests/test-signals-support.cpp
@@ -24,7 +24,7 @@ void test_signals_support_setup_sigabrt_signal_handler() {
     signals_support_register_signal_handler(
             SIGABRT,
             test_signals_support_signal_sigabrt_handler_longjmp,
-            NULL);
+            nullptr);
 }
 
 int test_signals_support_signal_handler_signal_number_received = -1;
@@ -77,7 +77,7 @@ TEST_CASE("signals_support.c", "[signals_support]") {
 
             signal_name = signals_support_name(NSIG, buffer, sizeof(buffer));
 
-            REQUIRE(signal_name == NULL);
+            REQUIRE(signal_name == nullptr);
         }
     }
 
@@ -93,7 +93,7 @@ TEST_CASE("signals_support.c", "[signals_support]") {
             REQUIRE(kill(0, SIGCHLD) == 0);
 
             // Restore original signal handler
-            REQUIRE(sigaction(SIGCHLD, &previous_action, NULL) == 0);
+            REQUIRE(sigaction(SIGCHLD, &previous_action, nullptr) == 0);
             REQUIRE(res);
             REQUIRE(test_signals_support_signal_handler_signal_number_received == SIGCHLD);
         }
@@ -109,7 +109,7 @@ TEST_CASE("signals_support.c", "[signals_support]") {
             REQUIRE(kill(0, SIGALRM) == 0);
 
             // Restore original signal handler
-            REQUIRE(sigaction(SIGCHLD, &previous_action, NULL) == 0);
+            REQUIRE(sigaction(SIGCHLD, &previous_action, nullptr) == 0);
             REQUIRE(res);
             REQUIRE(test_signals_support_signal_handler_signal_number_received == SIGALRM);
 
@@ -153,17 +153,17 @@ TEST_CASE("signals_support.c", "[signals_support]") {
         struct sigaction original_action = {0};
 
         // Fetch the original action for the SIGSEGV signal
-        REQUIRE(sigaction(SIGSEGV, NULL, &original_action) == 0);
+        REQUIRE(sigaction(SIGSEGV, nullptr, &original_action) == 0);
 
         // Update the signal handler
         signals_support_register_sigsegv_fatal_handler();
 
         // Fetch the action
-        REQUIRE(sigaction(SIGSEGV, NULL, &action) == 0);
+        REQUIRE(sigaction(SIGSEGV, nullptr, &action) == 0);
         REQUIRE((action.sa_handler == signals_support_handler_sigsegv_fatal));
 
         // Restore the original action
-        REQUIRE(sigaction(SIGSEGV, &original_action, NULL) == 0);
+        REQUIRE(sigaction(SIGSEGV, &original_action, nullptr) == 0);
     }
 
     close(internal_stderr);

--- a/tests/unit_tests/test-xalloc.cpp
+++ b/tests/unit_tests/test-xalloc.cpp
@@ -8,12 +8,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <string.h>
+#include <cstring>
+#include <csetjmp>
+#include <csignal>
 #include <unistd.h>
-#include <signal.h>
-#include <setjmp.h>
-#include <signal.h>
 #include <sys/mman.h>
+#include <fcntl.h>
 
 #include "hugepages.h"
 #include "signals_support.h"
@@ -28,15 +28,18 @@ void test_xalloc_setup_sigabrt_signal_handler() {
     signals_support_register_signal_handler(
             SIGABRT,
             test_xalloc_signal_sigabrt_handler_longjmp,
-            NULL);
+            nullptr);
 }
 
 TEST_CASE("xalloc.c", "[xalloc]") {
+    int internal_stderr = dup(STDERR_FILENO);
+    int internal_nullfd = open("/dev/null", O_RDWR);
+
     SECTION("xalloc_alloc") {
         SECTION("valid size") {
             char *data = (char*)xalloc_alloc(16);
 
-            REQUIRE(data != NULL);
+            REQUIRE(data != nullptr);
 
             xalloc_free(data);
         }
@@ -44,12 +47,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             char *data;
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (char*)xalloc_alloc(-1);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -63,7 +70,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
 
             data = (char*)xalloc_realloc(data, 32);
 
-            REQUIRE(data != NULL);
+            REQUIRE(data != nullptr);
             REQUIRE(strncmp(data, short_test_string, strlen(short_test_string)) == 0);
 
             xalloc_free(data);
@@ -72,12 +79,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             char *data = (char*)xalloc_alloc(16);
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (char*)xalloc_realloc(data, -1);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
 
@@ -88,7 +99,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
     SECTION("xalloc_free") {
         char *data = (char*)xalloc_alloc(16);
 
-        REQUIRE(data != NULL);
+        REQUIRE(data != nullptr);
 
         xalloc_free(data);
     }
@@ -97,7 +108,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
         SECTION("valid size") {
             char *data = (char*)xalloc_alloc_zero(16);
 
-            REQUIRE(data != NULL);
+            REQUIRE(data != nullptr);
             for(uint8_t i = 0; i < 16; i++) {
                 REQUIRE(data[i] == 0);
             }
@@ -105,8 +116,10 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             xalloc_free(data);
         }
         SECTION("invalid size") {
-            char *data = NULL;
+            char *data = nullptr;
             bool fatal_caught = false;
+
+            dup2(internal_nullfd, STDERR_FILENO);
 
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
@@ -114,6 +127,8 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -133,12 +148,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             uintptr_t data = 0;
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (uintptr_t)xalloc_alloc_aligned(64, -1);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -147,12 +166,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             uintptr_t data = 0;
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (uintptr_t)xalloc_alloc_aligned(-1, 16);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -175,12 +198,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             uintptr_t data = 0;
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (uintptr_t)xalloc_alloc_aligned_zero(64, -1);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -189,12 +216,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             uintptr_t data = 0;
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (uintptr_t)xalloc_alloc_aligned_zero(-1, 16);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -245,12 +276,16 @@ TEST_CASE("xalloc.c", "[xalloc]") {
             uintptr_t data = 0;
             bool fatal_caught = false;
 
+            dup2(internal_nullfd, STDERR_FILENO);
+
             if (sigsetjmp(jump_fp_xalloc, 1) == 0) {
                 test_xalloc_setup_sigabrt_signal_handler();
                 data = (uintptr_t)xalloc_mmap_alloc(-1);
             } else {
                 fatal_caught = true;
             }
+
+            dup2(internal_stderr, STDERR_FILENO);
 
             REQUIRE(fatal_caught);
         }
@@ -283,7 +318,10 @@ TEST_CASE("xalloc.c", "[xalloc]") {
         }
 
         SECTION("invalid size") {
-            REQUIRE(xalloc_hugepage_alloc(0) == NULL);
+            REQUIRE(xalloc_hugepage_alloc(0) == nullptr);
         }
     }
+
+    close(internal_stderr);
+    close(internal_nullfd);
 }

--- a/tests/unit_tests/test-xalloc.cpp
+++ b/tests/unit_tests/test-xalloc.cpp
@@ -136,7 +136,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
 
     SECTION("xalloc_alloc_aligned") {
         SECTION("valid size") {
-            uintptr_t data = (uintptr_t)xalloc_alloc_aligned(64, 16);
+            auto data = (uintptr_t)xalloc_alloc_aligned(64, 16);
 
             REQUIRE(data != 0);
             REQUIRE(data % 64 == 0);
@@ -183,7 +183,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
 
     SECTION("xalloc_alloc_aligned_zero") {
         SECTION("valid size") {
-            uintptr_t data = (uintptr_t)xalloc_alloc_aligned_zero(64, 16);
+            auto data = (uintptr_t)xalloc_alloc_aligned_zero(64, 16);
 
             REQUIRE(data != 0);
             REQUIRE(data % 64 == 0);
@@ -262,7 +262,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
         SECTION("valid size") {
             size_t size = 64;
             long alignment = sysconf(_SC_PAGESIZE);
-            uintptr_t data = (uintptr_t)xalloc_mmap_alloc(size);
+            auto data = (uintptr_t)xalloc_mmap_alloc(size);
 
             REQUIRE(data != 0);
             REQUIRE(data % alignment == 0);
@@ -294,7 +294,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
     SECTION("xalloc_mmap_free") {
         size_t size = 64;
         long alignment = sysconf(_SC_PAGESIZE);
-        uintptr_t data = (uintptr_t)xalloc_mmap_alloc(size);
+        auto data = (uintptr_t)xalloc_mmap_alloc(size);
 
         REQUIRE(data != 0);
         REQUIRE(data % alignment == 0);
@@ -306,7 +306,7 @@ TEST_CASE("xalloc.c", "[xalloc]") {
         SECTION("valid size") {
             if (hugepages_2mb_is_available(1)) {
                 size_t hugepage_2mb_size = 2 * 1024 * 1024;
-                uintptr_t data = (uintptr_t) xalloc_hugepage_alloc(hugepage_2mb_size);
+                auto data = (uintptr_t)xalloc_hugepage_alloc(hugepage_2mb_size);
 
                 REQUIRE(data != 0);
                 REQUIRE((data % (hugepage_2mb_size)) == 0);


### PR DESCRIPTION
This PR reduces the verbosity of the tests redirecting stderr to null for specific tests known to produce a lot of expected output on stderr.

WIth this change, the tests output is much more readable allowing to identify actual sigsegv or sigabort errors triggered by bugs in the code or in the tests.