### PR TITLE
Optimized Empty Chunk Checks

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -125,7 +125,7 @@ struct hashtable_half_hashes_chunk {
         uint32_t padding;
         struct {
             uint8_volatile_t overflowed_chunks_counter;
-            uint8_volatile_t changes_counter;
+            uint8_volatile_t slots_occupied;
             uint8_volatile_t is_full;
         };
     } metadata;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
@@ -106,6 +106,7 @@ bool hashtable_mcmp_op_delete(
                 *current_value = key_value->data;
             }
 
+            half_hashes_chunk->metadata.slots_occupied--;
             half_hashes_chunk->metadata.is_full = 0;
             half_hashes_chunk->half_hashes[chunk_slot_index].slot_id = 0;
 
@@ -195,6 +196,7 @@ bool hashtable_mcmp_op_delete_by_index(
             *current_value = key_value->data;
         }
 
+        half_hashes_chunk->metadata.slots_occupied--;
         half_hashes_chunk->metadata.is_full = 0;
         half_hashes_chunk->half_hashes[chunk_slot_index].slot_id = 0;
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -53,7 +53,7 @@ void *hashtable_mcmp_op_data_iter(
         }
 
         // If a chunk has no changes it can be skipped
-        if (half_hashes_chunk->metadata.changes_counter == 0) {
+        if (half_hashes_chunk->metadata.slots_occupied == 0) {
             distance += HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT - chunk_slot_index;
             *bucket_index = (chunk_index * HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) + HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT - 1;
             chunk_slot_index = 0;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
@@ -167,9 +167,11 @@ void hashtable_mcmp_op_rmw_commit_delete(
 void hashtable_mcmp_op_rmw_abort(
         hashtable_mcmp_op_rmw_status_t *rmw_status) {
     if (rmw_status->created_new) {
+        rmw_status->half_hashes_chunk->metadata.slots_occupied--;
 
         // Catch overflows anyway
         assert(rmw_status->half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+        rmw_status->half_hashes_chunk->metadata.is_full = 0;
         rmw_status->half_hashes_chunk->half_hashes[rmw_status->chunk_slot_index].slot_id = 0;
     }
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
@@ -130,12 +130,12 @@ void hashtable_mcmp_op_rmw_commit_update(
     // Validate if the passed key can be freed because unused or because inlined
     if (!rmw_status->created_new || key_inlined) {
         xalloc_free(rmw_status->key);
-
     }
 }
 
 void hashtable_mcmp_op_rmw_commit_delete(
         hashtable_mcmp_op_rmw_status_t *rmw_status) {
+    rmw_status->half_hashes_chunk->metadata.slots_occupied--;
     rmw_status->half_hashes_chunk->metadata.is_full = 0;
     rmw_status->half_hashes_chunk->half_hashes[rmw_status->chunk_slot_index].slot_id = 0;
     MEMORY_FENCE_STORE();

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
@@ -136,6 +136,10 @@ void hashtable_mcmp_op_rmw_commit_update(
 void hashtable_mcmp_op_rmw_commit_delete(
         hashtable_mcmp_op_rmw_status_t *rmw_status) {
     rmw_status->half_hashes_chunk->metadata.slots_occupied--;
+
+    // Catch overflows anyway
+    assert(rmw_status->half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+
     rmw_status->half_hashes_chunk->metadata.is_full = 0;
     rmw_status->half_hashes_chunk->half_hashes[rmw_status->chunk_slot_index].slot_id = 0;
     MEMORY_FENCE_STORE();
@@ -163,6 +167,9 @@ void hashtable_mcmp_op_rmw_commit_delete(
 void hashtable_mcmp_op_rmw_abort(
         hashtable_mcmp_op_rmw_status_t *rmw_status) {
     if (rmw_status->created_new) {
+
+        // Catch overflows anyway
+        assert(rmw_status->half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
         rmw_status->half_hashes_chunk->half_hashes[rmw_status->chunk_slot_index].slot_id = 0;
     }
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -72,7 +72,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
     LOG_DI("hashtable_data->buckets_count_real = %lu", hashtable_data->buckets_count_real);
     LOG_DI("half_hashes_chunk->write_lock.lock = %d", half_hashes_chunk->write_lock.transaction_id);
     LOG_DI("half_hashes_chunk->metadata.is_full = %lu", half_hashes_chunk->metadata.is_full);
-    LOG_DI("half_hashes_chunk->metadata.changes_counter = %lu", half_hashes_chunk->metadata.changes_counter);
+    LOG_DI("half_hashes_chunk->metadata.slots_occupied = %lu", half_hashes_chunk->metadata.slots_occupied);
     LOG_DI("half_hashes_chunk->metadata.overflowed_chunks_counter = %lu", overflowed_chunks_counter);
 
     slot_id_wrapper.filled = 1;
@@ -93,6 +93,11 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
         LOG_DI("> chunk_index = %lu", chunk_index);
 
         half_hashes_chunk = &hashtable_data->half_hashes_chunk[chunk_index];
+
+        if (half_hashes_chunk->metadata.slots_occupied == 0) {
+            LOG_DI(">> skipping chunk because it's empty");
+            continue;
+        }
 
         skip_indexes_mask = 0;
 
@@ -266,7 +271,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
 
     LOG_DI("half_hashes_chunk->write_lock.lock = %lu", half_hashes_chunk->write_lock.transaction_id);
     LOG_DI("half_hashes_chunk->metadata.is_full = %lu", half_hashes_chunk->metadata.is_full);
-    LOG_DI("half_hashes_chunk->metadata.changes_counter = %lu", half_hashes_chunk->metadata.changes_counter);
+    LOG_DI("half_hashes_chunk->metadata.slots_occupied = %lu", half_hashes_chunk->metadata.slots_occupied);
     LOG_DI("half_hashes_chunk->metadata.overflowed_chunks_counter = %lu", overflowed_chunks_counter);
 
     slot_id_wrapper.filled = 1;
@@ -336,6 +341,11 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                         LOG_DI(">> found chunk with free space");
                         found_chunk_with_freespace = true;
                     }
+                }
+
+                if (half_hashes_chunk->metadata.slots_occupied == 0) {
+                    LOG_DI(">> skipping chunk because it's empty");
+                    continue;
                 }
             }
 

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -410,9 +410,9 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                     LOG_DI(">>> empty slot found, updating the half_hashes in the chunk with the hash");
                 }
 
-                // Update the changes counter to the current chunk
-                half_hashes_chunk->metadata.changes_counter++;
-                LOG_DI(">>> incrementing the changes counter to %d", half_hashes_chunk->metadata.changes_counter);
+                // Update the counter for the occupied slots
+                half_hashes_chunk->metadata.slots_occupied++;
+                LOG_DI(">>> incrementing the slots_occupied to %d", half_hashes_chunk->metadata.slots_occupied);
 
                 *found_half_hashes_chunk = half_hashes_chunk;
                 *found_key_value = key_value;

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -422,6 +422,7 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
 
                 // Update the counter for the occupied slots
                 half_hashes_chunk->metadata.slots_occupied++;
+                assert(half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
                 LOG_DI(">>> incrementing the slots_occupied to %d", half_hashes_chunk->metadata.slots_occupied);
 
                 *found_half_hashes_chunk = half_hashes_chunk;

--- a/tests/unit_tests/data_structures/hashtable/mpmc/fixtures-hashtable-mpmc.h
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/fixtures-hashtable-mpmc.h
@@ -125,7 +125,7 @@ hashtable_hash_quarter_t test_key_long_1_hash_quarter = test_key_long_1_hash_hal
     hashtable->ht_current->keys_values[HASHTABLE_TO_BUCKET_INDEX(chunk_index, chunk_slot_index)]
 
 #define HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value) \
-    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).metadata.changes_counter++; \
+    HASHTABLE_HALF_HASHES_CHUNK(chunk_index).metadata.slots_occupied++; \
     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].quarter_hash = \
         (hash >> 32u) & 0xFFFFu; \
     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].distance = 0; \

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-delete.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-delete.cpp
@@ -76,6 +76,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_value_1,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags != HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
@@ -85,6 +86,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_key_1_len,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
             })
@@ -113,6 +115,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_value_1,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags != HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
@@ -122,6 +125,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_key_1_len,
                         &prev_value));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
                 REQUIRE(prev_value == test_value_1);
@@ -150,6 +154,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_value_1,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
                 REQUIRE(key_value->flags != HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
@@ -159,6 +164,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_key_1_len,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
 
@@ -172,6 +178,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_value_1,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
@@ -183,6 +190,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                         test_key_1_len,
                         nullptr));
 
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].slot_id == 0);
                 REQUIRE(key_value->flags == HASHTABLE_KEY_VALUE_FLAG_DELETED);
             })

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
@@ -72,7 +72,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                 REQUIRE(!spinlock_is_locked(&half_hashes_chunk->write_lock));
 
                 // Check if the first slot of the chain ring contains the correct key/value
-                REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
@@ -118,7 +118,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                 REQUIRE(!transaction_spinlock_is_locked(&half_hashes_chunk->write_lock));
 
                 // Check if the first slot of the chain ring contains the correct key/value
-                REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_long_1_hash_quarter);
@@ -171,7 +171,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         &prev_value2));
 
                 // Check if the first slot of the chain ring contains the correct key/value
-                REQUIRE(half_hashes_chunk->metadata.changes_counter == 2);
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 2);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);
@@ -505,7 +505,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                     REQUIRE(!transaction_spinlock_is_locked(&half_hashes_chunk->write_lock));
 
                     // Check if the first slot of the chain ring contains the correct key/value
-                    REQUIRE(half_hashes_chunk->metadata.changes_counter == 1);
+                    REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                     REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
                     REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
                     REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);


### PR DESCRIPTION
In this pull request, the changes_counter field is renamed to slots_occupied, which now tracks the number of occupied slots within a chunk.
This modification enables several optimizations that eliminate the need to check empty chunks, resulting in improved overall performance.