### PR TITLE
Switch clock monotonic to tsc

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -6,6 +6,13 @@
  * of the BSD license.  See the LICENSE file for details.
  **/
 
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "misc.h"
+#include "intrinsics.h"
+
 #include "clock.h"
 
 int64_t clock_realtime_coarse_get_resolution_ms() {
@@ -17,9 +24,5 @@ int64_t clock_realtime_coarse_get_resolution_ms() {
 }
 
 int64_t clock_monotonic_coarse_get_resolution_ms() {
-    timespec_t res;
-    clock_getres(CLOCK_MONOTONIC_COARSE, &res);
-    int64_t res_ms = clock_timespec_to_int64_ms(&res);
-
-    return res_ms;
+    return 1;
 }

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -7,5 +7,41 @@
  **/
 
 #include <stdint.h>
+#include <unistd.h>
+
+#include "misc.h"
 
 #include "intrinsics.h"
+
+uint64_t intrinsics_cycles_per_second = 0;
+
+FUNCTION_CTOR(intrinsics_cycles_per_second_init, {
+    intrinsics_cycles_per_second_calibrate();
+})
+
+void intrinsics_cycles_per_second_calibrate() {
+    intrinsics_cycles_per_second = intrinsics_cycles_per_second_calculate();
+}
+
+uint64_t intrinsics_cycles_per_second_calculate() {
+    uint64_t loops = 3;
+    uint64_t loop_wait_ms = 300;
+    uint64_t cycles_per_second_sum = 0;
+
+    // Calculate the average cycles per second
+    for(int i = 0; i < loops; i++) {
+        uint64_t start = intrinsics_tsc();
+        usleep(loop_wait_ms * 1000);
+        cycles_per_second_sum += intrinsics_tsc() - start;
+    }
+
+    // Calculate the average cycles per second
+    uint64_t cycles_per_second_internal =
+            (uint64_t)(((double)cycles_per_second_sum / (double)loops) * (1000.0 / (double)loop_wait_ms));
+
+    // Modern CPUs usually have GHz frequencies with 1 digit and one decimal, for example 42007283080 Hz is actually
+    // 4.2 GHz (or 4200 MHz) so we need to divide by 10000000 and then multiply it back to get the correct value
+    cycles_per_second_internal = (uint64_t)((uint64_t)cycles_per_second_internal / 10000000) * 10000000;
+
+    return cycles_per_second_internal;
+}

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -5,6 +5,16 @@
 extern "C" {
 #endif
 
+extern uint64_t intrinsics_cycles_per_second;
+
+void intrinsics_cycles_per_second_calibrate();
+
+uint64_t intrinsics_cycles_per_second_calculate();
+
+static inline  uint64_t intrinsics_cycles_per_second_get() {
+    return intrinsics_cycles_per_second;
+}
+
 static inline uint64_t intrinsics_tsc() {
 #if defined(__x86_64__)
     uint64_t rax, rdx;

--- a/tests/unit_tests/test-intrinsics.cpp
+++ b/tests/unit_tests/test-intrinsics.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <fstream>
+#include <string>
+#include <cstdint>
+#include <unistd.h>
+
+#include "intrinsics.h"
+
+double test_intrinsics_read_cpu_freq_from_cpuinfo() {
+    std::ifstream cpuinfo("/proc/cpuinfo");
+    std::string line;
+
+    while (std::getline(cpuinfo, line)) {
+        if (line.find("cpu MHz") != std::string::npos) {
+            std::size_t pos = line.find(':');
+            double cpu_freq = std::stod(line.substr(pos + 1));
+            return cpu_freq * 1000000; // Convert MHz to Hz
+        }
+    }
+    throw std::runtime_error("Cannot find 'cpu MHz' in /proc/cpuinfo");
+}
+
+TEST_CASE("intrinsics.c", "[intrinsics]") {
+    SECTION("intrinsics_cycles_per_second_calculate") {
+        uint64_t cycles_per_second = intrinsics_cycles_per_second_calculate();
+        double cpu_freq_from_cpuinfo = test_intrinsics_read_cpu_freq_from_cpuinfo();
+
+        // Since there can be some variation in the frequency, we will use a tolerance
+        double tolerance = 0.02 * cpu_freq_from_cpuinfo; // 2% tolerance
+
+        REQUIRE(cycles_per_second >= (cpu_freq_from_cpuinfo - tolerance));
+        REQUIRE(cycles_per_second <= (cpu_freq_from_cpuinfo + tolerance));
+    }
+}


### PR DESCRIPTION
This PR switches the backend of the clock_monotonic* functions to use the CPU TSC introducing a mechanism to calibrate the amount of cycles per second and then using this value to convert the TSC (timestamp / cycles counter) to uptime.

The clock tests have been updated a new set of tests have been introduced to validate the calibration that read the value from /proc/cpuinfo allowing up to a 2% of tollerance, which is fine because it's not a realtime clock but a monotonic one so if there is a slightly difference with the system one is fine.