### PR TITLE
Keys and data changes towards the snapshots threshold should take into account changes to existing keys

### DIFF
--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -133,9 +133,9 @@ void storage_db_counters_sum(
     counters->data_size = 0;
     while(workers_to_find > 0 && (found_slot_index =
             slots_bitmap_mpmc_iter(storage_db->counters_slots_bitmap, next_slot_index)) != UINT64_MAX) {
-        counters->data_size += storage_db->counters[found_slot_index].data_size;
         counters->keys_count += storage_db->counters[found_slot_index].keys_count;
-        counters->keys_changed += storage_db->counters[found_slot_index].keys_count;
+        counters->data_size += storage_db->counters[found_slot_index].data_size;
+        counters->keys_changed += storage_db->counters[found_slot_index].keys_changed;
         counters->data_changed += storage_db->counters[found_slot_index].data_changed;
         next_slot_index = found_slot_index + 1;
         workers_to_find--;

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1240,9 +1240,10 @@ bool storage_db_set_entry_index(
 
         storage_db_counters_get_current_thread_data(db)->keys_count += previous_entry_index ? 0 : 1;
         storage_db_counters_get_current_thread_data(db)->data_size += counter_data_size_delta;
-        storage_db_counters_get_current_thread_data(db)->keys_changed++;
-        storage_db_counters_get_current_thread_data(db)->data_changed += counter_data_size_delta;
     }
+
+    storage_db_counters_get_current_thread_data(db)->keys_changed++;
+    storage_db_counters_get_current_thread_data(db)->data_changed += (int64_t)entry_index->value.size;
 
     if (out_should_free_key) {
         xalloc_free(key);
@@ -1436,7 +1437,7 @@ bool storage_db_op_rmw_commit_update(
     storage_db_counters_get_current_thread_data(db)->keys_count += rmw_status->hashtable.current_value ? 0 : 1;
     storage_db_counters_get_current_thread_data(db)->data_size += counter_data_size_delta;
     storage_db_counters_get_current_thread_data(db)->keys_changed++;
-    storage_db_counters_get_current_thread_data(db)->data_changed += counter_data_size_delta;
+    storage_db_counters_get_current_thread_data(db)->data_changed += (int64_t)entry_index->value.size;
 
     result_res = true;
 
@@ -1517,8 +1518,7 @@ bool storage_db_op_delete(
         storage_db_counters_get_current_thread_data(db)->data_size -=
                 (int64_t)current_entry_index->value.size;
         storage_db_counters_get_current_thread_data(db)->keys_changed++;
-        storage_db_counters_get_current_thread_data(db)->data_changed +=
-                (int64_t)current_entry_index->value.size;
+        storage_db_counters_get_current_thread_data(db)->data_changed += (int64_t)current_entry_index->value.size;
 
         storage_db_worker_mark_deleted_or_deleting_previous_entry_index(db, current_entry_index);
     }
@@ -1541,8 +1541,7 @@ bool storage_db_op_delete_by_index(
         storage_db_counters_get_current_thread_data(db)->data_size -=
                 (int64_t)current_entry_index->value.size;
         storage_db_counters_get_current_thread_data(db)->keys_changed++;
-        storage_db_counters_get_current_thread_data(db)->data_changed +=
-                (int64_t)current_entry_index->value.size;
+        storage_db_counters_get_current_thread_data(db)->data_changed += (int64_t)current_entry_index->value.size;
 
         storage_db_worker_mark_deleted_or_deleting_previous_entry_index(db, current_entry_index);
     }

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -141,6 +141,7 @@ enum storage_db_snapshot_status {
     STORAGE_DB_SNAPSHOT_STATUS_BEING_FINALIZED,
     STORAGE_DB_SNAPSHOT_STATUS_COMPLETED,
     STORAGE_DB_SNAPSHOT_STATUS_FAILED,
+    STORAGE_DB_SNAPSHOT_STATUS_FAILED_DURING_PREPARATION,
 };
 typedef enum storage_db_snapshot_status storage_db_snapshot_status_t;
 typedef _Volatile(storage_db_snapshot_status_t) storage_db_snapshot_status_volatile_t;

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -191,8 +191,15 @@ void storage_db_snapshot_update_next_run_time(
         storage_db_t *db) {
     storage_db_config_t *config = db->config;
 
-    // Set the next run time
     db->snapshot.next_run_time_ms = clock_monotonic_coarse_int64_ms() + config->snapshot.interval_ms;
+}
+
+void storage_db_snapshot_skip_run(
+        storage_db_t *db) {
+    char next_shapshot_run_buffer[256] = { 0 };
+
+    // Do nothing if another thread has already updated the next run time
+    storage_db_snapshot_update_next_run_time(db);
 }
 
 void storage_db_snapshot_wait_for_prepared(

--- a/src/storage/db/storage_db_snapshot.h
+++ b/src/storage/db/storage_db_snapshot.h
@@ -31,10 +31,16 @@ void storage_db_snapshot_completed(
 void storage_db_snapshot_failed(
         storage_db_t *db);
 
+bool storage_db_snapshot_enough_keys_data_changed(
+        storage_db_t *db);
+
 bool storage_db_snapshot_should_run(
         storage_db_t *db);
 
 void storage_db_snapshot_update_next_run_time(
+        storage_db_t *db);
+
+void storage_db_snapshot_skip_run(
         storage_db_t *db);
 
 void storage_db_snapshot_wait_for_prepared(

--- a/src/worker/fiber/worker_fiber_storage_db_snapshot_rdb.c
+++ b/src/worker/fiber/worker_fiber_storage_db_snapshot_rdb.c
@@ -63,6 +63,13 @@ void worker_fiber_storage_db_snapshot_rdb_fiber_entrypoint(
                 continue;
             }
 
+            // Check if there is any configured constraint to run the snapshot
+            if (!storage_db_snapshot_enough_keys_data_changed(db)) {
+                // If there aren't enough keys or data changed, skip the run and wait for the next one
+                storage_db_snapshot_skip_run(db);
+                continue;
+            }
+
             // Ensure that the snapshot is prepared to run
             if (!storage_db_snapshot_rdb_ensure_prepared(db)) {
                 continue;


### PR DESCRIPTION
Because of a combination of bugs, cachegrand is not taking into account changes to existing keys when verifying if the threshold for the amount of keys or data changed have been hit to run the snapshot.

The PR fixes this bug and refactor the code to allow skipping a snapshot run instead of running, indefinitely, consuming a lot of cpu cycles, checking if a snapshot can be taken or not.

The PR also improves the reporting in case of failures at the preparation stage (e.g. the directory indicated for the snapshots doesn't exist).