### PR TITLE
Bug add test for expired keys in rdp generation

### DIFF
--- a/tests/unit_tests/modules/redis/snapshot/test-module-redis-shapshot-serialize-primitive.cpp
+++ b/tests/unit_tests/modules/redis/snapshot/test-module-redis-shapshot-serialize-primitive.cpp
@@ -62,9 +62,9 @@ bool test_module_redis_snapshot_serialize_primitive_vaidate_rdb(
     close(temp_test_snapshot_fd);
 
     // Run redis-check-rdb on the file to ensure it can be read, if the operation fails print out the command output
-    char command[1024];
-    char command_temp_buffer[1024];
-    char command_output[64 * 1024];
+    char command[1024] = { 0 };
+    char command_temp_buffer[8 * 1024] = { 0 };
+    char command_output[64 * 1024] = { 0 };
     char *command_output_ptr = command_output;
     size_t command_output_offset = 0;
 


### PR DESCRIPTION
The tests for the primitives to generated redis snapshots (RDB) files were not implemented for strings with expiration timestamps.

The PR includes 2 new set of tests, one with expired timestamps and one without.

It also include a fix for the output collection of redis-check-rdb, the memory allocated on the stack wasn't being empitied causing old content being displayed.