### PR TITLE
Add the SAVE and BGSAVE commands and add support for sync save in the SHUTDOWN command

### DIFF
--- a/docs/architecture/modules/redis.md
+++ b/docs/architecture/modules/redis.md
@@ -12,8 +12,9 @@ scalability.
 Only a subset of commands are supported, mostly string and keyspace related ones:
 
 | Command       | Notes                                                |
-| ------------- |------------------------------------------------------|
+|---------------|------------------------------------------------------|
 | ✔ APPEND      |                                                      |
+| ✔ BGSAVE      |                                                      |
 | ✔ COPY        | Missing DB parameter                                 |
 | ✔ DBSIZE      |                                                      |
 | ✔ DECR        |                                                      |
@@ -49,12 +50,13 @@ Only a subset of commands are supported, mostly string and keyspace related ones
 | ✔ RANDOMKEY   |                                                      |
 | ✔ RENAME      |                                                      |
 | ✔ RENAMENX    |                                                      |
+| ✔ SAVE        |                                                      |
 | ✔ SCAN        | Missing TYPE parameter                               |
 | ✔ SET         |                                                      |
 | ✔ SETEX       |                                                      |
 | ✔ SETNX       |                                                      |
 | ✔ SETRANGE    |                                                      |
-| ✔ SHUTDOWN    |                                                      |
+| ✔ SHUTDOWN    | Missing the NOSAVE, NOW and FORCE parameters         |
 | ✔ STRLEN      |                                                      |
 | ✔ SUBSTR      |                                                      |
 | ✔ TOUCH       |                                                      |

--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -133,11 +133,12 @@ database:
     # the timestamp of the start of the snapshot will be appended to the file name.
     path: /var/lib/cachegrand/dump.rdb
     # The interval between the snapshots, the allowed units are s, m, h, if not specified the default is seconds.
-    interval: 5m
+    interval: 30m
     # The number of keys that must be changed before a snapshot is taken, 0 means no limit
-    min_keys_changed: 1000
-    # The amount of data that must be changed before a snapshot is taken, the allowed units are b, k, m, g, if not
-    min_data_changed: 100mb
+    min_keys_changed: 1
+    # The amount of data that must be changed before a snapshot is taken, the allowed units are b, k, m, g, 0 means no
+    # limit
+    min_data_changed: 0
     # Rotation settings, optional, if missing the snapshots rotation will be disabled
     rotation:
       # The max number of snapshots files to keep, minimum 2

