### PR TITLE
Improve startup reporting

### DIFF
--- a/src/program.c
+++ b/src/program.c
@@ -754,12 +754,13 @@ int program_main(
     // later stage
     program_setup_initial_log_sink_console();
 
+    // Report some general information before starting
     program_startup_report();
 
+    // Load the configuration
     if ((program_context->config = program_parse_arguments_and_load_config(argc, argv)) == NULL) {
         goto end;
     }
-
 
     // Ensure the minimum kernel version is supported
     if (program_ensure_min_kernel_version() == false) {

--- a/src/program_startup_report.c
+++ b/src/program_startup_report.c
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/sysinfo.h>
+#include <sys/utsname.h>
+
+#include "misc.h"
+#include "intrinsics.h"
+#include "clock.h"
+#include "xalloc.h"
+#include "config.h"
+#include "log/log.h"
+#include "network/network_tls.h"
+
+#include "program_startup_report.h"
+
+#define TAG "program_startup_report"
+
+void program_startup_report_build() {
+    LOG_I(
+            TAG,
+            "%s version %s (built on %s)",
+            CACHEGRAND_CMAKE_CONFIG_NAME,
+            CACHEGRAND_CMAKE_CONFIG_VERSION_GIT,
+            CACHEGRAND_CMAKE_CONFIG_BUILD_DATE_TIME);
+    LOG_I(
+            TAG,
+            "> %s build, compiled using %s v%s",
+            CACHEGRAND_CMAKE_CONFIG_BUILD_TYPE,
+            CACHEGRAND_CMAKE_CONFIG_C_COMPILER_ID,
+            CACHEGRAND_CMAKE_CONFIG_C_COMPILER_VERSION);
+    LOG_I(
+            TAG,
+            "> Hashing algorithm in use %s",
+            CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2
+            ? "t1ha2"
+            : (CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3
+               ? "xxh3" :
+               "crc32c"));
+}
+
+void program_startup_report_machine_uname() {
+    struct utsname utsname;
+    if (uname(&utsname) == 0) {
+        LOG_I(
+                TAG,
+                "> Running on %s %s %s %s %s",
+                utsname.sysname,
+                utsname.nodename,
+                utsname.release,
+                utsname.version,
+                utsname.machine);
+    } else {
+        LOG_W(
+                TAG,
+                "> Running on Failed to get the machine information");
+    }
+}
+
+void program_startup_report_machine_memory() {
+    struct sysinfo system_info;
+
+    if (sysinfo(&system_info) == 0) {
+        LOG_I(
+                TAG,
+                "> Memory: %ld MB total, %ld MB swap total",
+                system_info.totalram / 1024 / 1024,
+                system_info.totalswap / 1024 / 1024);
+    } else {
+        LOG_W(
+                TAG,
+                "> Memory: Failed to get the memory information");
+    }
+}
+
+void program_startup_report_machine_tls() {
+    LOG_I(
+            TAG,
+            "> TLS: %s (kernel offloading %s)",
+            network_tls_mbedtls_version(),
+            network_tls_is_ulp_tls_supported() ? "enabled" : "disabled");
+    if (!network_tls_is_ulp_tls_supported()) {
+        LOG_I(
+                TAG,
+                "       Try to load the tls kernel module with \"modprobe tls\" and restart %s",
+                CACHEGRAND_CMAKE_CONFIG_NAME);
+    }
+}
+
+void program_startup_report_machine_clock() {
+    LOG_I(
+            TAG,
+            "> Realtime clock source <POSIX>, resolution <%ld ms>",
+            clock_realtime_coarse_get_resolution_ms());
+    LOG_I(
+            TAG,
+            "> Monotonic clock source <Hardware (TSC)>, %scpu cycles per second <%0.02lf GHz>",
+            intrinsics_frequency_max_estimated() ? "estimated " : "",
+            (double)intrinsics_frequency_max() / 1000000000.0f);
+}
+
+void program_startup_report() {
+    program_startup_report_build();
+    program_startup_report_machine_uname();
+    program_startup_report_machine_memory();
+    program_startup_report_machine_tls();
+    program_startup_report_machine_clock();
+}

--- a/src/program_startup_report.h
+++ b/src/program_startup_report.h
@@ -1,0 +1,14 @@
+#ifndef CACHEGRAND_PROGRAM_STARTUP_REPORT_H
+#define CACHEGRAND_PROGRAM_STARTUP_REPORT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void program_startup_report();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_PROGRAM_STARTUP_REPORT_H


### PR DESCRIPTION
This PR improves the information reported at the beginning, here the new output

```
$ ./cachegrand-server -c /etc/cachegrand.yaml
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] cachegrand-server version v0.1.5.1-51-g60bebd96-dirty (built on 2023-04-13T18:42:45Z)
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > Debug build, compiled using gcc v12.2.0
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > Hashing algorithm in use t1ha2
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > Running on Linux daalbano-lnx-pc 5.19.0-38-generic #39-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar 17 17:33:16 UTC 2023 x86_64
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > Memory: 64210 MB total, 1955 MB swap total
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > TLS: mbed TLS 2.28.1 (kernel offloading enabled)
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > Realtime clock source <POSIX>, resolution <4 ms>
[2023-03-13T18:46:15Z][INFO       ][program_startup_report] > Monotonic clock source <Hardware (TSC)>, estimated cpu cycles per second <4.20 GHz>
[2023-03-13T18:46:15Z][INFO       ][config] Loading the configuration from /etc/cachegrand.yaml
...
```

Here the previous output
```
$ ./cachegrand-server -c /etc/cachegrand.yaml
[2023-03-13T18:47:57Z][INFO       ][config] Loading the configuration from /etc/cachegrand.yaml
[2023-03-13T18:47:57Z][INFO       ][program] cachegrand-server version v0.1.5.1-51-g5b6a4889-dirty (built on 2023-04-13T18:47:53Z)
[2023-03-13T18:47:57Z][INFO       ][program] > Debug build, compiled using gcc v12.2.0
[2023-03-13T18:47:57Z][INFO       ][program] > Hashing algorithm in use t1ha2
[2023-03-13T18:47:57Z][INFO       ][program] > TLS: mbed TLS 2.28.1 (kernel offloading enabled)
[2023-03-13T18:47:57Z][INFO       ][program] > Clock resolution: 4 ms
```