### PR TITLE
Try to catch a transient test config failure

### DIFF
--- a/tests/unit_tests/test-config.cpp
+++ b/tests/unit_tests/test-config.cpp
@@ -1923,6 +1923,16 @@ TEST_CASE("config.c", "[config]") {
         SECTION("CYAML_LOG_DEBUG") {
             char* str_cmp = "[DEBUG      ][config] test log message: test argument\n";
             test_config_internal_cyaml_log_wrapper(CYAML_LOG_DEBUG, nullptr, "test log message: %s", "test argument");
+            if (strcmp(str_cmp, test_config_internal_log_sink_printer_data + 22) != 0) {
+                fprintf(
+                        stderr,
+                        "'%s' (%lu) != '%s' (%lu)\n",
+                        str_cmp,
+                        strlen(str_cmp),
+                        test_config_internal_log_sink_printer_data + 22,
+                        strlen(test_config_internal_log_sink_printer_data + 22));
+                fflush(stderr);
+            }
             REQUIRE(strcmp(str_cmp, test_config_internal_log_sink_printer_data + 22) == 0);
         }
 


### PR DESCRIPTION
This PR adds some debug code to a test to try to catch a very transient failure when running tests on the github agents.