### PR TITLE
Don't check the hard limit on each insert

### DIFF
--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1252,11 +1252,6 @@ bool storage_db_op_set(
     storage_db_entry_index_t *entry_index = NULL;
     bool result_res = false;
 
-    if (storage_db_will_new_entry_hit_hard_limit(db, value_chunk_sequence->size)) {
-        LOG_V(TAG, "Unable to set the key because it would exceed the hard limit");
-        goto end;
-    }
-
     entry_index = storage_db_entry_index_ring_buffer_new(db);
 
     // Set up the key if necessary
@@ -1383,11 +1378,6 @@ bool storage_db_op_rmw_commit_update(
         storage_db_expiry_time_ms_t expiry_time_ms) {
     storage_db_entry_index_t *entry_index = NULL;
     bool result_res = false;
-
-    if (storage_db_will_new_entry_hit_hard_limit(db, value_chunk_sequence->size)) {
-        LOG_V(TAG, "Unable to set the key because it would exceed the hard limit");
-        goto end;
-    }
 
     entry_index = storage_db_entry_index_ring_buffer_new(db);
 

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -572,23 +572,6 @@ static inline double storage_db_keys_eviction_calculate_close_to_hard_limit_perc
             keys_count_close_to_hard_limit_percentage : data_size_close_to_hard_limit_percentage;
 }
 
-static inline bool storage_db_will_new_entry_hit_hard_limit(
-        storage_db_t *db,
-        uint64_t new_entry_size) {
-    uint64_t keys_count = storage_db_op_get_keys_count(db);
-    uint64_t data_size = storage_db_op_get_data_size(db);
-
-    if (db->limits.keys_count.hard_limit > 0 && keys_count + 1 > db->limits.keys_count.hard_limit) {
-        return true;
-    }
-
-    if (db->limits.data_size.hard_limit > 0 && data_size + new_entry_size > db->limits.data_size.hard_limit) {
-        return true;
-    }
-
-    return false;
-}
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When inserting keys, don't check if they will hit the hardlimit on each single insert as the keys eviction fiber has already a mechanism to enter an --extreme-- purging mode if the the hard limit is going to be hit very soon.

This check literally reduces the performances by 50% when doing pipelines inserts, has an impact as well when doing normal sets.