### PR TITLE
Add function/line allocation tracking and support release mode in FFMA

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,7 +167,7 @@ target_compile_options(
         PUBLIC
         -include cmake_config.h)
 
-if (FFMA_DEBUG_ALLOCS_FREES)
+if (FFMA_TRACK_ALLOCS_FREES)
     target_compile_options(
             cachegrand-internal
             PUBLIC

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -20,6 +20,10 @@
 #include <string.h>
 #include <stdatomic.h>
 
+#if FFMA_DEBUG_ALLOCS_FREES == 1
+#include <pthread.h>
+#endif
+
 #include "misc.h"
 #include "exttypes.h"
 #include "memory_fences.h"
@@ -81,8 +85,7 @@ FUNCTION_DTOR(ffma_init_dtor, {
 })
 
 #if FFMA_DEBUG_ALLOCS_FREES == 1
-void ffma_debug_allocs_frees_end() {
-    ffma_t *ffma;
+void ffma_debug_allocs_frees_end_print_header() {
     fprintf(stdout, "> debug_ffma_list length <%d>\n", queue_mpmc_get_length(debug_ffma_list));
     fflush(stdout);
 
@@ -100,6 +103,10 @@ void ffma_debug_allocs_frees_end() {
             "-------------------------------", "-------------------------------", "-------------------------------",
             "-------------------------------", "-------------------------------", "-------------------------------",
             "-------------------------------", "-------------------------------");
+}
+
+void ffma_debug_allocs_frees_end() {
+    ffma_t *ffma;
 
     bool header_printed = false;
     pid_t previous_thread_id = 0;
@@ -398,7 +405,7 @@ void ffma_mem_free_wrapped(
         uint32_t freed_by_line) {
 #else
 void ffma_mem_free(
-        void* memptr) {
+    void* memptr) {
 #endif
     if (unlikely(memptr == NULL)) {
         return;

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -101,6 +101,7 @@ void ffma_debug_allocs_frees_end() {
             "-------------------------------", "-------------------------------", "-------------------------------",
             "-------------------------------", "-------------------------------");
 
+    bool header_printed = false;
     pid_t previous_thread_id = 0;
     while((ffma = (ffma_t*)queue_mpmc_pop(debug_ffma_list)) != NULL) {
         char thread_id_str[20] = { 0 };
@@ -112,6 +113,11 @@ void ffma_debug_allocs_frees_end() {
 
         if (leaked_object_count == 0) {
             continue;
+        }
+
+        if (header_printed == false) {
+            ffma_debug_allocs_frees_end_print_header();
+            header_printed = true;
         }
 
         fprintf(stdout, "| %-10s | %-20s | %p | %10u | %11u | %10u | %12u | %14u |\n",

--- a/src/memory_allocator/ffma.c
+++ b/src/memory_allocator/ffma.c
@@ -388,21 +388,8 @@ void ffma_mem_free_slot_different_thread(
     if (unlikely(!queue_mpmc_push(&ffma->free_ffma_slots_queue_from_other_threads, ffma_slot))) {
         FATAL(TAG, "Can't pass the slot to free to the owning thread, unable to continue");
     }
-
-    // To determine which thread can clean up the data the code simply checks if objects_inuse_count - length of the
-    // free_ffma_slots_queue queue is equals to 0, if it is this thread can perform the final clean up.
-    // The objects_inuse_count is not atomic but memory fences are in use
-    MEMORY_FENCE_LOAD();
-    if (unlikely(ffma->ffma_freed)) {
-        // If the last object pushed was the last that needed to be freed, ffma_free can be invoked.
-        bool can_free_ffma =
-                (ffma->metrics.objects_inuse_count -
-                queue_mpmc_get_length(&ffma->free_ffma_slots_queue_from_other_threads)) == 0;
-        if (unlikely(can_free_ffma)) {
-            ffma_free(ffma);
-        }
-    }
 }
+
 
 #if FFMA_DEBUG_ALLOCS_FREES == 1
 void ffma_mem_free_wrapped(

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -23,8 +23,8 @@ extern "C" {
 
 #define FFMA_LOG_TAG_INTERNAL "ffma"
 
-#ifndef FFMA_DEBUG_ALLOCS_FREES
-#define FFMA_DEBUG_ALLOCS_FREES 0
+#ifndef FFMA_TRACK_ALLOCS_FREES
+#define FFMA_TRACK_ALLOCS_FREES 0
 #endif
 
 #define FFMA_PREINIT_SOME_SLOTS_COUNT (16)
@@ -73,7 +73,7 @@ struct ffma {
         uint32_volatile_t objects_inuse_count;
     } metrics;
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
     pid_t thread_id;
     char thread_name[101];
 #endif
@@ -97,7 +97,7 @@ typedef union {
 #else
         bool available;
 #endif
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
         struct {
             const char *function;
             uint32_t line;
@@ -123,7 +123,7 @@ typedef union {
     } __attribute__((aligned(64))) data;
 } ffma_slice_t;
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
 void ffma_debug_allocs_frees_end_print_header();
 void ffma_debug_allocs_frees_end();
 #endif
@@ -172,7 +172,7 @@ void ffma_mem_free_slot_different_thread(
         ffma_t* ffma,
         ffma_slot_t* ffma_slot);
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
 #define ffma_mem_realloc(memptr, current_size, new_size, zero_new_memory) \
     ffma_mem_realloc_wrapped(memptr, current_size, new_size, zero_new_memory, __FUNCTION__, __LINE__)
 void* ffma_mem_realloc_wrapped(
@@ -190,7 +190,7 @@ void* ffma_mem_realloc(
         bool zero_new_memory);
 #endif
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
 #define ffma_mem_free(memptr) ffma_mem_free_wrapped(memptr, __FUNCTION__, __LINE__)
 void ffma_mem_free_wrapped(
         void *memptr,
@@ -310,7 +310,7 @@ static inline void ffma_slice_add_some_slots_to_per_thread_metadata_slots(
     }
 }
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
 #define ffma_mem_alloc_internal(ffma, size) ffma_mem_alloc_internal_wrapped(ffma, size, __FUNCTION__, __LINE__)
 __attribute__((malloc))
 static inline void* ffma_mem_alloc_internal_wrapped(
@@ -371,7 +371,7 @@ static inline void* ffma_mem_alloc_internal(
 #endif
 #endif
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
             ffma_slot->data.allocated_freed_by.function = allocated_by_function;
             ffma_slot->data.allocated_freed_by.line = allocated_by_line;
 #endif
@@ -415,7 +415,7 @@ static inline void* ffma_mem_alloc_internal(
 #endif
 #endif
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
     ffma_slot->data.allocated_freed_by.function = allocated_by_function;
     ffma_slot->data.allocated_freed_by.line = allocated_by_line;
 #endif
@@ -426,7 +426,7 @@ static inline void* ffma_mem_alloc_internal(
 }
 
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
 #define ffma_mem_alloc(size) ffma_mem_alloc_wrapped(size, __FUNCTION__, __LINE__)
 __attribute__((malloc))
 static inline void* ffma_mem_alloc_wrapped(
@@ -450,7 +450,7 @@ static inline void* ffma_mem_alloc(
     assert(index < FFMA_PREDEFINED_OBJECT_SIZES_COUNT);
 
     ffma_t *ffma = ffma_thread_cache_get()[index];
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
     memptr = ffma_mem_alloc_internal_wrapped(ffma, size, allocated_by_function, allocated_by_line);
 #else
     memptr = ffma_mem_alloc_internal(ffma, size);
@@ -462,7 +462,7 @@ static inline void* ffma_mem_alloc(
 }
 
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
 #define ffma_mem_alloc_zero(size) ffma_mem_alloc_zero_wrapped(size, __FUNCTION__, __LINE__)
 __attribute__((malloc))
 static inline void* ffma_mem_alloc_zero_wrapped(
@@ -475,7 +475,7 @@ static inline void* ffma_mem_alloc_zero(
     size_t size) {
 #endif
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
     void* memptr = ffma_mem_alloc_wrapped(size, allocated_by_function, allocated_by_line);
 #else
     void* memptr = ffma_mem_alloc(size);

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -66,14 +66,6 @@ struct ffma {
     double_linked_list_t *slots;
     double_linked_list_t *slices;
     queue_mpmc_t free_ffma_slots_queue_from_other_threads;
-
-    // When the thread owning an instance of an allocator is terminated, other threads might still own some memory it
-    // initialized and therefore some support is needed there.
-    // When a thread sends back memory to a thread it has to check if it has been terminated and if yes, process the
-    // free_ffma_slots_queue, free up the  slots, check if the slice owning the
-    // ffma_slot is then empty, and in case return the address sof the page.
-    bool_volatile_t ffma_freed;
-
     uint32_t object_size;
 
     struct {

--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -471,7 +471,7 @@ static inline void* ffma_mem_alloc_zero_wrapped(
         uint32_t allocated_by_line) {
 #else
 __attribute__((malloc))
-static inline void* ffma_mem_alloc(
+static inline void* ffma_mem_alloc_zero(
     size_t size) {
 #endif
 

--- a/src/memory_allocator/ffma_thread_cache.c
+++ b/src/memory_allocator/ffma_thread_cache.c
@@ -30,8 +30,8 @@ FUNCTION_CTOR(ffma_thread_cache_init_ctor, {
 })
 
 ffma_t **ffma_thread_cache_init() {
-    ffma_t **thread_ffmas = (ffma_t**)xalloc_alloc_zero(
-            FFMA_PREDEFINED_OBJECT_SIZES_COUNT * (sizeof(ffma_t*) + 1));
+    size_t size = FFMA_PREDEFINED_OBJECT_SIZES_COUNT * sizeof(ffma_t*);
+    ffma_t **thread_ffmas = (ffma_t**)xalloc_mmap_alloc(size);
 
     for(int i = 0; i < FFMA_PREDEFINED_OBJECT_SIZES_COUNT; i++) {
         uint32_t object_size = ffma_predefined_object_sizes[i];
@@ -43,7 +43,8 @@ ffma_t **ffma_thread_cache_init() {
 
 void ffma_thread_cache_free(
         ffma_t **thread_ffmas) {
-    xalloc_free(thread_ffmas);
+    size_t size = FFMA_PREDEFINED_OBJECT_SIZES_COUNT * sizeof(ffma_t*);
+    xalloc_mmap_free(thread_ffmas, size);
 }
 
 void ffma_thread_cache_thread_local_free(

--- a/src/memory_allocator/ffma_thread_cache.c
+++ b/src/memory_allocator/ffma_thread_cache.c
@@ -26,7 +26,7 @@ static pthread_key_t ffma_thread_cache_destructor_key;
 thread_local ffma_t** thread_local_ffmas = NULL;
 
 FUNCTION_CTOR(ffma_thread_cache_init_ctor, {
-    pthread_key_create(&ffma_thread_cache_destructor_key, ffma_thread_cache_thread_local_free);
+    pthread_key_create(&ffma_thread_cache_destructor_key, NULL);
 })
 
 ffma_t **ffma_thread_cache_init() {
@@ -42,9 +42,7 @@ ffma_t **ffma_thread_cache_init() {
 }
 
 void ffma_thread_cache_free(
-        void *data) {
-    ffma_t **thread_ffmas = data;
-
+        ffma_t **thread_ffmas) {
     for(int i = 0; i < FFMA_PREDEFINED_OBJECT_SIZES_COUNT; i++) {
         uint32_t object_size = ffma_predefined_object_sizes[i];
         uint32_t thread_ffmas_index = ffma_index_by_object_size(object_size);
@@ -52,17 +50,7 @@ void ffma_thread_cache_free(
         thread_ffmas[thread_ffmas_index] = NULL;
     }
 
-    xalloc_free(data);
-}
-
-void ffma_thread_cache_thread_local_free(
-        __attribute__((unused)) void *data) {
-    if (thread_local_ffmas == NULL) {
-        return;
-    }
-
-    ffma_thread_cache_free(thread_local_ffmas);
-    thread_local_ffmas = NULL;
+    xalloc_free(thread_ffmas);
 }
 
 ffma_t** ffma_thread_cache_get() {

--- a/src/memory_allocator/ffma_thread_cache.h
+++ b/src/memory_allocator/ffma_thread_cache.h
@@ -14,6 +14,9 @@ ffma_t **ffma_thread_cache_init();
 void ffma_thread_cache_free(
         ffma_t **thread_ffmas);
 
+void ffma_thread_cache_thread_local_free(
+        __attribute__((unused)) void *data);
+
 ffma_t **ffma_thread_cache_get();
 
 void ffma_thread_cache_set(

--- a/src/memory_allocator/ffma_thread_cache.h
+++ b/src/memory_allocator/ffma_thread_cache.h
@@ -12,10 +12,7 @@ extern thread_local ffma_t **thread_local_ffmas;
 ffma_t **ffma_thread_cache_init();
 
 void ffma_thread_cache_free(
-        void *data);
-
-void ffma_thread_cache_thread_local_free(
-        __attribute__((unused)) void *data);
+        ffma_t **thread_ffmas);
 
 ffma_t **ffma_thread_cache_get();
 

--- a/tests/unit_tests/test-ffma.cpp
+++ b/tests/unit_tests/test-ffma.cpp
@@ -381,7 +381,7 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE((void*)slot.data.memptr == slot.double_linked_list_item.data);
         }
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
         SECTION("ensure that ffma_slot_t is 48 bytes") {
             REQUIRE(sizeof(ffma_slot_t) == 48);
         }

--- a/tests/unit_tests/test-ffma.cpp
+++ b/tests/unit_tests/test-ffma.cpp
@@ -336,42 +336,7 @@ TEST_CASE("ffma.c", "[ffma]") {
         REQUIRE(ffma->slots->count == 0);
         REQUIRE(ffma->slices->count == 0);
 
-        REQUIRE(ffma_free(ffma));
-    }
-
-    SECTION("ffma_free") {
-        SECTION("without objects allocated") {
-            ffma_t* ffma = ffma_init(128);
-
-            REQUIRE(ffma->object_size == 128);
-            REQUIRE(ffma->metrics.objects_inuse_count == 0);
-            REQUIRE(ffma->metrics.slices_inuse_count == 0);
-            REQUIRE(ffma->slots->count == 0);
-            REQUIRE(ffma->slices->count == 0);
-
-            REQUIRE(ffma_free(ffma));
-        }
-
-        SECTION("with objects allocated - locally") {
-            ffma_t* ffma = ffma_init(128);
-
-            ffma->metrics.objects_inuse_count = 1;
-            REQUIRE(!ffma_free(ffma));
-
-            ffma->metrics.objects_inuse_count = 0;
-            REQUIRE(ffma_free(ffma));
-        }
-
-        SECTION("with objects allocated - in free list") {
-            int value = 0;
-            ffma_t* ffma = ffma_init(128);
-
-            REQUIRE(queue_mpmc_push(&ffma->free_ffma_slots_queue_from_other_threads, &value));
-            REQUIRE(!ffma_free(ffma));
-
-            REQUIRE(queue_mpmc_pop(&ffma->free_ffma_slots_queue_from_other_threads) != NULL);
-            REQUIRE(ffma_free(ffma));
-        }
+        ffma_free(ffma);
     }
 
     SECTION("ffma_index_by_object_size") {
@@ -416,9 +381,15 @@ TEST_CASE("ffma.c", "[ffma]") {
             REQUIRE((void*)slot.data.memptr == slot.double_linked_list_item.data);
         }
 
+#if FFMA_DEBUG_ALLOCS_FREES == 1
+        SECTION("ensure that ffma_slot_t is 48 bytes") {
+            REQUIRE(sizeof(ffma_slot_t) == 48);
+        }
+#else
         SECTION("ensure that ffma_slot_t is 32 bytes to be cache-aligned") {
             REQUIRE(sizeof(ffma_slot_t) == 32);
         }
+#endif
     }
 
     SECTION("ffma_slice_calculate_usable_memory_size") {
@@ -841,7 +812,7 @@ TEST_CASE("ffma.c", "[ffma]") {
 
             REQUIRE(queue_mpmc_get_length(&ffma2->free_ffma_slots_queue_from_other_threads) == slots_count);
 
-            REQUIRE(ffma_free(ffma2));
+            ffma_free(ffma2);
         }
 
         ffma_free(ffma);

--- a/tools/cmake/build-types/build-types.cmake
+++ b/tools/cmake/build-types/build-types.cmake
@@ -13,6 +13,7 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-ggdb3>)
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     set(CMAKE_VERBOSE_MAKEFILE ON)
     add_definitions(-DDEBUG=1)
+    add_definitions(-DFFMA_DEBUG_ALLOCS_FREES=1)
 
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-O0>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-O0>)

--- a/tools/cmake/build-types/build-types.cmake
+++ b/tools/cmake/build-types/build-types.cmake
@@ -13,7 +13,7 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-ggdb3>)
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     set(CMAKE_VERBOSE_MAKEFILE ON)
     add_definitions(-DDEBUG=1)
-    add_definitions(-DFFMA_DEBUG_ALLOCS_FREES=1)
+    add_definitions(-DFFMA_TRACK_ALLOCS_FREES=1)
 
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-O0>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-O0>)

--- a/tools/cmake/options.cmake
+++ b/tools/cmake/options.cmake
@@ -6,7 +6,7 @@
 
 option(BUILD_TESTS "Build Tests" 0)
 option(BUILD_INTERNAL_BENCHES "Build Internal Benches" 0)
-option(FFMA_DEBUG_ALLOCS_FREES "Enable the fast fixed memory allocator allocs/frees debugging" 0)
+option(FFMA_TRACK_ALLOCS_FREES "Enable the fast fixed memory allocator allocs/frees debugging" 0)
 
 option(USE_HASH_ALGORITHM_XXH3 "Use xxh3 (xxHash) as hash algorithm for the hashtable" 0)
 option(USE_HASH_ALGORITHM_T1HA2 "Use t1ha2 as hash algorithm for the hashtable" 0)


### PR DESCRIPTION
This PR improves the memory allocation / freeing tracking in FFMA and add its support to the release mode.

The implementation is fairly simple, it doesn't store entire entire stack trace but just a pointer to the function name and the line number adding a total of 12 bytes to each ffma_slot_t entry.

The tracking is done leveraging __FUNCTION__ and __LINE__ using some defines to wrap the underlying invocations.

At the end cachegrand's execution now if there are memory leaks these are printed out.

Also FFMA is not freed anymore as it doesn't make sense to free it, it's the memory allocator and keeping around the basic data structure allows better tracking of the memory leaks and avoid issues with threads trying to write to freed FFMA instances (which is bad :)).

This new feature has allowed to discover some memory leaks that are going to be fixed with ad-hoc PRs.