### PR TITLE
Allocate the memory via mmap instead of ffma

### DIFF
--- a/src/data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h
+++ b/src/data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h
@@ -33,6 +33,7 @@ typedef struct slots_bitmap_mpmc slots_bitmap_mpmc_t;
 struct slots_bitmap_mpmc {
     size_t size;
     size_t shards_count;
+    size_t allocation_size;
     slots_bitmap_mpmc_shard_t shards[0];
     uint8_volatile_t shards_used_slots[0];
 };


### PR DESCRIPTION
To allow allocations larger than 64k use mmap directly instead of ffma, there are no small bitmaps allocated internally so in general there will be no memory wasted or will be a very small percentage (1 page - 1 byte).