### PR TITLE
Ensure fibers switch back at the end of the function body

### DIFF
--- a/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.c
+++ b/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.c
@@ -54,4 +54,7 @@ void worker_fiber_storage_db_gc_deleted_entries_fiber_entrypoint(
             storage_db_worker_garbage_collect_deleting_entry_index_when_no_readers(worker_context->db);
         }
     }
+
+    // Switch back
+    fiber_scheduler_switch_back();
 }

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -98,4 +98,7 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
             last_run = clock_monotonic_coarse_int64_ms();
         }
     }
+
+    // Switch back
+    fiber_scheduler_switch_back();
 }

--- a/src/worker/fiber/worker_fiber_storage_db_snapshot_rdb.c
+++ b/src/worker/fiber/worker_fiber_storage_db_snapshot_rdb.c
@@ -119,4 +119,7 @@ void worker_fiber_storage_db_snapshot_rdb_fiber_entrypoint(
             ? WORKER_FIBER_STORAGE_DB_SNAPSHOT_RDB_WAIT_LOOP_MS
             : 0);
     }
+
+    // Switch back
+    fiber_scheduler_switch_back();
 }


### PR DESCRIPTION
In some cases the `worker_op_wait_ms` wrapper might return false, e.g. if the io_uring ring has been freed. When it happens it's legit that the fiber terminates because something else is going really bad or the application has been terminated using CTRL+C or a signal.

This will avoid cachegrand printing messages like
```
[...][ERROR      ][worker][id: 04][cpu: 04][fiber_scheduler] Internal error, the fiber <worker-fiber-storage-db-gc-deleted-entries> is terminating but the termination hasn't been requested
[...][ERROR      ][worker][id: 36][cpu: 36][fiber_scheduler] Internal error, the fiber <worker-fiber-storage-db-snapshot-rdb> is terminating but the termination hasn't been requested
[...][ERROR      ][worker][id: 04][cpu: 04][fiber_scheduler] Internal error, the fiber <worker-fiber-storage-db-snapshot-rdb> is terminating but the termination hasn't been requested
```

When there is no actual reason for it.