### PR TITLE
FFMA realloc check object size

### DIFF
--- a/src/memory_allocator/ffma.h
+++ b/src/memory_allocator/ffma.h
@@ -173,21 +173,17 @@ void ffma_mem_free_slot_different_thread(
         ffma_slot_t* ffma_slot);
 
 #if FFMA_TRACK_ALLOCS_FREES == 1
-#define ffma_mem_realloc(memptr, current_size, new_size, zero_new_memory) \
-    ffma_mem_realloc_wrapped(memptr, current_size, new_size, zero_new_memory, __FUNCTION__, __LINE__)
+#define ffma_mem_realloc(memptr, size) \
+    ffma_mem_realloc_wrapped(memptr, size, __FUNCTION__, __LINE__)
 void* ffma_mem_realloc_wrapped(
         void *memptr,
-        size_t current_size,
-        size_t new_size,
-        bool zero_new_memory,
+        size_t size,
         const char *allocated_by_function,
         uint32_t allocated_by_line);
 #else
 void* ffma_mem_realloc(
         void *memptr,
-        size_t current_size,
-        size_t new_size,
-        bool zero_new_memory);
+        size_t size);
 #endif
 
 #if FFMA_TRACK_ALLOCS_FREES == 1

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -45,14 +45,10 @@ void transaction_manager_init() {
 
 bool transaction_expand_locks_list(
         transaction_t *transaction) {
-    size_t current_mem_size = sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size;
-
     transaction->locks.size = transaction->locks.size * 2;
     transaction->locks.list = ffma_mem_realloc(
             transaction->locks.list,
-            current_mem_size,
-            sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size,
-            false);
+            sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size);
 
     return transaction->locks.list != NULL;
 }


### PR DESCRIPTION
The ffma_mem_realloc mimics the behaviour of realloc and therefore should have the same signature, the pointer to resize and the new size.

The function should also check if the new size still fit in the size class of the allocation, if yes it can just return the existing pointer avoiding further allocations! This specific case is extremely common in cachegrand.

This PR introduces these 2 fixes and update the code to take into account these changes as some functionalities were relying on ffma_mem_realloc zero-ing the memory and therefore now need to do it by themselves.