### PR TITLE
Use volatile for hastable_key_data_t and hashtable_key_size_t

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable.h
+++ b/src/data_structures/hashtable/mcmp/hashtable.h
@@ -44,7 +44,9 @@ typedef uint8_t hashtable_chunk_slot_index_t;
 typedef hashtable_bucket_index_t hashtable_bucket_count_t;
 typedef hashtable_chunk_index_t hashtable_chunk_count_t;
 typedef uint32_t hashtable_key_size_t;
+typedef _Volatile(hashtable_key_size_t) hashtable_key_size_volatile_t;
 typedef char hashtable_key_data_t;
+typedef _Volatile(hashtable_key_data_t) hashtable_key_data_volatile_t;
 typedef uintptr_t hashtable_value_data_t;
 
 typedef _Volatile(uint32_t) hashtable_slot_id_volatile_t;
@@ -88,8 +90,8 @@ typedef _Volatile(hashtable_key_value_t) hashtable_key_value_volatile_t;
 struct hashtable_key_value {
     union {                                     // union 23 bytes (HASHTABLE_KEY_INLINE_MAX_LENGTH must match this size)
         struct {
-            hashtable_key_size_t size;          // 4 bytes
-            hashtable_key_data_t* data;         // 8 bytes
+            hashtable_key_size_volatile_t size;          // 4 bytes
+            hashtable_key_data_volatile_t* data;         // 8 bytes
         } __attribute__((packed)) external_key;
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         struct {

--- a/src/data_structures/hashtable/mcmp/hashtable_data.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.c
@@ -110,7 +110,7 @@ void hashtable_mcmp_data_keys_free(
             continue;
         }
 
-        xalloc_free(key_value->external_key.data);
+        xalloc_free((hashtable_key_data_t*)key_value->external_key.data);
     }
 }
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
@@ -127,7 +127,7 @@ bool hashtable_mcmp_op_delete(
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
             if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value_flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
 #endif
-            xalloc_free(key_value->external_key.data);
+            xalloc_free((hashtable_key_data_t*)key_value->external_key.data);
             key_value->external_key.data = NULL;
             key_value->external_key.size = 0;
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
@@ -223,7 +223,7 @@ bool hashtable_mcmp_op_delete_by_index(
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value_flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
 #endif
-        xalloc_free(key_value->external_key.data);
+        xalloc_free((hashtable_key_data_t*)key_value->external_key.data);
         key_value->external_key.data = NULL;
         key_value->external_key.size = 0;
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
@@ -33,7 +33,7 @@ bool hashtable_mcmp_op_get_key(
         hashtable_bucket_index_t bucket_index,
         hashtable_key_data_t **key,
         hashtable_key_size_t *key_size) {
-    char *source_key = NULL;
+    volatile char *source_key = NULL;
     size_t source_key_size = 0;
     hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(bucket_index);
     hashtable_chunk_slot_index_t chunk_slot_index = HASHTABLE_TO_CHUNK_SLOT_INDEX(bucket_index);
@@ -68,7 +68,7 @@ bool hashtable_mcmp_op_get_key(
 
     *key_size = source_key_size;
     *key = xalloc_alloc(source_key_size + 1);
-    memcpy(*key, source_key, source_key_size);
+    memcpy(*key, (char*)source_key, source_key_size);
     (*key)[source_key_size] = 0;
 
     // Validate that the hash and the key length in the bucket haven't changed or that the bucket has been deleted in

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.c
@@ -153,7 +153,7 @@ void hashtable_mcmp_op_rmw_commit_delete(
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
         if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value_flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
 #endif
-        xalloc_free(rmw_status->key_value->external_key.data);
+        xalloc_free((hashtable_key_data_t*)rmw_status->key_value->external_key.data);
         rmw_status->key_value->external_key.data = NULL;
         rmw_status->key_value->external_key.size = 0;
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -229,8 +229,8 @@ bool CONCAT(hashtable_mcmp_support_op_search_key_or_create_new, CACHEGRAND_HASHT
     hashtable_chunk_slot_index_t chunk_slot_index;
     hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk;
     hashtable_key_value_volatile_t* key_value;
-    volatile hashtable_key_data_t* found_key;
-    hashtable_key_size_t found_key_compare_size;
+    hashtable_key_data_volatile_t* found_key;
+    hashtable_key_size_volatile_t found_key_compare_size;
     uint32_t skip_indexes_mask;
     bool found = false;
     bool found_chunk_with_freespace = false;

--- a/src/program.c
+++ b/src/program.c
@@ -852,7 +852,7 @@ end:
     // Final cleanup
     program_cleanup(program_context);
 
-#if FFMA_DEBUG_ALLOCS_FREES == 1
+#if FFMA_TRACK_ALLOCS_FREES == 1
     ffma_debug_allocs_frees_end();
 #endif
 

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-set.cpp
@@ -197,7 +197,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
                         (char*)key_value->inline_key.data,
 #else
-                        key_value->external_key.data,
+                        (char*)key_value->external_key.data,
 #endif
                         test_key_1,
                         test_key_1_len) == 0);
@@ -273,7 +273,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
                 (char*)key_value1->inline_key.data,
 #else
-                key_value1->external_key.data,
+                (char*)key_value1->external_key.data,
 #endif
                         test_key_1,
                         test_key_1_len) == 0);
@@ -293,7 +293,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
                 (char*)key_value2->inline_key.data,
 #else
-                key_value2->external_key.data,
+                (char*)key_value2->external_key.data,
 #endif
                         test_key_2,
                         test_key_2_len) == 0);
@@ -549,7 +549,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_set.c", "[hashtable][hashtable_op][hashta
 #if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
                             (char*)key_value->inline_key.data,
 #else
-                            key_value->external_key.data,
+                            (char*)key_value->external_key.data,
 #endif
                             test_key_1,
                             test_key_1_len) == 0);


### PR DESCRIPTION
To avoid that the compiler carry out any distruptive optimization for the hashtable mpmc algorithm implemented, use volatile for hashtable_key_data_t and hashtable_key_size_t in the hashtable to hold the key and the length of the key.