### PR TITLE
Update dockerfiles

### DIFF
--- a/tools/docker/build/Dockerfile
+++ b/tools/docker/build/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update -y \
         libnuma1 libnuma-dev \
         libcurl4-openssl-dev libcurl4 \
         libyaml-0-2 libyaml-dev \
-        libmbedtls-dev libmbedtls14 \
+        libmbedtls-dev libmbedtls14 liblzf1 liblzf-dev \
         libpcre2-8-0 libpcre2-dev \
         libjson-c-dev \
         lcov gcovr \

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update -y \
         libnuma1 libnuma-dev \
         libcurl4-openssl-dev libcurl4 \
         libyaml-0-2 libyaml-dev \
-        libmbedtls-dev libmbedtls14 \
+        libmbedtls-dev libmbedtls14 liblzf1 liblzf-dev \
         lcov gcovr \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -65,7 +65,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         apt-utils \
     && apt-get install -y --no-install-recommends \
-        libnuma1 libyaml-0-2 libcurl4 libmbedtls14 libatomic1 openssl \
+        libnuma1 libyaml-0-2 libcurl4 libmbedtls14 libatomic1 openssl liblzf1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -4,6 +4,13 @@
 # This software may be modified and distributed under the terms
 # of the BSD license. See the LICENSE file for details.
 
+# Build commands
+#docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#docker buildx create --name cachegrand-builder --platform linux/amd64 --use
+#docker buildx create --name cachegrand-builder --append --platform linux/arm64,linux/arm/v8 ssh://cg-server-arm64-01
+#docker buildx build --pull --push --platform linux/amd64,linux/arm64/v8 --tag cachegrand/cachegrand-server:latest --tag cachegrand/cachegrand-server:v0.2.0 .
+#docker buildx rm --name cachegrand-builder
+
 FROM ubuntu:22.04 AS builder
 
 # General dpkg and packages settings


### PR DESCRIPTION
The dockerfiles for the build & release docker images weren't updated after introducing liblzf as additional dependency.

This PR adds liblzf1 and liblzf-def, where needed, to the list of dependencies installed as part of the docker image build process.