### PR TITLE
Bug fix pexpiretime test flakyness

### DIFF
--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
@@ -74,7 +74,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME"
 
         unixtime_response = strtoll(buffer + 1, nullptr, 10);
 
-        if (!(unixtime_response >= unixtime_ms_plus_5s - 10 && unixtime_response <= unixtime_ms_plus_5s + 10)) {
+        REQUIRE((unixtime_response >= unixtime_ms_plus_5s - 25 && unixtime_response <= unixtime_ms_plus_5s + 25));
             fprintf(stdout, "unixtime_response: %ld\n", unixtime_response);
             fprintf(stdout, "unixtime_ms_plus_5s: %ld\n", unixtime_ms_plus_5s);
             fprintf(stdout, "difference: %ld\n", abs(unixtime_response - unixtime_ms_plus_5s));
@@ -83,6 +83,5 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME"
             fflush(stdout);
         }
 
-        REQUIRE((unixtime_response >= unixtime_ms_plus_5s - 10 && unixtime_response <= unixtime_ms_plus_5s + 10));
     }
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
@@ -75,13 +75,5 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PEXPIRETIME"
         unixtime_response = strtoll(buffer + 1, nullptr, 10);
 
         REQUIRE((unixtime_response >= unixtime_ms_plus_5s - 25 && unixtime_response <= unixtime_ms_plus_5s + 25));
-            fprintf(stdout, "unixtime_response: %ld\n", unixtime_response);
-            fprintf(stdout, "unixtime_ms_plus_5s: %ld\n", unixtime_ms_plus_5s);
-            fprintf(stdout, "difference: %ld\n", abs(unixtime_response - unixtime_ms_plus_5s));
-            fprintf(stdout, "unixtime_response >= unixtime_ms_plus_5s - 10: %d\n", unixtime_response >= unixtime_ms_plus_5s - 10);
-            fprintf(stdout, "unixtime_response <= unixtime_ms_plus_5s - 10: %d\n", unixtime_response <= unixtime_ms_plus_5s + 10);
-            fflush(stdout);
-        }
-
     }
 }


### PR DESCRIPTION
This PR fixes the flakyness of PEXPIRETIME, this execution might take a few extra milliseconds to run, depending on how busy the build agent is, and this will lead to longer execution times so the allowed fork of valid ranges is increased by +/- 25 milliseconds.

The PR also drops the code used for debugging this transient issue.