### PR TITLE
FFMA - Don't preinit all slots

### DIFF
--- a/src/fiber/fiber.c
+++ b/src/fiber/fiber.c
@@ -15,11 +15,6 @@
 #include <errno.h>
 #include <assert.h>
 
-#if defined(DEBUG) &&  __has_include(<valgrind/valgrind.h>)
-#include <valgrind/valgrind.h>
-#define HAS_VALGRIND
-#endif
-
 #include "misc.h"
 #include "exttypes.h"
 #include "xalloc.h"

--- a/src/fiber/fiber_scheduler.c
+++ b/src/fiber/fiber_scheduler.c
@@ -13,11 +13,6 @@
 #include <errno.h>
 #include <string.h>
 
-#if defined(DEBUG) &&  __has_include(<valgrind/valgrind.h>)
-#include <valgrind/valgrind.h>
-#define HAS_VALGRIND
-#endif
-
 #include "misc.h"
 #include "xalloc.h"
 #include "log/log.h"

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -20,15 +20,8 @@
 #include <string.h>
 #include <stdatomic.h>
 
-#if DEBUG == 1 &&  __has_include(<valgrind/valgrind.h>)
-#include <valgrind/valgrind.h>
-#define HAS_VALGRIND
-#endif
-
 #include "misc.h"
 #include "exttypes.h"
-#include "clock.h"
-#include "log/log.h"
 #include "memory_fences.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -39,7 +39,7 @@
 #include <sys/syscall.h>
 #endif
 
