### PR TITLE
Move the keys eviction onto a fiber and improve efficiency with auto-tuning of the aggressiveness depending on the proximity to the hard limit

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -417,13 +417,13 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
                     half_hashes_chunk->half_hashes[chunk_slot_index].slot_id = slot_id_wrapper.slot_id;
                     *created_new = true;
 
+                    // Update the counter for the occupied slots
+                    half_hashes_chunk->metadata.slots_occupied++;
+                    assert(half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+                    LOG_DI(">>> incrementing the slots_occupied to %d", half_hashes_chunk->metadata.slots_occupied);
+
                     LOG_DI(">>> empty slot found, updating the half_hashes in the chunk with the hash");
                 }
-
-                // Update the counter for the occupied slots
-                half_hashes_chunk->metadata.slots_occupied++;
-                assert(half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
-                LOG_DI(">>> incrementing the slots_occupied to %d", half_hashes_chunk->metadata.slots_occupied);
 
                 *found_half_hashes_chunk = half_hashes_chunk;
                 *found_key_value = key_value;

--- a/src/program.c
+++ b/src/program.c
@@ -855,7 +855,7 @@ int program_main(
 
     // Ensure that all the workers started correctly
     if (!program_workers_ensure_started(program_context)) {
-        LOG_E(TAG, "One or more workers didn't start correctly, can't continue");
+        LOG_E(TAG, "One or more workers didn't start correctly, aborting");
         goto end;
     }
 
@@ -874,7 +874,7 @@ end:
     // thread is aborting, every other thread is also notified and will terminate the execution
     program_request_terminate(&program_terminate_event_loop);
 
-    LOG_V(TAG, "Terminating");
+    LOG_I(TAG, "Terminating");
 
     // Final cleanup
     program_cleanup(program_context);

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1659,8 +1659,9 @@ void storage_db_keys_eviction_bitonic_sort_16_elements(storage_db_keys_eviction_
 uint8_t storage_db_keys_eviction_run_worker(
         storage_db_t *db,
         bool only_ttl,
-        config_database_keys_eviction_policy_t policy,
-        uint32_t worker_index) {
+        config_database_keys_eviction_policy_t policy) {
+    assert(STORAGE_DB_KEYS_EVICTION_EVICT_FIRST_N_KEYS <= STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH);
+
     storage_db_keys_eviction_kv_list_entry_t keys_evitction_candidates_list[
             STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH];
     uint64_t keys_eviction_candidates_list_count;
@@ -1675,23 +1676,39 @@ uint8_t storage_db_keys_eviction_run_worker(
 
     // Iterates over the hashtable to free up the entry index
     hashtable_bucket_index_t bucket_index = 0;
-    hashtable_bucket_count_t segment_size = buckets_end / STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH;
+    hashtable_bucket_count_t segment_size =
+            buckets_end / STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH;
+    uint32_t search_attempts = 0;
     void *data = NULL;
     for(
             keys_eviction_candidates_list_count = 0;
-            keys_eviction_candidates_list_count < STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH;
+            keys_eviction_candidates_list_count < STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH &&
+                search_attempts < STORAGE_DB_KEYS_EVICTION_ITER_MAX_SEARCH_ATTEMPTS;
             keys_eviction_candidates_list_count++) {
         hashtable_bucket_count_t increment = random_generate() % segment_size;
         bucket_index += increment;
 
-        data = hashtable_mcmp_op_iter(db->hashtable, &bucket_index);
+        // Tries to fetch the next entry index
+        data = hashtable_mcmp_op_iter_max_distance(
+                db->hashtable,
+                &bucket_index,
+                STORAGE_DB_KEYS_EVICTION_ITER_MAX_DISTANCE * search_attempts);
         if (unlikely(bucket_index >= buckets_end || data == NULL)) {
-            // Restarts from the beginning and retry
-            bucket_index = 0;
+            // In case data is null but the bucket index is not at the end, it means that the max distance has been
+            // reached and no bucket has been found.
+            if (unlikely(bucket_index >= buckets_end)) {
+                // Restarts from the beginning and retry
+                bucket_index = 0;
+            }
             keys_eviction_candidates_list_count--;
+            search_attempts++;
             continue;
         }
 
+        // Bucket found, reset the search attempts
+        search_attempts = 0;
+
+        // Fetch the entry index
         storage_db_entry_index_t *entry_index = data;
 
         // If only the keys with expiry time have to be evicted and the current key has no expiry time, then skip it
@@ -1728,12 +1745,32 @@ uint8_t storage_db_keys_eviction_run_worker(
         keys_evitction_candidates_list[keys_eviction_candidates_list_count].value = bucket_index;
     }
 
+    // If too many search attempts have been carried out, fill the rest of the array with key set to UINT64_MAX and
+    // value set to UINT64_MAX
+    if (unlikely(search_attempts >= STORAGE_DB_KEYS_EVICTION_ITER_MAX_SEARCH_ATTEMPTS)) {
+        #pragma unroll(STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH)
+        for (;
+                keys_eviction_candidates_list_count < STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH;
+                keys_eviction_candidates_list_count++) {
+            keys_evitction_candidates_list[keys_eviction_candidates_list_count].key = UINT64_MAX;
+            keys_evitction_candidates_list[keys_eviction_candidates_list_count].value = UINT64_MAX;
+        }
+    }
+
     // Sort the keys
     storage_db_keys_eviction_bitonic_sort_16_elements(keys_evitction_candidates_list);
 
     // Delete the first 10 keys
-    #pragma unroll(10)
-    for (uint8_t i = 0; i < 10; i++) {
+    #pragma unroll(STORAGE_DB_KEYS_EVICTION_EVICT_FIRST_N_KEYS)
+    for (uint8_t i = 0; i < STORAGE_DB_KEYS_EVICTION_EVICT_FIRST_N_KEYS; i++) {
+        // Check if the key is set to UINT64_MAX and the value is set to UINT64_MAX, in which case there are no more
+        // keys to evict in the list
+        if (unlikely(keys_evitction_candidates_list[i].key == UINT64_MAX &&
+            keys_evitction_candidates_list[i].value == UINT64_MAX)) {
+            break;
+        }
+
+        // Try to delete the key by index
         if (storage_db_op_delete_by_index(db, keys_evitction_candidates_list[i].value)) {
             keys_evicted_count++;
         }

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -730,6 +730,7 @@ void storage_db_chunk_sequence_free_chunks(
     ffma_mem_free(sequence->sequence);
     sequence->count = 0;
     sequence->sequence = NULL;
+    sequence->size = 0;
 }
 
 void storage_db_entry_index_chunks_free(

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -505,13 +505,13 @@ static inline double storage_db_keys_eviction_calculate_close_to_hard_limit_perc
         return 0;
     }
 
-    if (db->limits.keys_count.soft_limit > 0) {
+    if (db->limits.keys_count.soft_limit > 0 && keys_count > db->limits.keys_count.soft_limit) {
         keys_count_close_to_hard_limit_percentage =
                 (double)(keys_count - db->limits.keys_count.soft_limit) /
                 (double)(db->limits.keys_count.hard_limit - db->limits.keys_count.soft_limit);
     }
 
-    if (db->limits.data_size.soft_limit > 0) {
+    if (db->limits.data_size.soft_limit > 0 && data_size > db->limits.data_size.soft_limit) {
         data_size_close_to_hard_limit_percentage =
                 (double)(data_size - db->limits.data_size.soft_limit) /
                 (double)(db->limits.data_size.hard_limit - db->limits.data_size.soft_limit);

--- a/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.c
+++ b/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.c
@@ -43,7 +43,7 @@ void worker_fiber_storage_db_gc_deleted_entries_fiber_entrypoint(
         void *user_data) {
     worker_context_t* worker_context = worker_context_get();
 
-    while(worker_op_timer(0, WORKER_FIBER_GC_DELETED_STORAGE_DB_ENTRIES_TIMER_LOOP_MS * 1000000l)) {
+    while(worker_op_wait_ms(WORKER_FIBER_STORAGE_DB_GC_DELETED_STORAGE_DB_ENTRIES_WAIT_LOOP_MS)) {
         // The condition checked below is mostly for the tests, as there are some simple tests that should setup the
         // storage_db otherwise
         if (likely(worker_context->db)) {

--- a/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.h
+++ b/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#define WORKER_FIBER_GC_DELETED_STORAGE_DB_ENTRIES_TIMER_LOOP_MS 50l
+#define WORKER_FIBER_STORAGE_DB_GC_DELETED_STORAGE_DB_ENTRIES_WAIT_LOOP_MS 50l
 
 void worker_fiber_storage_db_gc_deleted_entries_fiber_entrypoint(
         void *user_data);

--- a/src/worker/fiber/worker_fiber_storage_db_initialize.c
+++ b/src/worker/fiber/worker_fiber_storage_db_initialize.c
@@ -5,6 +5,7 @@
  * This software may be modified and distributed under the terms
  * of the BSD license.  See the LICENSE file for details.
  **/
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <arpa/inet.h>
@@ -40,13 +41,12 @@
 
 void worker_fiber_storage_db_initialize_fiber_entrypoint(
         void* user_data) {
+    bool *storage_db_initialized = (bool*)user_data;
     worker_context_t *worker_context = worker_context_get();
 
-    if (!storage_db_open(worker_context->db)) {
-        // TODO: execution has to terminate
-        LOG_E(TAG, "Failed to open the database, terminating");
-    }
+    // Initialize the storage db
+    *storage_db_initialized = storage_db_open(worker_context->db);
 
-    // Switch back to the scheduler, as the lister has been closed this fiber will never be invoked and will get freed
-    fiber_scheduler_switch_back();
+    // Mark the current fiber as terminated
+    fiber_scheduler_terminate_current_fiber();
 }

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <arpa/inet.h>
+#include <stddef.h>
+
+#include "exttypes.h"
+#include "misc.h"
+#include "clock.h"
+#include "fiber/fiber.h"
+#include "log/log.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "config.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+#include "fiber/fiber_scheduler.h"
+#include "worker/worker_op.h"
+
+#include "worker_fiber_storage_db_keys_eviction.h"
+
+#define TAG "worker_fiber_storage_db_initialize"
+
+void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
+        void* user_data) {
+    worker_context_t *worker_context = worker_context_get();
+
+    uint64_t last_run = clock_monotonic_coarse_int64_ms();
+    while(worker_op_wait_ms(WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS)) {
+        // Check if limits have been passed
+        if (likely(!storage_db_keys_eviction_should_run(worker_context->db))) {
+            continue;
+        }
+
+        // To avoid to run the eviction too often, we calculate how close we are to the hard limits and then calculate
+        // a wait time based on that, closer to the limits lower the wait time with being at 95% close to the hard limit
+        // means run immediately.
+        double close_to_hard_limit = storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(
+                worker_context->db);
+
+        // Upscale close_to_hard_limit, 95% means 100%
+        close_to_hard_limit = close_to_hard_limit * 1.05;
+
+        // Ensure that close_to_hard_limit isn't greater than 1
+        if (unlikely(close_to_hard_limit > 1)) {
+            close_to_hard_limit = 1;
+        }
+
+        // Calculate the wait time
+        uint64_t wait_time = (uint64_t) (1000 * (1 - close_to_hard_limit));
+
+        // Check if enough time has passed from the last run
+        if (likely(clock_monotonic_coarse_int64_ms() - last_run < wait_time)) {
+            continue;
+        }
+
+        // Run the eviction
+        storage_db_keys_eviction_run_worker(
+                worker_context->db,
+                worker_context->config->database->keys_eviction->only_ttl,
+                worker_context->config->database->keys_eviction->policy);
+    }
+}

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -35,8 +35,6 @@
 
 #define TAG "worker_fiber_storage_db_initialize"
 
-#define STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD 0.95
-
 void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
         void* user_data) {
     worker_context_t *worker_context = worker_context_get();
@@ -61,7 +59,7 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
 
             // Upscale close_to_hard_limit to take into account the threshold
             close_to_hard_limit =
-                    close_to_hard_limit * (1 + (1 - STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD));
+                    close_to_hard_limit * (1 + (1 - WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD));
 
             // Ensure that close_to_hard_limit isn't greater than 1
             if (unlikely(close_to_hard_limit > 1)) {
@@ -88,7 +86,7 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
             eviction_run = true;
 
         } while(storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(worker_context->db) >
-                STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD);
+                WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD);
 
         if (eviction_run) {
             last_run = clock_monotonic_coarse_int64_ms();

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -41,6 +41,7 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
 
     uint64_t last_run = clock_monotonic_coarse_int64_ms();
     while(worker_op_wait_ms(WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS)) {
+        uint64_t iterations = 0;
         bool eviction_run = false;
 
         // Check if limits have been passed
@@ -84,9 +85,10 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
                     worker_context->config->database->keys_eviction->policy);
 
             eviction_run = true;
-
-        } while(storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(worker_context->db) >
-                WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD);
+            iterations++;
+        } while(iterations < 100 &&
+                storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(worker_context->db) >
+                    WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD);
 
         if (eviction_run) {
             last_run = clock_monotonic_coarse_int64_ms();

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -9,13 +9,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <arpa/inet.h>
-#include <stddef.h>
 
 #include "exttypes.h"
 #include "misc.h"
 #include "clock.h"
-#include "fiber/fiber.h"
-#include "log/log.h"
 #include "spinlock.h"
 #include "transaction.h"
 #include "transaction_spinlock.h"
@@ -32,12 +29,13 @@
 #include "storage/db/storage_db.h"
 #include "worker/worker_stats.h"
 #include "worker/worker_context.h"
-#include "fiber/fiber_scheduler.h"
 #include "worker/worker_op.h"
 
 #include "worker_fiber_storage_db_keys_eviction.h"
 
 #define TAG "worker_fiber_storage_db_initialize"
+
+#define STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD 0.95
 
 void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
         void* user_data) {
@@ -45,37 +43,55 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
 
     uint64_t last_run = clock_monotonic_coarse_int64_ms();
     while(worker_op_wait_ms(WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS)) {
+        bool eviction_run = false;
+
         // Check if limits have been passed
         if (likely(!storage_db_keys_eviction_should_run(worker_context->db))) {
             continue;
         }
 
-        // To avoid to run the eviction too often, we calculate how close we are to the hard limits and then calculate
-        // a wait time based on that, closer to the limits lower the wait time with being at 95% close to the hard limit
-        // means run immediately.
-        double close_to_hard_limit = storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(
-                worker_context->db);
+        // If the storage db is close to hit the hard limit (e.g.
+        // STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD from the soft limit to the hard limit) than
+        // run until enough data have been freed up
+        do {
+            // To avoid to run the eviction too often, we calculate how close we are to the hard limits and then
+            // calculate a wait time based on that, closer to the limits lower the wait time.
+            double close_to_hard_limit = storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(
+                    worker_context->db);
 
-        // Upscale close_to_hard_limit, 95% means 100%
-        close_to_hard_limit = close_to_hard_limit * 1.05;
+            // Upscale close_to_hard_limit to take into account the threshold
+            close_to_hard_limit =
+                    close_to_hard_limit * (1 + (1 - STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD));
 
-        // Ensure that close_to_hard_limit isn't greater than 1
-        if (unlikely(close_to_hard_limit > 1)) {
-            close_to_hard_limit = 1;
+            // Ensure that close_to_hard_limit isn't greater than 1
+            if (unlikely(close_to_hard_limit > 1)) {
+                close_to_hard_limit = 1;
+            }
+
+            // Calculate the wait time
+            uint64_t wait_time = (uint64_t) (100 * (1 - close_to_hard_limit));
+
+            // Check if enough time has passed from the last run
+            uint64_t now = clock_monotonic_coarse_int64_ms();
+            uint64_t elapsed = now - last_run;
+
+            if (likely(elapsed < wait_time)) {
+                continue;
+            }
+
+            // Run the eviction
+            storage_db_keys_eviction_run_worker(
+                    worker_context->db,
+                    worker_context->config->database->keys_eviction->only_ttl,
+                    worker_context->config->database->keys_eviction->policy);
+
+            eviction_run = true;
+
+        } while(storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(worker_context->db) >
+                STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD);
+
+        if (eviction_run) {
+            last_run = clock_monotonic_coarse_int64_ms();
         }
-
-        // Calculate the wait time
-        uint64_t wait_time = (uint64_t) (1000 * (1 - close_to_hard_limit));
-
-        // Check if enough time has passed from the last run
-        if (likely(clock_monotonic_coarse_int64_ms() - last_run < wait_time)) {
-            continue;
-        }
-
-        // Run the eviction
-        storage_db_keys_eviction_run_worker(
-                worker_context->db,
-                worker_context->config->database->keys_eviction->only_ttl,
-                worker_context->config->database->keys_eviction->policy);
     }
 }

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 1l
+#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD 0.95
 
 void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
         void* user_data);

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 50l
+#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 1l
 
 void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
         void* user_data);

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 #define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 1l
-#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD 0.95
+#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD 0.99
 
 void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
         void* user_data);

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
@@ -1,0 +1,17 @@
+#ifndef CACHEGRAND_WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_H
+#define CACHEGRAND_WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 50l
+
+void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
+        void* user_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_H

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -287,11 +287,16 @@ void worker_set_aborted(
 
 bool worker_initialize_storage_db(
         worker_context_t *worker_context) {
-    if (!worker_fiber_register(
-            worker_context,
+    bool storage_db_initialized = false;
+
+    // No need to keep track of this fiber, it will be freed right away once the control is returned to the code
+    fiber_scheduler_new_fiber(
             "worker-fiber-storage-db-initialize",
+            strlen("worker-fiber-storage-db-initialize"),
             worker_fiber_storage_db_initialize_fiber_entrypoint,
-            NULL)) {
+            &storage_db_initialized);
+
+    if (!storage_db_initialized) {
         return false;
     }
 

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -373,23 +373,23 @@ void* worker_thread_func(
     }
 
     if (!worker_initialize_network(worker_context)) {
-        LOG_E(TAG, "Unable to initialize the network, can't continue!");
+        LOG_E(TAG, "Unable to initialize the network subsystem!");
         goto end;
     }
 
     if (!worker_initialize_storage(worker_context)) {
-        LOG_E(TAG, "Unable to initialize the storage, can't continue!");
+        LOG_E(TAG, "Unable to initialize the storage subsystem!");
         goto end;
     }
 
     if (worker_initialize_storage_db(worker_context) == false) {
-        LOG_E(TAG, "Unable to initialize the database, can't continue!");
+        LOG_E(TAG, "Unable to initialize the database!");
         goto end;
     }
 
     if ((worker_module_contexts = worker_module_contexts_initialize(
             worker_context->config)) == NULL) {
-        LOG_E(TAG, "Unable to initialize the listeners, can't continue!");
+        LOG_E(TAG, "Unable to initialize the listeners!");
         goto end;
     }
 
@@ -400,7 +400,7 @@ void* worker_thread_func(
             worker_module_contexts,
             &listeners,
             &listeners_count)) {
-        LOG_E(TAG, "Unable to initialize the listeners, can't continue!");
+        LOG_E(TAG, "Unable to initialize the listeners!");
         goto end;
     }
 

--- a/src/worker/worker_fiber.c
+++ b/src/worker/worker_fiber.c
@@ -73,7 +73,6 @@ bool worker_fiber_register(
 
 void worker_fiber_free(
         worker_context_t* worker_context) {
-
     double_linked_list_item_t *item;
     while ((item = double_linked_list_pop_item(worker_context->fibers)) != NULL) {
         fiber_t *fiber = item->data;

--- a/src/worker/worker_iouring_op.c
+++ b/src/worker/worker_iouring_op.c
@@ -47,7 +47,7 @@
 
 #define TAG "worker_iouring_op"
 
-bool worker_iouring_op_timer(
+bool worker_iouring_op_wait(
         long seconds,
         long long nanoseconds) {
     kernel_timespec_t kernel_timespec = {
@@ -72,6 +72,17 @@ bool worker_iouring_op_timer(
     return true;
 }
 
+bool worker_iouring_op_wait_ms(
+        uint64_t ms) {
+    kernel_timespec_t kernel_timespec = {
+            .tv_sec = (long long)(ms / 1000ull),
+            .tv_nsec = (long long)((ms % 1000ull) * 1000000ll),
+    };
+
+    return worker_iouring_op_wait(kernel_timespec.tv_sec, kernel_timespec.tv_nsec);
+}
+
 void worker_iouring_op_register() {
-    worker_op_timer = worker_iouring_op_timer;
+    worker_op_wait = worker_iouring_op_wait;
+    worker_op_wait_ms = worker_iouring_op_wait_ms;
 }

--- a/src/worker/worker_iouring_op.h
+++ b/src/worker/worker_iouring_op.h
@@ -6,19 +6,6 @@ extern "C" {
 #endif
 
 typedef struct worker_iouring_context worker_iouring_context_t;
-typedef struct worker_iouring_op_context worker_iouring_op_context_t;
-
-typedef bool (worker_iouring_op_wrapper_completion_cb_fp_t)(
-        worker_iouring_context_t* worker_iouring_context,
-        worker_iouring_op_context_t* worker_iouring_op_context,
-        io_uring_cqe_t *cqe,
-        bool *free_op_context);
-
-bool worker_iouring_op_fds_map_files_update_cb(
-        worker_iouring_context_t *context,
-        worker_iouring_op_context_t *op_context,
-        io_uring_cqe_t *cqe,
-        bool *free_op_context);
 
 void worker_iouring_op_register();
 

--- a/src/worker/worker_op.c
+++ b/src/worker/worker_op.c
@@ -7,9 +7,11 @@
  **/
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "worker/worker_op.h"
 
 #define TAG "worker_op"
 
-worker_op_timer_fp_t* worker_op_timer;
+worker_op_wait_fp_t* worker_op_wait;
+worker_op_wait_ms_fp_t* worker_op_wait_ms;

--- a/src/worker/worker_op.h
+++ b/src/worker/worker_op.h
@@ -5,11 +5,15 @@
 extern "C" {
 #endif
 
-typedef bool (worker_op_timer_fp_t)(
+typedef bool (worker_op_wait_fp_t)(
         long seconds,
         long long nanoseconds);
 
-extern worker_op_timer_fp_t* worker_op_timer;
+typedef bool (worker_op_wait_ms_fp_t)(
+        uint64_t ms);
+
+extern worker_op_wait_fp_t* worker_op_wait;
+extern worker_op_wait_ms_fp_t* worker_op_wait_ms;
 
 #ifdef __cplusplus
 }

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
@@ -171,7 +171,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
                         &prev_value2));
 
                 // Check if the first slot of the chain ring contains the correct key/value
-                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 2);
+                REQUIRE(half_hashes_chunk->metadata.slots_occupied == 1);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].filled == true);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].distance == 0);
                 REQUIRE(half_hashes_chunk->half_hashes[chunk_slot_index].quarter_hash == test_key_1_hash_quarter);

--- a/tests/unit_tests/modules/redis/snapshot/test-module-redis-shapshot-serialize-primitive.cpp
+++ b/tests/unit_tests/modules/redis/snapshot/test-module-redis-shapshot-serialize-primitive.cpp
@@ -16,6 +16,7 @@
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
 #include "random.h"
+#include "clock.h"
 
 #include "module/redis/snapshot/module_redis_snapshot.h"
 #include "module/redis/snapshot/module_redis_snapshot_serialize_primitive.h"
@@ -61,9 +62,9 @@ bool test_module_redis_snapshot_serialize_primitive_vaidate_rdb(
     close(temp_test_snapshot_fd);
 
     // Run redis-check-rdb on the file to ensure it can be read, if the operation fails print out the command output
-    char command[1024];
-    char command_temp_buffer[1024];
-    char command_output[64 * 1024];
+    char command[1024] = { 0 };
+    char command_temp_buffer[8 * 1024] = { 0 };
+    char command_output[64 * 1024] = { 0 };
     char *command_output_ptr = command_output;
     size_t command_output_offset = 0;
 
@@ -1164,6 +1165,160 @@ TEST_CASE("module_redis_snapshot_serialize_primitive") {
                 size_t key_length = strlen(key);
                 sprintf(string, "value%d", i);
                 size_t string_length = strlen(string);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_value_type(
+                        MODULE_REDIS_SNAPSHOT_VALUE_TYPE_STRING,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_key(
+                        key,
+                        key_length,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_string_length(
+                        string_length,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_string_data_plain(
+                        string,
+                        string_length,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+            }
+
+            REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_eof(
+                    0,
+                    buffer,
+                    buffer_size,
+                    buffer_offset_out,
+                    &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+            // Write the data
+            REQUIRE(test_module_redis_snapshot_serialize_primitive_vaidate_rdb((char*)buffer, buffer_offset_out));
+        }
+
+        SECTION("generate an rdb with 5 random strings with random expiration in ms (not expired)") {
+            uint8_t buffer[1024];
+            size_t buffer_size = sizeof(buffer);
+            size_t buffer_offset_out = 0;
+            module_redis_snapshot_header_t module_redis_snapshot_header = { .version = rdb_version };
+
+            REQUIRE(module_redis_snapshot_serialize_primitive_encode_header(
+                    &module_redis_snapshot_header,
+                    buffer,
+                    buffer_size,
+                    buffer_offset_out,
+                    &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+            REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_db_number(
+                    0,
+                    buffer,
+                    buffer_size,
+                    buffer_offset_out,
+                    &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+            for (int i = 0; i < 5; i++) {
+                char key[10];
+                char string[10];
+                sprintf(key, "key%d", i);
+                size_t key_length = strlen(key);
+                sprintf(string, "value%d", i);
+                size_t string_length = strlen(string);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_expire_time_ms(
+                        clock_realtime_int64_ms() + (random_generate() % 1000000),
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_value_type(
+                        MODULE_REDIS_SNAPSHOT_VALUE_TYPE_STRING,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_key(
+                        key,
+                        key_length,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_string_length(
+                        string_length,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_string_data_plain(
+                        string,
+                        string_length,
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+            }
+
+            REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_eof(
+                    0,
+                    buffer,
+                    buffer_size,
+                    buffer_offset_out,
+                    &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+            // Write the data
+            REQUIRE(test_module_redis_snapshot_serialize_primitive_vaidate_rdb((char*)buffer, buffer_offset_out));
+        }
+
+        SECTION("generate an rdb with 5 random strings with random expiration in ms (expired)") {
+            uint8_t buffer[1024];
+            size_t buffer_size = sizeof(buffer);
+            size_t buffer_offset_out = 0;
+            module_redis_snapshot_header_t module_redis_snapshot_header = { .version = rdb_version };
+
+            REQUIRE(module_redis_snapshot_serialize_primitive_encode_header(
+                    &module_redis_snapshot_header,
+                    buffer,
+                    buffer_size,
+                    buffer_offset_out,
+                    &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+            REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_db_number(
+                    0,
+                    buffer,
+                    buffer_size,
+                    buffer_offset_out,
+                    &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
+
+            for (int i = 0; i < 5; i++) {
+                char key[10];
+                char string[10];
+                sprintf(key, "key%d", i);
+                size_t key_length = strlen(key);
+                sprintf(string, "value%d", i);
+                size_t string_length = strlen(string);
+
+                REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_expire_time_ms(
+                        clock_realtime_int64_ms() - (random_generate() % 1000000),
+                        buffer,
+                        buffer_size,
+                        buffer_offset_out,
+                        &buffer_offset_out) == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK);
 
                 REQUIRE(module_redis_snapshot_serialize_primitive_encode_opcode_value_type(
                         MODULE_REDIS_SNAPSHOT_VALUE_TYPE_STRING,


### PR DESCRIPTION
This pull request moves the keys eviction code onto an ad-hoc fiber and enhances the eviction process file by implementing a proximity-based aggressiveness auto-tuning mechanism to optimize key eviction efficiency and balance out the amount of resources required.
The eviction process is adjusted based on the proximity to the hard limit, with reduced wait times for closer limits. The logic ensures an optimized eviction process by running until sufficient data is freed up when approaching the hard limit threshold.

When very close to the hard limit (99%) then a very aggressive mechanism kicks in to reduce the memory consumption below the threshold.