### PR TITLE
Ensure all the log data are always written to disk

### DIFF
--- a/src/log/sink/log_sink_file.c
+++ b/src/log/sink/log_sink_file.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include "misc.h"
+#include "clock.h"
 #include "log/log.h"
 #include "log/sink/log_sink.h"
 #include "log/sink/log_sink_support.h"


### PR DESCRIPTION
This PR changes the behaviour of log_sink_file_printer to ensure that all the log data are always written to the disk.