-#define TAG _INTERNAL_FFMA_TAG
+#define TAG FFMA_LOG_TAG_INTERNAL
 
 /**
  * The memory allocator requires regions aligned to size of the region itself to calculate the initial address of the

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -143,11 +143,6 @@ void ffma_set_use_hugepages(
     internal_ffma_region_cache->use_hugepages = use_hugepages;
 }
 
-bool ffma_get_use_hugepages(
-        bool use_hugepages) {
-    return internal_ffma_region_cache;
-}
-
 ffma_t* ffma_init(
         size_t object_size) {
     assert(object_size <= FFMA_OBJECT_SIZE_MAX);

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -21,13 +21,15 @@
 extern "C" {
 #endif
 
-#define _INTERNAL_FFMA_TAG "ffma"
+#define FFMA_LOG_TAG_INTERNAL "ffma"
 
 #ifndef FFMA_DEBUG_ALLOCS_FREES
 #define FFMA_DEBUG_ALLOCS_FREES 0
 #endif
 
-#define FFMA_SLICE_SIZE         (2 * 1024 * 1024)
+#define FFMA_PREINIT_SOME_SLOTS_COUNT (16)
+
+#define FFMA_SLICE_SIZE         (8 * 1024 * 1024)
 #define FFMA_REGION_CACHE_SIZE  (32)
 
 #define FFMA_OBJECT_SIZE_16     (0x00000010)
@@ -327,16 +329,16 @@ static inline void* ffma_mem_alloc_internal(
             ffma_slot->data.available = false;
 
 #if DEBUG == 1
-        ffma_slot->data.allocs++;
+            ffma_slot->data.allocs++;
 
 #if defined(HAS_VALGRIND)
-        ffma_slice = ffma_slice_from_memptr(ffma_slot->data.memptr);
-        VALGRIND_MEMPOOL_ALLOC(ffma_slice->data.page_addr, ffma_slot->data.memptr, size);
+            ffma_slice = ffma_slice_from_memptr(ffma_slot->data.memptr);
+            VALGRIND_MEMPOOL_ALLOC(ffma_slice->data.page_addr, ffma_slot->data.memptr, size);
 #endif
 #endif
 
-        // To keep the code simpler and avoid convoluted ifs, the code returns here
-        return ffma_slot->data.memptr;
+            // To keep the code simpler and avoid convoluted ifs, the code returns here
+            return ffma_slot->data.memptr;
         }
 
         if (ffma_slot == NULL || ffma_slot->data.available == false) {
@@ -347,8 +349,8 @@ static inline void* ffma_mem_alloc_internal(
                 return NULL;
             }
 
-        ffma_grow(
-                ffma,
+            ffma_grow(
+                    ffma,
                     addr);
 
             slots_head_item = slots_list->head;

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -114,7 +114,6 @@ typedef union {
         ffma_t *ffma;
         void *page_addr;
         uintptr_t data_addr;
-        uint32_t slots_count;
         bool available;
         struct {
             uint32_t objects_total_count;
@@ -130,9 +129,6 @@ void ffma_debug_allocs_frees_end();
 #endif
 
 void ffma_set_use_hugepages(
-        bool use_hugepages);
-
-bool ffma_get_use_hugepages(
         bool use_hugepages);
 
 ffma_t* ffma_init(

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -118,6 +118,7 @@ typedef union {
         bool available;
         struct {
             uint32_t objects_total_count;
+            uint32_t objects_initialized_count;
             uint32_t objects_inuse_count;
         } metrics;
         ffma_slot_t slots[];
@@ -252,6 +253,41 @@ static inline ffma_t* ffma_thread_cache_get_ffma_by_size(
     return ffma_list[ffma_index_by_object_size(object_size)];
 }
 
+static inline bool ffma_slice_can_add_one_slot_to_per_thread_metadata_slots(
+        ffma_slice_t* ffma_slice) {
+    return ffma_slice->data.metrics.objects_initialized_count < ffma_slice->data.metrics.objects_total_count;
+}
+
+static inline void ffma_slice_add_some_slots_to_per_thread_metadata_slots(
+        ffma_t* ffma,
+        ffma_slice_t* ffma_slice) {
+    ffma_slot_t* ffma_slot;
+
+    uint32_t index_end = ffma_slice->data.metrics.objects_initialized_count + FFMA_PREINIT_SOME_SLOTS_COUNT;
+    if (unlikely(index_end > ffma_slice->data.metrics.objects_total_count)) {
+        index_end = ffma_slice->data.metrics.objects_total_count;
+    }
+
+#pragma unroll(FFMA_PREINIT_SOME_SLOTS_COUNT)
+    for(uint32_t index = ffma_slice->data.metrics.objects_initialized_count; index < index_end; index++) {
+        assert(index < ffma_slice->data.metrics.objects_total_count);
+        ffma_slot = &ffma_slice->data.slots[index];
+        ffma_slot->data.available = true;
+        ffma_slot->data.memptr = (void*)(ffma_slice->data.data_addr + (index * ffma->object_size));
+
+#if DEBUG == 1
+        ffma_slot->data.allocs = 0;
+        ffma_slot->data.frees = 0;
+#endif
+
+        double_linked_list_unshift_item(
+                ffma->slots,
+                &ffma_slot->double_linked_list_item);
+
+        ffma_slice->data.metrics.objects_initialized_count++;
+    }
+}
+
 __attribute__((malloc))
 static inline void* ffma_mem_alloc_internal(
         ffma_t* ffma,
@@ -268,14 +304,31 @@ static inline void* ffma_mem_alloc_internal(
     slots_head_item = slots_list->head;
     ffma_slot = (ffma_slot_t*)slots_head_item;
 
-    // If it can't get the slot from the local cache tries to fetch if from the free list which is a bit slower as it
-    // involves atomic operations, on the other end it requires less operation to be prepared as e.g. it is already on
-    // the correct side of the slots double linked list
-    if (
-            (ffma_slot == NULL || ffma_slot->data.available == false) &&
-            (ffma_slot = (ffma_slot_t*)queue_mpmc_pop(ffma->free_ffma_slots_queue_from_other_threads)) != NULL) {
-        assert(ffma_slot->data.memptr != NULL);
-        ffma_slot->data.available = false;
+    if (unlikely(ffma_slot == NULL || ffma_slot->data.available == false)) {
+        // If the local cache is empty tries to check if the slices has slot to initialize and if yes initializes one
+        // and adds it to the local cache.
+        // The newly added slice with uninitialized slots is added to the tail of the list during the growing process so
+        // it's possible to check the tail of the slices list.
+        if (likely(
+                ffma->slices->tail != NULL &&
+                ffma_slice_can_add_one_slot_to_per_thread_metadata_slots((ffma_slice_t*)ffma->slices->tail))) {
+            ffma_slice_add_some_slots_to_per_thread_metadata_slots(ffma, (ffma_slice_t*)ffma->slices->tail);
+
+            // After adding the slot to the local cache tries to get it again
+            slots_head_item = slots_list->head;
+            ffma_slot = (ffma_slot_t *) slots_head_item;
+
+            // There should always be a valid slot so if it's not the case it's a bug
+            assert(ffma_slot != NULL);
+            assert(ffma_slot->data.available == true);
+
+            // If it can't get the slot from the local cache tries to fetch if from the free list which is a bit slower as
+            // it involves atomic operations, on the other end it requires less operation to be prepared as e.g. it is
+            // already on the correct side of the slots double linked list
+        } else if ((ffma_slot =
+                (ffma_slot_t *) queue_mpmc_pop(ffma->free_ffma_slots_queue_from_other_threads)) != NULL) {
+            assert(ffma_slot->data.memptr != NULL);
+            ffma_slot->data.available = false;
 
 #if DEBUG == 1
         ffma_slot->data.allocs++;
@@ -288,26 +341,23 @@ static inline void* ffma_mem_alloc_internal(
 
         // To keep the code simpler and avoid convoluted ifs, the code returns here
         return ffma_slot->data.memptr;
-    }
-
-    if (ffma_slot == NULL || ffma_slot->data.available == false) {
-        void* addr = ffma_region_cache_pop(internal_ffma_region_cache);
-
-#if defined(HAS_VALGRIND)
-        VALGRIND_CREATE_MEMPOOL(addr, 0, false);
-#endif
-
-        if (!addr) {
-            LOG_E(_INTERNAL_FFMA_TAG, "Unable to allocate %lu bytes of memory", size);
-            return NULL;
         }
+
+        if (ffma_slot == NULL || ffma_slot->data.available == false) {
+            void *addr = ffma_region_cache_pop(internal_ffma_region_cache);
+
+            if (!addr) {
+                LOG_E(FFMA_LOG_TAG_INTERNAL, "Unable to allocate %lu bytes of memory", size);
+                return NULL;
+            }
 
         ffma_grow(
                 ffma,
-                addr);
+                    addr);
 
-        slots_head_item = slots_list->head;
-        ffma_slot = (ffma_slot_t*)slots_head_item;
+            slots_head_item = slots_list->head;
+            ffma_slot = (ffma_slot_t *) slots_head_item;
+        }
     }
 
     assert(ffma_slot->data.memptr != NULL);

--- a/src/memory_allocator/ffma_thread_cache.h
+++ b/src/memory_allocator/ffma_thread_cache.h
@@ -7,17 +7,24 @@ extern "C" {
 
 typedef struct ffma ffma_t;
 
+extern thread_local ffma_t **thread_local_ffmas;
+
 ffma_t **ffma_thread_cache_init();
 
 void ffma_thread_cache_free(
         void *data);
+
+void ffma_thread_cache_thread_local_free(
+        __attribute__((unused)) void *data);
 
 ffma_t **ffma_thread_cache_get();
 
 void ffma_thread_cache_set(
         ffma_t **ffmas);
 
-bool ffma_thread_cache_has();
+static inline bool ffma_thread_cache_has() {
+    return thread_local_ffmas != NULL;
+}
 
 #ifdef __cplusplus
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -11,6 +11,11 @@ extern "C" {
 #endif
 #endif
 
+#if DEBUG == 1 &&  __has_include(<valgrind/valgrind.h>)
+#include <valgrind/valgrind.h>
+#define HAS_VALGRIND
+#endif
+
 /* gcc doesn't know _Thread_local from C11 yet */
 #ifdef __GNUC__
 #define thread_local __thread

