### PR TITLE
Optimized Hashtable MCMP Iteration with Max Distance Parameter and Empty Chunk Skipping

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -44,6 +44,13 @@ void *hashtable_mcmp_op_data_iter(
             chunk_index++) {
         half_hashes_chunk = &hashtable_data->half_hashes_chunk[chunk_index];
 
+        // If a chunk has no changes it can be skipped
+        if (half_hashes_chunk->metadata.changes_counter == 0) {
+            *bucket_index = (chunk_index * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) + HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT - 1;
+            chunk_slot_index = 0;
+            continue;
+        }
+
         for(; chunk_slot_index < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; chunk_slot_index++) {
             MEMORY_FENCE_LOAD();
             *bucket_index = (chunk_index * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) + chunk_slot_index;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
@@ -7,11 +7,17 @@ extern "C" {
 
 void *hashtable_mcmp_op_data_iter(
         hashtable_data_volatile_t *hashtable_data,
-        uint64_t *bucket_index);
+        uint64_t *bucket_index,
+        uint64_t max_distance);
 
 void *hashtable_mcmp_op_iter(
         hashtable_t *hashtable,
         uint64_t *bucket_index);
+
+void *hashtable_mcmp_op_iter_max_distance(
+        hashtable_t *hashtable,
+        uint64_t *bucket_index,
+        uint64_t max_distance);
 
 #ifdef __cplusplus
 }

--- a/tests/unit_tests/data_structures/hashtable/mpmc/fixtures-hashtable-mpmc.h
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/fixtures-hashtable-mpmc.h
@@ -125,6 +125,7 @@ hashtable_hash_quarter_t test_key_long_1_hash_quarter = test_key_long_1_hash_hal
     hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)]
 
 #define HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value) \
+    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).metadata.changes_counter++; \
     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].quarter_hash = \
         (hash >> 32u) & 0xFFFFu; \
     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].distance = 0; \


### PR DESCRIPTION
This pull request enhances the hashtable_mcmp_op_data_iter function by incorporating a max_distance parameter, which limits the number of inspected buckets for improved optimization.
Additionally, an optimization has been introduced to bypass searching empty chunks when the changes_counter is set to zero, further streamlining the process.