### PR TITLE
Fix ffma concurrent deallocation

### DIFF
--- a/src/data_structures/queue_mpmc/queue_mpmc.h
+++ b/src/data_structures/queue_mpmc/queue_mpmc.h
@@ -49,7 +49,17 @@ struct queue_mpmc {
 
 queue_mpmc_t *queue_mpmc_init();
 
-void queue_mpmc_free(queue_mpmc_t *queue_mpmc);
+void queue_mpmc_init_noalloc(
+        queue_mpmc_t *);
+
+void queue_mpmc_free(
+        queue_mpmc_t *queue_mpmc);
+
+void queue_mpmc_free_noalloc(
+        queue_mpmc_t *queue_mpmc);
+
+void queue_mpmc_free_nodes(
+        queue_mpmc_t *queue_mpmc);
 
 bool queue_mpmc_push(
         queue_mpmc_t *queue_mpmc,

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -147,7 +147,7 @@ ffma_t* ffma_init(
         size_t object_size) {
     assert(object_size <= FFMA_OBJECT_SIZE_MAX);
 
-    ffma_t* ffma = (ffma_t*)xalloc_alloc_zero(sizeof(ffma_t));
+    ffma_t* ffma = (ffma_t*)xalloc_mmap_alloc(sizeof(ffma_t));
 
     ffma->object_size = object_size;
     ffma->slots = double_linked_list_init();

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -154,7 +154,7 @@ ffma_t* ffma_init(
     ffma->slices = double_linked_list_init();
     ffma->metrics.slices_inuse_count = 0;
     ffma->metrics.objects_inuse_count = 0;
-    ffma->free_ffma_slots_queue_from_other_threads = queue_mpmc_init();
+    queue_mpmc_init_noalloc(&ffma->free_ffma_slots_queue_from_other_threads);
 
 #if FFMA_DEBUG_ALLOCS_FREES == 1
     ffma->thread_id = syscall(SYS_gettid);
@@ -184,13 +184,13 @@ bool ffma_free(
     // shuts-down.
     uint32_t objects_inuse_count =
             ffma->metrics.objects_inuse_count -
-            queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads);
+            queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads);
     if (objects_inuse_count > 0) {
         return false;
     }
 
     // Clean up the free list
-    while((ffma_slot = queue_mpmc_pop(ffma->free_ffma_slots_queue_from_other_threads)) != NULL) {
+    while((ffma_slot = queue_mpmc_pop(&ffma->free_ffma_slots_queue_from_other_threads)) != NULL) {
         ffma_slice_t* ffma_slice = ffma_slice_from_memptr(ffma_slot->data.memptr);
         ffma_mem_free_slot_in_current_thread(ffma, ffma_slice, ffma_slot);
     }
@@ -214,10 +214,11 @@ bool ffma_free(
 #if FFMA_DEBUG_ALLOCS_FREES == 1
     // Do nothing really, it's to ensure that the memory will get always freed if the condition checked is not 1
 #else
-
-    queue_mpmc_free(ffma->free_ffma_slots_queue_from_other_threads);
-    xalloc_free(ffma);
+    queue_mpmc_free_noalloc(&ffma->free_ffma_slots_queue_from_other_threads);
 #endif
+
+    // Never ever free ffma itself as another thread might be trying to access its data meanwhile checking if it has
+    // to free it or not
 
     return true;
 }
@@ -357,7 +358,7 @@ void ffma_mem_free_slot_in_current_thread(
 void ffma_mem_free_slot_different_thread(
         ffma_t* ffma,
         ffma_slot_t* ffma_slot) {
-    if (unlikely(!queue_mpmc_push(ffma->free_ffma_slots_queue_from_other_threads, ffma_slot))) {
+    if (unlikely(!queue_mpmc_push(&ffma->free_ffma_slots_queue_from_other_threads, ffma_slot))) {
         FATAL(TAG, "Can't pass the slot to free to the owning thread, unable to continue");
     }
 
@@ -369,7 +370,7 @@ void ffma_mem_free_slot_different_thread(
         // If the last object pushed was the last that needed to be freed, ffma_free can be invoked.
         bool can_free_ffma =
                 (ffma->metrics.objects_inuse_count -
-                queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads)) == 0;
+                queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads)) == 0;
         if (unlikely(can_free_ffma)) {
             ffma_free(ffma);
         }
@@ -415,7 +416,7 @@ void ffma_mem_free(
     bool is_different_thread = ffma != ffma_thread_cache_get_ffma_by_size(
             ffma->object_size);
     if (unlikely(is_different_thread)) {
-        // This is slow path as it involves always atomic ops and potentially also a spinlock
+        // This is slow path as it involves always atomic ops
         ffma_mem_free_slot_different_thread(ffma, ffma_slot);
     } else {
         ffma_mem_free_slot_in_current_thread(ffma, ffma_slice, ffma_slot);

--- a/tests/unit_tests/test-ffma.cpp
+++ b/tests/unit_tests/test-ffma.cpp
@@ -366,10 +366,10 @@ TEST_CASE("ffma.c", "[ffma]") {
             int value = 0;
             ffma_t* ffma = ffma_init(128);
 
-            REQUIRE(queue_mpmc_push(ffma->free_ffma_slots_queue_from_other_threads, &value));
+            REQUIRE(queue_mpmc_push(&ffma->free_ffma_slots_queue_from_other_threads, &value));
             REQUIRE(!ffma_free(ffma));
 
-            REQUIRE(queue_mpmc_pop(ffma->free_ffma_slots_queue_from_other_threads) != NULL);
+            REQUIRE(queue_mpmc_pop(&ffma->free_ffma_slots_queue_from_other_threads) != NULL);
             REQUIRE(ffma_free(ffma));
         }
     }
@@ -574,7 +574,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             void *memptr = ffma_mem_alloc_internal(ffma, ffma_predefined_object_sizes[0]);
 
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->tail->data == memptr);
             REQUIRE(((ffma_slot_t *) ffma->slots->tail)->data.available == false);
             REQUIRE(((ffma_slot_t *) ffma->slots->head)->data.available == true);
@@ -599,7 +599,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             }
 
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slices->count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count == slots_count);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_inuse_count == slots_count);
@@ -625,7 +625,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             }
 
             REQUIRE(ffma->metrics.slices_inuse_count == 2);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slices->head != ffma->slices->tail);
             REQUIRE(ffma->slices->head->next == ffma->slices->tail);
             REQUIRE(ffma->slices->head == ffma->slices->tail->prev);