--- a/src/thread.c
+++ b/src/thread.c
@@ -34,12 +34,6 @@ thread_local uint32_t thread_current_numa_node_index = UINT32_MAX;
 uint16_t* internal_selected_cpus = NULL;
 uint16_t internal_selected_cpus_count = 0;
 
-void thread_ensure_core_index_and_numa_node_index_filled() {
-    if (thread_current_core_index == UINT32_MAX || thread_current_numa_node_index == UINT32_MAX) {
-        getcpu(&thread_current_core_index, &thread_current_numa_node_index);
-    }
-}
-
 void thread_flush_cached_core_index_and_numa_node_index() {
     thread_current_core_index = UINT32_MAX;
     thread_current_numa_node_index = UINT32_MAX;
@@ -97,14 +91,4 @@ void thread_affinity_set_selected_cpus(
 
     internal_selected_cpus = selected_cpus;
     internal_selected_cpus_count = selected_cpus_count;
-}
-
-uint8_t thread_get_current_numa_node_index() {
-    thread_ensure_core_index_and_numa_node_index_filled();
-    return thread_current_numa_node_index;
-}
-
-uint16_t thread_get_current_core_index() {
-    thread_ensure_core_index_and_numa_node_index_filled();
-    return thread_current_core_index;
 }

--- a/src/thread.h
+++ b/src/thread.h
@@ -5,6 +5,11 @@
 extern "C" {
 #endif
 
+extern thread_local uint32_t thread_current_core_index;
+extern thread_local uint32_t thread_current_numa_node_index;
+
+extern int getcpu (unsigned int *, unsigned int *);
+
 void thread_flush_cached_core_index_and_numa_node_index();
 
 long thread_current_get_id();
@@ -20,9 +25,22 @@ void thread_affinity_set_selected_cpus(
         uint16_t* selected_cpus,
         uint16_t selected_cpus_count);
 
-uint8_t thread_get_current_numa_node_index();
+static inline void thread_ensure_core_index_and_numa_node_index_filled() {
+    if (thread_current_core_index == UINT32_MAX || thread_current_numa_node_index == UINT32_MAX) {
+        getcpu(&thread_current_core_index, &thread_current_numa_node_index);
+    }
+}
 
-uint16_t thread_get_current_core_index();
+static inline uint8_t thread_get_current_numa_node_index() {
+    thread_ensure_core_index_and_numa_node_index_filled();
+    return thread_current_numa_node_index;
+}
+
+static inline uint16_t thread_get_current_core_index() {
+    thread_ensure_core_index_and_numa_node_index_filled();
+    return thread_current_core_index;
+}
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR improves the FFMA startup time shifting the initialization of the ffma slots to when they are needed instead of at the startup.

This is crucial in reducing cold start times as instead of initializing 10k/50k/100k+ blocks it just initializes 16, leaving the initialization of the remaining after these first 16 will be requested.
The slots are always initialized in groups of 16.