--- a/src/config.c
+++ b/src/config.c
@@ -931,7 +931,7 @@ bool config_process_string_values(
                     config->database->snapshots->min_data_changed_str,
                     strlen(config->database->snapshots->min_data_changed_str),
                     false,
-                    false,
+                    true,
                     false,
                     true,
                     true,

--- a/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
+++ b/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
@@ -41,6 +41,8 @@
 #include "module/redis/module_redis.h"
 #include "module/redis/module_redis_connection.h"
 
+#include "module_redis_command_helper_incr_decr.h"
+
 #define TAG "module_redis_command_helper_incr_decr"
 
 bool module_redis_command_helper_incr_decr(

--- a/src/module/redis/command/helpers/module_redis_command_helper_save.c
+++ b/src/module/redis/command/helpers/module_redis_command_helper_save.c
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "log/log.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "utils_string.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "memory_allocator/ffma.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "worker/worker_op.h"
+
+#include "module_redis_command_helper_save.h"
+
+#define TAG "module_redis_command_helper_save"
+
+bool module_redis_command_helper_save_is_running(
+        module_redis_connection_context_t *connection_context) {
+    MEMORY_FENCE_LOAD();
+    return connection_context->db->snapshot.running;
+}
+
+uint64_t module_redis_command_helper_save_request(
+        module_redis_connection_context_t *connection_context) {
+    // Request the background save to start
+    uint64_t now = clock_monotonic_int64_ms();
+    connection_context->db->snapshot.next_run_time_ms = now - 1;
+    MEMORY_FENCE_STORE();
+
+    return now;
+}
+
+bool module_redis_command_helper_save_wait(
+        module_redis_connection_context_t *connection_context,
+        uint64_t start_time_ms) {
+    // Wait for the snapshot to complete or fail, it simply check if next_run_time_ms changes
+    do {
+        // Wait 1 ms
+        if (!worker_op_wait_ms(1)) {
+            // If the wait fails something is really wrong with io_uring, terminate the connection
+            return false;
+        }
+
+        MEMORY_FENCE_LOAD();
+    } while (connection_context->db->snapshot.next_run_time_ms <= start_time_ms);
+}

--- a/src/module/redis/command/helpers/module_redis_command_helper_save.c
+++ b/src/module/redis/command/helpers/module_redis_command_helper_save.c
@@ -75,4 +75,6 @@ bool module_redis_command_helper_save_wait(
 
         MEMORY_FENCE_LOAD();
     } while (connection_context->db->snapshot.next_run_time_ms <= start_time_ms);
+
+    return true;
 }

--- a/src/module/redis/command/helpers/module_redis_command_helper_save.h
+++ b/src/module/redis/command/helpers/module_redis_command_helper_save.h
@@ -1,0 +1,22 @@
+#ifndef CACHEGRAND_MODULE_REDIS_COMMAND_HELPER_SAVE_H
+#define CACHEGRAND_MODULE_REDIS_COMMAND_HELPER_SAVE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool module_redis_command_helper_save_is_running(
+        module_redis_connection_context_t *connection_context);
+
+uint64_t module_redis_command_helper_save_request(
+        module_redis_connection_context_t *connection_context);
+
+bool module_redis_command_helper_save_wait(
+        module_redis_connection_context_t *connection_context,
+        uint64_t start_time_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_MODULE_REDIS_COMMAND_HELPER_SAVE_H

--- a/src/module/redis/command/module_redis_command_bgsave.c
+++ b/src/module/redis/command/module_redis_command_bgsave.c
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdarg.h>
+#include <arpa/inet.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "network/network.h"
+#include "worker/worker_op.h"
+#include "helpers/module_redis_command_helper_save.h"
+
+#define TAG "module_redis_command_bgsave"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(bgsave) {
+    // Check if the snapshot is already running
+    if (module_redis_command_helper_save_is_running(connection_context)) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR A background save is already in progress");
+    }
+
+    module_redis_command_helper_save_request(connection_context);
+
+    // Confirm the snapshot is complete
+    module_redis_connection_send_ok(connection_context);
+    if (network_flush_send_buffer(connection_context->network_channel) != NETWORK_OP_RESULT_OK) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/module/redis/command/module_redis_command_save.c
+++ b/src/module/redis/command/module_redis_command_save.c
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2018-2022 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdarg.h>
+#include <arpa/inet.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+#include "network/network.h"
+#include "helpers/module_redis_command_helper_save.h"
+
+#define TAG "module_redis_command_save"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(save) {
+    // Check if the snapshot is already running
+    if (module_redis_command_helper_save_is_running(connection_context)) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR A background save is already in progress");
+    }
+
+    module_redis_command_helper_save_wait(
+            connection_context,
+            module_redis_command_helper_save_request(connection_context));
+
+    // Confirm the snapshot is complete
+    module_redis_connection_send_ok(connection_context);
+    if (network_flush_send_buffer(connection_context->network_channel) != NETWORK_OP_RESULT_OK) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/module/redis/command/module_redis_command_save.c
+++ b/src/module/redis/command/module_redis_command_save.c
@@ -49,9 +49,12 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(save) {
                 "ERR A background save is already in progress");
     }
 
-    module_redis_command_helper_save_wait(
+    if (!module_redis_command_helper_save_wait(
             connection_context,
-            module_redis_command_helper_save_request(connection_context));
+            module_redis_command_helper_save_request(connection_context))) {
+        // If the wait fails something is really wrong
+        return false;
+    }
 
     // Confirm the snapshot is complete
     module_redis_connection_send_ok(connection_context);

