### PR TITLE
Fix storagedb memory leak

### DIFF
--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -654,7 +654,8 @@ void storage_db_entry_index_ring_buffer_free(
         storage_db_entry_index_free(db, entry_index_to_free);
     }
 
-    assert(ring_bounded_queue_spsc_voidptr_enqueue(rb, entry_index));
+    bool result = ring_bounded_queue_spsc_voidptr_enqueue(rb, entry_index);
+    assert(result);
 }
 
 storage_db_entry_index_t *storage_db_entry_index_new() {

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -64,6 +64,10 @@ static void storage_db_counters_index_key_destroy(void *value) {
     storage_db_counters_slots_bitmap_and_index_t *slot =
             (storage_db_counters_slots_bitmap_and_index_t*)value;
 
+    if (!slot) {
+        return;
+    }
+
     slots_bitmap_mpmc_release(slot->slots_bitmap, slot->index);
     ffma_mem_free(slot);
 }


### PR DESCRIPTION
Never wrap non-debug code within asserts to test the return value, the code will be discarded in the release builds leading to bugs.

In this case the storage db wasn't caching the storage db entry index objects for later reuse leading to a MASSIVE memory leak.

The PR fixes it, splitting the assert, and also adds a check to avoid trying to free already freed entry indexes.