### PR TITLE
Don't report an error if the io_uring fd registration fails

### DIFF
--- a/src/support/io_uring/io_uring_support.c
+++ b/src/support/io_uring/io_uring_support.c
@@ -75,7 +75,7 @@ io_uring_t* io_uring_support_init(
     }
 
     if (io_uring_register_ring_fd(io_uring) != 1) {
-        LOG_W(TAG, "Unable to register the io_uring ring fd");
+        LOG_V(TAG, "Unable to register the io_uring ring fd");
         LOG_E_OS_ERROR(TAG);
     }
 


### PR DESCRIPTION
This PR changes the severity of the message reported in case the (pre-)registration of the file descriptor used by io_uring fails. 

This functionality requires a recent kernel but as there is no real downside if it fails, apart from not having the functionality enabled in io_uring, it's not really worth to report the failure as a warning. Therefore this PR reduces the severity of the message down to a mere verbose message in case it fails.