--- a/src/module/redis/command/module_redis_command_shutdown.c
+++ b/src/module/redis/command/module_redis_command_shutdown.c
@@ -57,7 +57,10 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(shutdown) {
             start_time_ms = clock_monotonic_int64_ms() - 1;
         }
 
-        module_redis_command_helper_save_wait(connection_context, start_time_ms);
+        if (!module_redis_command_helper_save_wait(connection_context, start_time_ms)) {
+            // If the operation fails it means that something really bad just happened, skip directly to the termination
+            goto end;
+        }
     }
 
     if (!module_redis_connection_send_ok(connection_context)) {

--- a/src/program.c
+++ b/src/program.c
@@ -656,7 +656,7 @@ bool program_config_setup_storage_db(
         storage_db_config_free(config);
     }
 
-    return program_context->db;
+    return program_context->db != NULL;
 }
 
 void program_setup_sentry(

--- a/src/program.h
+++ b/src/program.h
@@ -26,6 +26,9 @@ program_context_t *program_get_context();
 
 void program_reset_context();
 
+bool program_config_setup_storage_db(
+        program_context_t* program_context);
+
 bool program_epoch_gc_workers_initialize(
         bool_volatile_t *terminate_event_loop,
         program_context_t *program_context);

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -278,6 +278,7 @@ storage_db_t* storage_db_new(
     memcpy(&db->limits, &config->limits, sizeof(storage_db_limits_t));
 
     return db;
+
 fail:
     if (hashtable) {
         hashtable_mcmp_free(hashtable);

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -196,8 +196,6 @@ void storage_db_snapshot_update_next_run_time(
 
 void storage_db_snapshot_skip_run(
         storage_db_t *db) {
-    char next_shapshot_run_buffer[256] = { 0 };
-
     // Do nothing if another thread has already updated the next run time
     storage_db_snapshot_update_next_run_time(db);
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
@@ -146,17 +146,20 @@ TestModulesRedisCommandFixture::TestModulesRedisCommandFixture() {
     db_config->backend_type = STORAGE_DB_BACKEND_TYPE_MEMORY;
     db_config->limits.keys_count.hard_limit = 1000;
 
-    db = storage_db_new(db_config, workers_count);
-    storage_db_open(db);
-
     program_context = program_get_context();
     program_context->config = &config;
-    program_context->db = db;
+    program_context->workers_count = 1;
+
+    program_config_setup_storage_db(program_context);
+    db = program_context->db;
+    storage_db_open(db);
 
     program_epoch_gc_workers_initialize(&terminate_event_loop, program_context);
 
     program_config_thread_affinity_set_selected_cpus(program_context);
+
     program_workers_initialize_count(program_context);
+
     worker_context = program_workers_initialize_context(
             &terminate_event_loop,
             program_context);

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
@@ -123,11 +123,20 @@ TestModulesRedisCommandFixture::TestModulesRedisCommandFixture() {
             .policy = CONFIG_DATABASE_KEYS_EVICTION_POLICY_RANDOM
     };
 
+    config_database_snapshots = {
+            .path = "/tmp/dump.rdb",
+            .interval_str = "7d",
+            .min_data_changed_str = "0",
+            .min_keys_changed = 0,
+            .rotation = nullptr,
+    };
+
     config_database = {
             .limits = &config_database_limits,
             .keys_eviction = &config_database_keys_eviction,
             .backend = CONFIG_DATABASE_BACKEND_MEMORY,
-            .memory = &config_database_memory
+            .snapshots = &config_database_snapshots,
+            .memory = &config_database_memory,
     };
 
     config = {

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.hpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.hpp
@@ -33,6 +33,7 @@ protected:
     config_database_memory_limits_t config_database_memory_limits{};
     config_database_memory_t config_database_memory{};
     config_database_keys_eviction_t config_database_keys_eviction{};
+    config_database_snapshots_t config_database_snapshots{};
     config_database_t config_database{};
     config_t config{};
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-save.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-save.cpp
@@ -42,48 +42,25 @@
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
-TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SHUTDOWN", "[redis][command][SHUTDOWN]") {
-    SECTION("Plain") {
-        REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"SHUTDOWN"},
-                "+OK\r\n"));
-
-        // Wait up to 5 seconds for the worker to stop
-        for(int i = 0; i < 5100; i++) {
-            MEMORY_FENCE_LOAD();
-            if(!worker_context->running) {
-                break;
-            }
-
-            usleep(1000);
-        }
-
-        MEMORY_FENCE_LOAD();
-        REQUIRE(!worker_context->running);
-    }
-
-    SECTION("Trigger save") {
+TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SAVE", "[redis][command][SAVE]") {
+    SECTION("Snapshot not running") {
         uint64_t now = clock_monotonic_int64_ms() - 1;
 
         REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"SHUTDOWN", "SAVE"},
+                std::vector<std::string>{"SAVE"},
                 "+OK\r\n"));
 
         // Check that the save operation has successfully run
-        REQUIRE(worker_context->db->snapshot.next_run_time_ms > now);
-
-        // Wait up to 5 seconds for the worker to stop
-        for(int i = 0; i < 5100; i++) {
-            MEMORY_FENCE_LOAD();
-            if(!worker_context->running) {
-                break;
-            }
-
-            usleep(1000);
-        }
-
         MEMORY_FENCE_LOAD();
-        REQUIRE(!worker_context->running);
+        REQUIRE(worker_context->db->snapshot.next_run_time_ms > now);
+    }
 
+    SECTION("Snapshot already running") {
+        worker_context->db->snapshot.running = true;
+        MEMORY_FENCE_STORE();
+
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                std::vector<std::string>{"SAVE"},
+                "-ERR A background save is already in progress\r\n"));
     }
 }