@@ -645,6 +645,8 @@ TEST_CASE("ffma.c", "[ffma]") {
     SECTION("ffma_mem_free") {
         ffma_t *ffma = ffma_init(ffma_predefined_object_sizes[0]);
         ffma_t *ffmas[] = { ffma };
+        ffma_t *ffma2 = ffma_init(ffma_predefined_object_sizes[0]);
+        ffma_t *ffmas2[] = { ffma2 };
 
         ffma_thread_cache_set(ffmas);
 
@@ -655,7 +657,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count ==
                 FFMA_PREINIT_SOME_SLOTS_COUNT);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head->data != memptr);
             REQUIRE(ffma->slots->tail->data == memptr);
 
@@ -665,7 +667,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count ==
                 FFMA_PREINIT_SOME_SLOTS_COUNT);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head != nullptr);
             REQUIRE(ffma->slots->tail != nullptr);
         }
@@ -677,7 +679,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count ==
                 FFMA_PREINIT_SOME_SLOTS_COUNT);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head->data != memptr);
             REQUIRE(ffma->slots->tail->data == memptr);
 
@@ -687,7 +689,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count ==
                 FFMA_PREINIT_SOME_SLOTS_COUNT);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head != nullptr);
             REQUIRE(ffma->slots->tail != nullptr);
         }
@@ -711,7 +713,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
             REQUIRE(ffma->metrics.objects_inuse_count == slots_count);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count == slots_count);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head != nullptr);
             REQUIRE(ffma->slots->tail != nullptr);
 
@@ -730,7 +732,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->metrics.objects_inuse_count == 0);
             REQUIRE(ffma->metrics.slices_inuse_count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count == slots_count);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head != nullptr);
             REQUIRE(ffma->slots->tail != nullptr);
         }
@@ -765,7 +767,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->slices->count == 2);
             REQUIRE(((ffma_slice_t *) ffma->slices->tail)->data.metrics.objects_inuse_count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->tail)->data.metrics.objects_initialized_count == FFMA_PREINIT_SOME_SLOTS_COUNT);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head != nullptr);
             REQUIRE(ffma->slots->tail != nullptr);
 
