### PR TITLE
If chunk if is null it has already been freed, skip it

### DIFF
--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -419,6 +419,10 @@ bool storage_db_chunk_data_pre_allocate(
 void storage_db_chunk_data_free(
         storage_db_t *db,
         storage_db_chunk_info_t *chunk_info) {
+    if (chunk_info == NULL) {
+        return;
+    }
+
     if (db->config->backend_type == STORAGE_DB_BACKEND_TYPE_MEMORY) {
         ffma_mem_free(chunk_info->memory.chunk_data);
     } else {


### PR DESCRIPTION
Under extreme high pressure it's possible that a chunk_info coming from the list of garbage collected ones has already been freed and it must not be freed again.