--- a/tools/redis-commands-scaffolding-generator/commands.json
+++ b/tools/redis-commands-scaffolding-generator/commands.json
@@ -52,6 +52,31 @@
         ]
     },
     {
+        "command_string": "BGSAVE",
+        "command_callback_name": "bgsave",
+        "since": "1.0.0",
+        "required_arguments_count": 0,
+        "has_variable_arguments": false,
+        "key_specs": [
+        ],
+        "arguments": [
+            {
+                "name": "schedule_schedule",
+                "type": "bool",
+                "since": "3.2.2",
+                "key_spec_index": null,
+                "token": "SCHEDULE",
+                "sub_arguments": [],
+                "is_positional": false,
+                "is_optional": true,
+                "is_sub_argument": false,
+                "has_sub_arguments": false,
+                "has_multiple_occurrences": false,
+                "has_multiple_token": false
+            }
+        ]
+    },
+    {
         "command_string": "COPY",
         "command_callback_name": "copy",
         "since": "6.2.0",
@@ -2160,6 +2185,17 @@
                 "has_multiple_occurrences": false,
                 "has_multiple_token": false
             }
+        ]
+    },
+    {
+        "command_string": "SAVE",
+        "command_callback_name": "save",
+        "since": "1.0.0",
+        "required_arguments_count": 0,
+        "has_variable_arguments": false,
+        "key_specs": [
+        ],
+        "arguments": [
         ]
     },
     {


### PR DESCRIPTION
The PR implements 2 new commands, SAVE and BGSAVE, to trigger a save, in foreground or background, and add support for the SAVE token in the SHUTDOWN command to trigger a foreground save when running the shutdown command.

The PR also contains some other minor changes:
- require only 1 changed key by default to trigger the snapshots and increase the interval to 30 minutes
- enable the snapshotting support in the tests
- allow "0" as value in database.snapshots.min_changed_data