@@ -779,18 +781,21 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma->slices->count == 1);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_inuse_count == 0);
             REQUIRE(((ffma_slice_t *) ffma->slices->head)->data.metrics.objects_initialized_count == slots_count - 1);
-            REQUIRE(queue_mpmc_get_length(ffma->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma->slots->head != nullptr);
             REQUIRE(ffma->slots->tail != nullptr);
         }
 
         SECTION("free via different ffma") {
-            ffma_t *ffma2 = ffma_init(ffma_predefined_object_sizes[0]);
+            // Set the threads cache to ffmas2
+            ffma_thread_cache_set(ffmas2);
 
-            void *memptr1 = ffma_mem_alloc_internal(ffma2, ffma_predefined_object_sizes[0]);
+            void *memptr1 = ffma_mem_alloc(ffma_predefined_object_sizes[0]);
             REQUIRE(ffma2->metrics.objects_inuse_count == 1);
             REQUIRE(ffma2->metrics.slices_inuse_count == 1);
 
+            // Revert the threads cache to ffams
+            ffma_thread_cache_set(ffmas);
             ffma_mem_free(memptr1);
 
             REQUIRE(ffma2->metrics.objects_inuse_count == 1);
@@ -798,7 +803,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE(ffma2->metrics.slices_inuse_count == 1);
             REQUIRE(ffma->metrics.slices_inuse_count == 0);
 
-            REQUIRE(queue_mpmc_get_length(ffma2->free_ffma_slots_queue_from_other_threads) == 1);
+            REQUIRE(queue_mpmc_get_length(&ffma2->free_ffma_slots_queue_from_other_threads) == 1);
 
             // slots from the queue are used if all the items in the hugepages have been used so it's necessary to
             // fill the hugepage allocated
@@ -818,12 +823,12 @@ TEST_CASE("ffma.c", "[ffma]") {
             }
 
             // All the previous allocation must have come out from the local list of slots
-            REQUIRE(queue_mpmc_get_length(ffma2->free_ffma_slots_queue_from_other_threads) == 1);
+            REQUIRE(queue_mpmc_get_length(&ffma2->free_ffma_slots_queue_from_other_threads) == 1);
 
             // This last allocation must come from the free list
             void *memptr2 = ffma_mem_alloc_internal(ffma2, ffma_predefined_object_sizes[0]);
 
-            REQUIRE(queue_mpmc_get_length(ffma2->free_ffma_slots_queue_from_other_threads) == 0);
+            REQUIRE(queue_mpmc_get_length(&ffma2->free_ffma_slots_queue_from_other_threads) == 0);
             REQUIRE(ffma2->metrics.objects_inuse_count == slots_count);
             REQUIRE(ffma2->metrics.slices_inuse_count == 1);
             REQUIRE(memptr1 == memptr2);
@@ -834,7 +839,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             }
             ffma_mem_free(memptr2);
 
-            REQUIRE(queue_mpmc_get_length(ffma2->free_ffma_slots_queue_from_other_threads) == slots_count);
+            REQUIRE(queue_mpmc_get_length(&ffma2->free_ffma_slots_queue_from_other_threads) == slots_count);
 
             REQUIRE(ffma_free(ffma2));
         }


### PR DESCRIPTION
The FFMA allocators owned by the threads don't normally get de-allocated unless a thread is terminated which isn't something that happens in cachegrand unless the service is entirely terminated.

In the tests though that's a different story, FFMA is continuously allocated and de-allocated as part of the testing framework and,under some extreme contention, it might happen that at the end of the multi-threaded tests more than 1 thread will try to de-allocate the same FFMA allocator owned by another thread that was able to terminate succesfully.

In this case a race condition might be triggered which this PR patches as follow:
- queue_mpmc is now embedded in ffma_t instead of being a pointer
- ffma_t is allocated via mmap
- ffma_t is never de-allocated to guarantee that if there is thread sending back memory to free during the shutdown it's there

Of course this will lead the memory loss of a page but we don't really need to care, cachegrand terminates the worker threads only during the shutdown and therefore the memory loss would happen only during that phase.