### PR TITLE
Use an uintptr_t to calculate the offset of the network_channel_t

### DIFF
--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -479,7 +479,9 @@ network_channel_t* worker_network_iouring_network_channel_multi_new(
 network_channel_t* worker_network_iouring_network_channel_multi_get(
         network_channel_t *channels,
         uint32_t index) {
-    return ((void*)channels) + (worker_network_iouring_op_network_channel_size() * index);
+    uintptr_t offset = worker_network_iouring_op_network_channel_size() * index;
+    uintptr_t channels_ptr = (uintptr_t)channels;
+    return (network_channel_t*)(channels_ptr + offset);
 }
 
 void worker_network_iouring_network_channel_multi_free(


### PR DESCRIPTION
This PR fixes the security warning https://github.com/danielealbano/cachegrand/security/code-scanning/442 .

Although the pointer math is required, it switches to use an uintptr_t to calculate an offset, then to acquire the pointer to the channel 0 and then to calculate the pointer to the desired network_channel object.