### PR TITLE
Multi database support

### DIFF
--- a/benches/bench-art-spsc-op-get.cpp
+++ b/benches/bench-art-spsc-op-get.cpp
@@ -1,0 +1,419 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <cstring>
+#include <benchmark/benchmark.h>
+
+#include "exttypes.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "memory_allocator/ffma.h"
+#include "xalloc.h"
+
+#include "benchmark-program-simple.hpp"
+
+#include "data_structures/art_spsc/art_spsc.h"
+
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+#pragma GCC diagnostic ignored "-Wpointer-arith"
+
+char *global_keys[] = {
+        "oemd","jluy","mriw","phqu","bxzm","jaqi","hopc","deqk","rmje","lyvx","mlqq","bfqc","vncj","laxm","mtms","lrvy",
+        "goxz","skvl","rtmm","vjno","bwvg","nllk","cgad","wfot","wckw","zlby","hejy","kcud","esny","dbcn","dvcm","ivzy",
+        "bcvf","kmbs","dasp","ncbo","ebkz","yvfb","xjvu","qdnd","ikyn","zztf","svkz","nnkf","hywx","thhr","hnkp","yvkl",
+        "ctte","fqvl","lymx","gbdw","njdl","wdqb","rdfj","eiky","zdcg","tsww","umgu","qaif","yvjx","tmxj","bgld","abms",
+        "krva","qnuz","qumy","jplz","gsao","cqlb","ebaq","renk","budf","mavg","nghe","wzop","kvju","cmha","deaz","xwdu",
+        "npvg","mgtu","cpxq","teuy","rjej","omst","elrv","olfy","wvma","pvkb","tnob","jxzg","ttud","udpd","ltgr","odop",
+        "soei","towc","cmun","xxrj","jvvr","uolj","rcyn","rlhm","ktdh","krsh","syyp","zmro","kqsm","klec","gtkx","ztus",
+        "mwes","dmob","vtqm","jpid","addl","ubxm","wjgk","vafc","zwjv","xxfk","drie","xwrw","zzmn","cjij","paaq","wbgi",
+        "mdtn","fnat","uuun","mkzx","btco","gpsi","lses","icza","sqqa","bdes","xtao","vshn","wurp","ywam","axpy","ekke",
+        "rmwc","fdzt","rumb","jwyt","ijgv","hzqq","tpki","gjbn","fxqi","vfic","cfrt","uyza","proc","ocje","bddi","vfgu",
+        "poaw","wixj","odlh","lxhv","valg","edss","greq","kwez","jmup","vgfc","pocj","dwwe","xmfh","eeke","zlte","ynqv",
+        "fanw","tssc","fuzn","dmgb","rkbc","yzqb","pvdu","iypk","aqws","guub","dant","rlfj","jhgx","rosg","vmwz","pfbt",
+        "wxms","tfzk","ucfb","ioyi","zsqp","xpcj","pgtz","manv","dvyv","cncx","vjvs","jhvv","djyq","kskr","txxh","vzjy",
+        "uzdt","iino","dtcs","kxte","oizl","moqq","fkej","ddoa","tjov","aebb","ovbc","sris","lcqs","swhi","ndlm","spla",
+        "tmgm","urmd","lxmo","rpmh","kkyt","llnq","vvdu","egsx","fsma","htvu","yyxj","peru","pfpk","jdmp","fcvd","rhsc",
+        "ajqg","maba","hhor","pjwg","yonp","bpdl","utmz","zmpb","hswe","zzgn","yfgr","srwa","qxnk","jgif","mrlv","puvr",
+        "ryhs","htyd","hiuh","vuvc","bdzn","fpyg","mqgk","haik","nebx","jywe","jcij","zmlw","hznm","jrfj","krlv","aeaa",
+        "mpeh","whzw","pzfb","zllb","pgvt","kspt","argm","zubb","itoj","ryhy","ehvk","kufp","awpa","cnsu","jzzd","zfbd",
+        "rbns","jduj","gjeg","grvp","yjmo","rrfc","puad","ovaa","xwgw","cbfp","nzxn","hnxy","mlqb","wexf","ltbi","mcdk",
+        "vdkj","tkme","pivb","ggra","qnrg","ggky","gbck","ccdj","rcgr","icjx","vdub","zxfm","lcry","whxk","kxll","bxlk",
+        "yiqo","zfqk","ywmc","pyod","vcoy","depw","mmoa","rxlm","wxdn","ocif","glyb","kbty","fqyv","dtcz","ghcf","fydf",
+        "ejey","egrq","mpmg","mpom","mgst","xcwz","jxqd","lrzi","hytx","nudh","jtbd","gbqj","lqqx","kdbn","xaul","ytbg",
+        "aiep","hjii","ndyp","uskt","tprd","lvzo","rmpo","vejd","bpqu","arbh","qawk","mdxw","amkj","yhax","redc","ncfd",
+        "tjuc","ylti","nfpa","jdql","txix","dwnm","fzrb","bfvr","sudc","zsor","etun","diry","xtxn","mwbo","oylw","wpki",
+        "eogv","mnrf","lrug","agdv","rtnv","orbz","otgn","iaza","rghl","dfoe","ppqz","cjry","gdtu","wtko","pppg","mltr",
+        "uzlt","xqcy","qsll","seme","scvz","ikno","evoa","mfpc","ueku","cuqf","dske","ugbf","onga","zkxm","biuk","swvl",
+        "njkv","oxrq","surs","uucf","seug","zjjy","ewbo","msgp","izwz","ktrj","yagb","jstk","wfzi","tqcw","egvs","txqp",
+        "jahk","xzrl","jnor","ekno","ralq","njxr","uqhd","vyze","hgwm","kqbn","cmnw","cgkg","uadg","zcqw","rflf","efev",
+        "zzvx","gvxk","ufsh","fcsj","tpyj","waee","mvtn","pxkz","kqms","anom","egxv","kiyq","oovy","gare","uafm","knav",
+        "tsnb","ccuq","mcsc","mkzv","qodw","nici","rrgx","glzz","ntko","aimx","kbqg","dxeu","aabh","mfsw","vdbz","tidh",
+        "pkmo","hhkr","oobg","clkh","kzfj","dgqj","kdes","thia","ymue","rplf","mweh","ehkw","wyjt","qpmb","snmv","zbkm",
+        "zwyc","mqii","rwhm","buzi","afdn","uzek","ftlz","pkvi","mjwn","cikp","mwea","cday","hwur","axpw","gmrv","nxom",
+        "ppwp","fabw","kvbv","rntf","lxaz","iiab","hxix","iqjv","fssw","hzty","mgwp","rckr","fler","cmal","tuuo","iiux",
+        "jlhd","euzm","zqwl","weai","pylq","tctt","cdrj","vrkg","ppni","dfjj","jwgw","itwj","nmcf","kfpf","gcnw","dfpp",
+        "bueh","nlhn","isys","skko","lqrf","lieu","ijgp","eeqg","cnym","wkev","kqly","papp","aifu","ctve","bnlp","polx",
+        "ktim","ftcd","puse","xsrm","rmvi","hify","peyq","tnhq","ugvo","anpy","tbch","igul","ztxe","kaop","alwy","kiyx",
+        "bpaf","qahf","nfck","qirn","qbzq","kzeg","objq","cjzi","jzfa","pztu","ftlo","rose","zprv","rvio","jgks","dvic",
+        "vlli","fgqx","vrxb","ngif","bueu","ceiy","hnxj","jnug","oqvo","muqs","ryhx","ujke","jipn","jujb","zxye","furs",
+        "wpmh","ehlx","nlfx","eapi","scgx","qaup","uwpb","hlqb","fqgy","nlso","mcrn","jiyh","tigp","ijgs","eadj","jcsm",
+        "mdsa","skku","gnnh","uyau","pims","ybxo","sptc","jxrw","fqxf","ecvm","plxf","lucb","neak","cecr","wvkv","mntk",
+        "gysu","fnsr","ikpo","zegm","jxer","znqp","mhts","oykt","elih","jaad","ihec","bthu","mmor","cekh","okmu","wrac",
+        "lfxr","zeus","kced","svnc","qfox","wxvl","uqrt","msib","nmox","qrcj","avyc","elya","urul","qkci","wioi","zxzr",
+        "urtw","tccb","oqja","ejlr","iahc","ingv","yjju","ehvl","plty","coie","yzta","itad","rxkx","rxnk","lrgq","qlyh",
+        "sgfq","ebyq","akad","jjog","ssee","bszh","wkcx","lgap","nxkx","anzk","fzrh","bgdk","srzo","xfqc","mjoy","rusr",
+        "bcfs","xywe","ncnu","fyyv","mfze","fhba","shht","xros","rfxr","gpxk","tgjh","vgmo","rllu","gogb","gdbd","bhob",
+        "szxd","yamh","aeyy","jxkd","wnmw","nxhm","uolt","ymph","zdms","vdwe","jvmu","hshc","xoze","dkvx","ewsc","wmjl",
+        "nckk","itzb","zunq","orjg","zidy","wvas","cyij","khra","clqo","erwb","mamb","tsch","zuir","icrb","wwwu","xkod",
+        "xeeo","ugfu","fihz","osxd","baij","jcoo","zogt","orib","gmnd","wwmg","eilb","bcll","blbt","ucjy","tnto","dfdz",
+        "rrtp","kjdj","ynxu","aswn","aztn","gvdp","jcsf","aceh","yalp","ayga","znjd","thes","sxmk","sqze","vlbt","ztny",
+        "rfby","dlob","wxqy","hdnm","jlxz","zmvo","wizg","rbfv","vvyu","sdzi","uaiw","cslo","tycf","rlrs","wiis","lkeh",
+        "pmtq","rkoi","ewbd","uokr","dist","hqjn","uqce","zafy","smdu","aebz","rcuo","msdh","krtu","xkjt","dgxj","eova",
+        "qqct","iefq","ylys","bwrl","hjmj","tgmy","fegx","eqvz","ldil","jypr","kzgw","ndzh","vsig","xpub","jfcb","bkmb",
+        "eerj","qoih","jptr","hhih","vxie","qbbm","taro","pqwc","gkft","vzam","ytxb","wanh","skiy","shld","ihog","jzdb",
+        "igkq","bjvp","fqvt","hufv","qarc","kvnj","qykk","jcrc","aocd","uuqr","huve","rosu","ejdo","knku","oreb","qlnr",
+        "krmk","dpid","eevy","ibhx","dceq","rqrr","vgcw","azfg","xhxh","patu","bzcu","xslu","wsoc","pzhg","jbla","yxih",
+        "ptyw","egfl","syrw","fbhz","hsyy","tabv","vpqi","lphw","iydc","swdw","fbrs","eovg","eaqu","uftg","kryd","lsnw",
+        "ddji","ulxe","ajsu","zixr","rqwc","cavl","anzt","coki","qcis","hliq","txoq","jysr","cfum","tquw","imcv","zijo",
+        "zooe","nlzi","wvwu","unfz","dzcf","sofe","hmmd","hdef","lbbc","zmox","kvmi","qzkf","raxm","dbiv","mbwm","yyod",
+        "eyph","fbto","egfs","mfcc","caww","gooq","pqlo","thjk","umjo","htga","ygtx","pqib","lpvw","tlli","xhhj","glfn",
+        "jwme","soro","cquc","jpxp","hgkh","ftol","ohmr","hggd","evhs","fmlv","dtiw","wgpx","pnqe","kmrq","xymm","gfeb",
+        "oonx","hjei","xugd","bzcw","jpck","qarp","zead","zxbx","okeo","fvxk","rgni","wufi","zjbe","hsby","riyl","rukc",
+        "tjal","zias","otwz","mkdj","hdpg","utpb","hhoz","olum","cvji","jtfp","tsua","dunx","voqy","roho","dgen","mtod",
+        "kwpo","sidd","hkfk","ugjj","file","krnn","lgxe","xbjk","vwbr","xngh","aciq","klyi","kcpe","hcby","iucu","cbep",
+        "orbr","iqbk","ktyl","iuzd","wuzo","uptg","bzoa","yvzu","ybdv","bvir","kmwc","evuq","ihnk","pkyn","arqd","hllf",
+        "gjpi","uxxo","qoni","epoc","ypzx","tmhi","umxn","swcx","elqe","utrk","blkv","htrw","tqai","foje","clna","wckj",
+        "avrh","lcct","ckpn","hpry","subk","lpzp","wdzy","cgxa","fqps","lwol","anvc","fsvn","oqyy","cfhy","tqmv","ntbb",
+        "dmqy","wjmh","qmsq","dxfr","ojuu","xgwj","ygmc","zrqv","bzwj","xvvu","cpdf","wavs","crkq","kjmj","lxpz","eayw",
+        "hscj","yaen","pvkl","qumo","nnuw","mfdm","vknm","monj","vdjb","hitv","llgf","tmte","npio","jpcs","qacb","iuge",
+        "gzgt","awui","ckxy","bnhj","kruy","ylwi","ylnm","cczc","ifih","zyxt","lftj","dwhc","osxv","tffo","hxzr","ggxx",
+        "jpwn","nfhg","rpra","mvvu","pzxf","xias","xlme","tuvr","ucav","sdbj","twks","lthw","fkpd","lljq","xekl","zgre",
+        "uqnw","lxgo","xtwo","fbrd","bksr","idvy","mozy","ynfp","lxkk","ylym","gffy","qdfb","yhmm","ffof","fzzj","ifry",
+        "ktkr","pbat","bhqa","zmqc","iqjz","ffpe","ezxw","yirm","hsak","fwfg","rplh","dfmh","ajti","gpkw","iveh","hlcy",
+        "ymbr","vsiy","eqns","ludj","qrfn","vwvq","ozyp","xedq","cvpl","wnoi","ixqy","yjpn","gtvh","vmaa","ausi","vkui",
+        "mtgt","zbeh","oybb","pcvf","gpms","ntyf","kdry","datm","cihh","njtk","apgk","xyoq","aibs","cgzk","qovd","hjdx",
+        "hvwy","vgto","eauz","nawq","kjzn","bayg","xmzx","vztz","fbie","nnmi","pwus","ktjz","zvdw","lrmq","uqqx","qthl",
+        "mxki","xirf","ytck","skhg","jzkl","ejnw","ifdp","eohv","klxa","dwqp","gdhk","mfod","afaz","hjjy","fbtx","mmrl",
+        "mcgl","tilp","qsjn","wnfv","tijk","rrmj","byei","mfqp","eixo","kqxx","jzja","hnmg","oiev","ijtk","osqq","stfy",
+        "dnib","iwsp","xvtk","mdrp","cxta","jhqn","wrjw","kdib","flql","gkia","hmln","zxce","wytl","shiv","ugou","vhtn",
+        "rgja","riqq","gxgg","fsfq","uyrq","ecco","yehc","flll","yycv","jxvt","zhni","rzqk","absd","fpop","dubv","ctqn",
+        "terv","hrgl","updu","zfsl","xuym","cour","acua","fnhp","dzix","ofqt","bpax","ityp","eqpv","cebw","ndoa","bclk",
+        "eeie","frry","paex","vglz","sfzf","iwus","nivz","pcfo","dftm","eils","udll","tyih","quku","adkj","jcsx","vnjf",
+        "oqot","pnfb","jatg","wbqc","sisn","dign","pbdy","wfrw","dldb","ngsb","ivzp","umsc","buqf","fzfh","pwef","qief",
+        "dvft","mbpx","qeln","punk","kmcw","fmxr","kaqa","ocra","lmub","vqam","ouyu","utrr","zpre","saay","kryo","room",
+        "xjoh","hhwq","kagt","qhkc","dnxe","zoal","pwal","ccbg","kcze","ujcm","blwq","rfke","etou","olnm","kvqw","iyzt",
+        "avuz","cwsq","isbr","ibwu","gkat","oxif","uobc","lrqm","uzur","hqxo","dfuw","bimp","imrb","tdcq","ednj","ktbn",
+        "yzeu","iaay","bfko","dvlf","atso","jthx","olyq","rpnp","dhke","iaqu","pkdh","jrkz","neyo","skdf","cylk","zjyu",
+        "juzu","svhn","scmy","jvvz","pdby","kecz","bhxv","ksjz","dtjp","hdvb","ewhf","ezbh","kyak","csxn","nfxj","ymwq",
+        "bkja","fjvw","masy","iqod","zmbf","jrsd","ugri","smaz","lbvd","fjrp","pdir","ngos","qyek","hyoq","vdkw","rtad",
+        "skau","cstw","rgkw","ywmq","zuye","iahe","faev","dayd","isvt","uyag","hpun","sldi","oakd","orgy","spij","tici",
+        "pylx","ffaf","bjsz","wezk","ciur","clzx","ajjw","lekj","wseq","ramw","yogk","owmy","wdsc","wsnw","kprw","fwar",
+        "ekjt","lqyf","wold","gvvx","qoiz","gstf","sakk","whmm","odrk","edeu","vyjk","wnyg","ovau","xzaw","reqw","hygn",
+        "iteu","jfsj","eluz","brwi","iwzn","dneh","byjk","fnhy","mpar","fsbr","lyjl","yxmx","zhng","xneh","ckna","ucuy",
+        "gsrm","krwp","mxfz","buza","rocv","qqlm","gxwc","sevz","azpx","fyzg","ouwg","rxqs","txae","ubbf","osia","zrdk",
+        "erew","sdiu","jbeq","rmfb","rlgz","pamm","ainv","jfeu","wyxt","bknw","ttnp","xebm","untc","rbpx","hjts","ovev",
+        "wkcn","lgno","qlmp","wiuv","oxll","mkqj","hxqf","iffk","dlnq","lqva","enef","njmj","rrhi","gvna","aitb","iudf",
+        "fmdl","jdey","ojyq","ygyz","rlgc","lura","ashh","cewj","sccz","miwr","mwnn","wgjx","syft","vadj","cgrr","kxjg",
+        "xogw","mzph","eioy","wzim","srfx","xnjd","nqtr","xfox","dege","fhic","gwku","vwwp","king","lxqq","aluo","hqmb",
+        "avpe","ggjj","tvug","cbna","hpkf","irqy","kaqm","rcqi","vmme","xwcq","joya","djpg","ajba","hpsp","prkk","soxw",
+        "lyze","pjcs","rjmu","bofg","othd","qynp","aqeo","alyl","uybe","mjsn","zwpo","gvpw","zzqp","qxet","fvgw","lcnu",
+        "cekt","xknz","wfox","ulhx","yrdp","ozuj","bvjg","zoup","wajy","cqms","ujxn","sdam","ijwe","fjbl","fmnq","jheu",
+        "ukas","wdgg","rwzi","pcob","vlig","wdcc","gwnq","apej","hlso","agym","fexf","viww","fzjh","ukky","jerk","hwbh",
+        "tpzr","uwaw","eznu","ryod","tzhk","kcne","uepv","owxy","rgxc","clfh","dkrb","yloh","pwhq","ceuo","hnpy","qlnj",
+        "kkaz","dyps","yfjf","skqb","chgw","ddvg","sjpx","xuhp","gimq","bdaf","kuel","efar","wrtr","gigx","chfs","zzkv",
+        "jrhz","thjx","ujvl","smbe","nese","sxli","iknp","evkb","mrlp","urob","wcoz","hfmu","tilx","bhhj","zwyy","wotu",
+        "pntt","ozow","ynpb","jrsm","pcxq","cgqd","cqru","lwgw","dhjo","ubze","zvsj","zkoc","qktb","xvbt","fbms","yoxc",
+        "llkm","bsef","anjf","lfcy","jdhq","hvka","ubzb","fwyt","vfhm","apyh","ytng","ysyk","npqi","ofgr","cnac","tuze",
+        "vcrf","ayla","hkrq","lyej","seww","eqvn","wtab","ywmw","ukgk","gmqm","ople","pmdn","vzop","cxhr","wpta","kycz",
+        "lrat","flku","xlld","ztxr","ehyn","mgoc","keed","dcgf","twjm","gptz","pzrc","jcet","othq","uhyh","uqro","fkql",
+        "tujs","amjb","mxif","arrs","abiu","yuud","vdwi","ldnp","pczb","yxjn","xyzp","kiac","tslv","elza","lgcp","vbaz",
+        "woli","lmhw","jkyy","pqqu","dblv","doem","hffd","agem","zmah","obpn","lleh","ecuk","reah","twnq","qlzg","bvcc",
+        "zrqa","vxqs","ojea","hvjq","aihk","cann","cugx","syar","izib","hmlr","wrsz","yewl","rbur","qmms","jbqi","ovpm",
+        "hulk","omyy","kfzx","zzgp","hkha","jqod","fylu","abzg","jjzg","obft","owug","yefs","avhr","ieuu","favr","sclk",
+        "ufvd","mkaw","rtoz","qzle","cvah","ltbh","asyq","gszi","dfry","uioi","soxa","ozjq","acga","smef","kgzy","wzrh",
+        "eibw","pblp","qthp","yxuf","qmqk","zmjq","gwvh","uedj","rkxk","pvaj","hrhz","tnha","cgxe","tfyy","lbuq","jycl",
+        "anca","uehf","qvnj","etwq","xfid","gqlg","rooz","gbgi","cppp","jpcp","gfdy","tpld","ragl","acmn","rndj","blkn",
+        "bcux","ndud","gbho","blug","bpub","takl","qozb","zlbz","vfbv","iiyn","swbe","kocp","yeyo","fatp","kzup","bdxk",
+        "wyog","wxkh","ixez","ghpj","vstx","otio","yqfz","zxdd","fvbs","uiok","hnka","orav","uzbw","mbhf","lcam","jrkj",
+        "aobd","izum","hixs","qolb","bewj","qxjq","bxtu","mcip","zfxu","oghs","opza","mqtu","xtpo","etva","pmkm","vzfc",
+        "icdm","dkap","nyuk","wpfc","payu","eowd","tpen","lveg","kuxi","zahi","kzqf","tegy","cfmw","owqh","dueh","hddn",
+        "xjdg","appy","zmat","ufzi","swhn","btqb","jqcs","fjid","yylk","zhcf","rmvl","jsgb","qmjc","tfwx","rnaf","mvgf",
+        "amyp","nxbp","cium","ollm","dcyq","hict","zdfp","srmz","vyla","eiso","dcbp","mrcm","peji","fysw","reoo","gcoi",
+        "dapd","xzkw","ppvy","petd","tbpz","lttc","owup","mfbz","winh","xige","soju","yjzd","gjph","appk","leth","etsi",
+        "nlot","ppcb","nuze","soqr","uqoa","pspz","rfrp","tmqw","wkwh","uewr","otrk","ymca","epaf","qpwz","hmjz","abbj",
+        "vehp","ndeb","edik","ogah","nmuu","pmmz","hcgy","xmtg","ygkn","akmu","edux","bemp","fmrb","fyjj","tzoo","kwcz",
+        "ssfc","zrqp","jgys","zvkz","zbmd","miss","lyqq","orkm","oawv","abgm","xujs","tnbe","qbgt","bdmn","fvib","uiai",
+        "cthk","zrfo","toia","ayko","ejae","lofb","dwmk","hpvs","egql","lumn","kxwf","ayvb","nwhb","pfrk","yand","zuyf",
+        "fkdd","lksd","gwxb","sdcd","wzrd","zdhw","awen","kvxh","cvsq","tyvl","omhk","kqyh","phlu","ppew","uurs","zhkr",
+        "iycu","htlq","xxpe","uasu","komp","xbki","duev","uyhi","ntcq","tfgr","gnwj","vbwm","xhsr","yata","qzyx","mdmq",
+        "kbuy","pvmm","lvbh","pnlq","nuar","nwsg","skxf","dfid","rvjw","nukc","tmhd","kykk","epdi","ykpv","jpkr","jbyf",
+        "bifz","ukex","jcsj","vfvp","usis","ytlh","insk","lrax","iykv","guqk","tjmx","adcr","vxlq","amsn","zctm","rbzr",
+        "dslq","rihj","lqil","yler","dftv","zrsx","udxv","qtbk","lzyh","lagr","kfin","itrm","huke","yudp","zrdn","wtmk",
+        "lgfc","mtsp","zgbm","yjut","ryqe","xgan","zpwd","pshd","xmzw","webv","wydg","zkma","pmso","btqj","ezjr","unas",
+        "yqkj","phls","lxdh","gzsu","fgvy","vyqs","jsux","tiit","laij","nkwd","dhgi","cmtm","ukrt","ftte","osoa","sflc",
+        "kyyg","hlid","bbdl","brwh","vkak","htqw","wfoy","arab","rebw","dgki","mfai","xfer","exob","dmyj","suvx","usiw",
+        "iper","fzpg","xtib","vaqo","pgnw","pece","gbzd","inpj","sgpy","jhjn","vfmy","grxd","uqna","qhfe","pnrs","wwtn",
+        "byub","nmcj","retp","rmjm","wwlz","hlrm","itfv","tync","kzki","wgtw","sptf","motk","gdpa","aldo","jobt","uxqw",
+        "sxkf","wtnt","mdde","sfqd","gusb","dzmq","ngrc","iusg","kmfk","qmjn","xnmm","imtg","hqqf","gwlg","vgrl","bduv",
+        "ybgd","prsv","hamq","hjrt","dove","uffl","qeks","ulpp","hnfm","oxjx","kljd","dnee","stgx","avhc","knom","ddho",
+        "jhlx","wecr","bmlx","ozdq","xtki","ipnk","ivsb","jjdr","yljp","qxst","rsgz","pbdu","eopu","oaxs","lnxe","syyh",
+        "pukc","umrh","zkuj","admk","ocdm","gntx","mnlf","eivu","zgyc","kyoj","rsjd","njne","ermf","nzma","plvt","zoml",
+        "fjen","sliu","sdid","xdub","javj","cwqt","mzwb","gvjc","coza","xcpc","eivy","qzve","wbbi","btrl","ttap","kfvg",
+        "fmev","njvt","trki","mfgp","kgmj","reul","mabk","gmbh","nppq","suoh","yxzs","syws","xrlr","nhry","mwye","gukm",
+        "zazm","lxvl","ixzb","texm","gypu","luqv","heun","gmuf","aenk","ituu","vhev","wztk","rmcr","dogm","fgzq","hbbp",
+        "cqlr","bokw","wlfo","snrb","ysaw","bbej","xacm","gkmy","vfuq","hoga","sacb","uvml","xigg","bfyw","xigf","oqan",
+        "olpy","jfhs","bcvc","otrf","dnmx","ekvt","onlr","zfei","bqze","ckoz","wava","nalz","alas","nyre","dndm","uzwy",
+        "tuab","qqkf","yuaj","yoje","skzo","febt","mrbt","uxox","flyi","vzyv","kslu","awfd","uxag","xmjx","uibt","hpvf",
+        "pssh","vpzc","ashn","qojz","gmbw","xtyp","mmup","appl","luab","zjhg","ijai","tbyf","upvx","ibfw","ynxp","geno",
+        "oyiq","gzkv","iyne","bkog","oimi","uoxg","askc","ocyb","agkr","kdcl","rzpn","ajgc","doaa","dvul","nxzo","waer",
+        "tsta","crfo","birp","hlmk","kejk","zcmj","lfpy","aubx","gjgc","mdyu","psmc","tunz","dirf","oshv","tjft","qiln",
+        "vhnl","yvky","gycu","tkbx","hufk","qwob","qlxh","wwbf","zzij","aklj","pmoi","cees","qfjk","zipy","hzzx","nrre",
+        "fxgf","nbta","gova","rlnt","xect","vbgs","bqex","tlrz","oalh","sjkr","ljfx","fove","mppt","ankv","wlto","qvkb",
+        "ymvl","zuii","pmzd","efoy","ceri","epsq","laeg","mdjt","ohde","ywvx","hoxa","whmc","vhfc","wsxt","bdez","jwba",
+        "yttf","dsai","gmjj","bkdn","brih","qyum","ljbh","jqsp","fmaa","axcw","uivx","ehxf","ouyv","zkkb","dmik","dhst",
+        "mede","hfkr","ihuj","scoh","axpe","ufvy","sfnr","aaaj","pwcw","mzhw","fcot","ailp","ddym","egtr","rlkj","ovel",
+        "ahhf","hjnx","azri","kjox","aavt","xeqh","djya","vzmy","lswh","nmun","bxzc","mwbi","mipy","kcpg","cbut","eldf",
+        "ylub","lunk","xkue","xuen","sffp","euau","hgoz","qotv","coct","htof","ecsa","bvee","wmyr","ruhl","wrpc","pazy",
+        "atew","bhff","izvw","ogfy","pfsg","gikl","iyhm","uhhc","glvk","gapt","biio","cnyy","ilbq","vkzq","voke","hdbo",
+        "jcwk","cmpu","seem","ailm","eewd","tagh","hebi","pqbn","hrew","dbtx","iupz","ycoj","lave","uwnd","muwy","vwxe",
+        "lteg","mklz","apel","cwty","btdj","pnoc","gnzj","vvir","rekn","kvfy","tkwj","ldje","yydx","xubu","tszv","jkpb",
+        "xngx","nnat","cdwr","jigk","obkv","aibt","cmco","ajaw","jhpv","eevv","rgpz","kgqn","ktsf","sdqx","hgmq","utvu",
+        "tuxz","ayyd","vubo","cihl","mkqi","zlgm","hqlq","ilvt","hjgr","bgmu","mlga","ugim","rgwb","joma","xoig","evze",
+        "ukvq","mcou","ugna","lbok","ldzh","atgx","ewyb","htnc","iwwc","bfea","fptk","sxtn","krmi","xglf","rmyj","hhfk",
+        "jpot","zfyw","atik","cwaw","eqnt","fzgm","tdmz","bolw","trdk","kehv","cjyo","anyl","qkxb","lice","ejxf","ewma",
+        "gxcf","miqb","ojay","ircg","tpvp","dgbi","vqzk","rlwd","qjas","xgck","bmus","kvka","oria","bxkl","fswp","xbzb",
+        "ynlx","ttba","ctkr","dnld","rfgz","qufd","aora","bhnn","rcby","axpx","jwam","ocuh","vtqk","ryqp","cuex","xvlz",
+        "dkbf","uoeh","cuiy","quva","sbvu","hrrd","ptbw","pqtx","abqe","azrv","ljup","hfmn","hkib","rtxw","ajxf","llwv",
+        "jmxr","pjow","wfth","gkbh","coae","kbsk","zara","sdap","oigi","cybg","saej","mybo","qmer","wmlb","acyo","lqsn",
+        "zlpu","ccun","wqgg","bfxr","qzpg","iqnd","pkqz","iwmg","iizf","bjki","xgic","civp","dure","sywi","onuv","ozfy",
+        "lotu","sucg","fhpu","fhmr","aazn","skkr","stwy","vmjr","ilym","wqql","jjer","sggx","imwe","ixsg","udfs","pwbj",
+        "usyl","jmnb","yehm","wneg","lkgz","lfac","anai","dwdg","ojrw","vkuq","vdse","yjqk","pije","uhmg","bwbc","svzw",
+        "vqae","gsjp","abvz","aqtt","zald","qoey","rcno","lkcw","doyv","ablc","mlbw","dxzv","vlql","ixrn","nawn","kpug",
+        "tupn","rwde","uycp","zsbs","dhec","cnth","fqrc","bqst","yclg","mafh","rqqd","juwh","fimw","sbja","pzjo","fefs",
+        "zvgw","pzeo","yayl","wdko","ginn","ygrz","nppm","gjnu","fety","iwot","pdbk","xmxc","sqjh","ohqi","xkzq","tnnb",
+        "gizs","mdnl","fdrd","selp","ezhy","uhxa","tnfk","sptj","ywer","qdms","xogh","swby","vwli","kjxo","czwr","auyu",
+        "sfpx","pvse","nktu","usgf","ypgw","fdjb","yguk","bkxh","frwj","cyvm","xmgv","xndf","wpwd","jpmv","iexg","pxtb",
+        "xtyj","zfsh","wlox","xfon","jtpe","jkwr","egku","adxt","zieb","lwmr","ijxe","qsnd","xocf","bqaj","tufx","ixrr",
+        "yexb","hyao","rmqb","kgvy","vlrt","gqqj","ajjc","enhc","aqpu","duoo","adrx","ryfn","zqwj","hiln","vyfy","wnpu",
+        "gfqj","pzlh","klzc","viyd","arfm","htuy","pjyz","rzce","xkal","ktsr","fari","gyvc","xifu","hxna","pdqt","lrgw",
+        "ldcr","qcyu","ippc","qmme","myyd","hegg","efkz","rutq","uzlx","kfus","plea","pcbo","gzjz","bcnm","zjei","jcob",
+        "vgbw","fanc","iyix","smgd","ljmk","sbgn","jcfq","skjc","qjgb","cytl","uhqs","kqmt","bnqf","iawi","fncb","sdnt",
+        "soji","uctx","eqer","idhm","lqua","nfvd","nwdh","igjb","xamb","lgrb","lmju","hzlp","nmpv","myza","xxwd","hbyl",
+        "lczu","ddua","eovd","gtbp","mldr","wbnv","cnho","xcai","rreu","fbdz","ixrl","hfyx","xoxa","dvcd","bxcp","xfia",
+        "fvjt","duxs","yyar","iagh","eadf","kkbw","uesl","hfca","jkwb","dseg","ubec","jmux","ceqb","vdqa","psnb","zykh",
+        "iozg","nlcc","ksva","bptt","hcxk","azal","aqbt","fymr","pvfo","bxlm","jblc","hchn","ftwt","ppny","frrv","zuxd",
+        "wdsk","falw","redk","kwij","puri","vwfe","hbjb","krpm","ujiu","cdwi","pddm","szkr","well","ojty","cnpk","pizj",
+        "xnsl","asev","euly","fzrv","lysr","xxjt","pifp","azto","okcg","oels","ffwj","tsre","btwb","nuaf","fnxv","nzdc",
+        "wwbm","krnl","wwfd","hxun","fjgv","ppgx","nwfl","tgnv","ancp","nvnf","pelh","dbjd","snlu","jcgq","gtzj","ilnh",
+        "gknx","dici","oogz","zomt","jreq","tzpa","mhhu","qfsi","zopc","xqhx","mota","yjnj","wxmb","aoxk","pzco","ppox",
+        "yrno","xwae","soct","umbc","djsz","bino","qlek","grhl","knzq","ircj","hchw","zjem","hjof","rmip","xctx","cvpn",
+        "oirm","ifsk","abgc","huqc","rcmz","mgek","yfqi","bpiw","iesq","jxty","ftke","izve","hhby","hzlk","inwy","qzfb",
+        "tkmx","zvts","heio","fayn","kmqv","mlor","vhtc","nhpd","haau","qbhl","jbnn","olgb","unfj","fllc","ovoe","ynbf",
+        "ljcw","dxna","prvm","cojn","mepj","utbv","funa","yyyr","ccmx","xkdn","bwjp","coqn","ubvs","pdan","jkba","axts",
+        "rxsn","quck","tgkf","cfrs","uaxs","rmjv","lsev","sywy","jmym","uoml","wasd","tuzc","chgr","wdva","flfi","xfjk",
+        "zhdb","tnlo","byng","kitq","kjwu","hawe","rdzh","tspn","qlwl","vhta","dcdo","wbpn","wxpd","gzga","ijal","etco",
+        "ekaw","hkwx","btmd","kvxe","cxqu","ecpv","dfyx","evrc","klrs","mxql","ekfm","vpbx","cqte","phan","dqnw","pcft",
+        "pbcf","qqpf","xdce","dspe","vnhy","gjvz","unxt","tect","gotg","jojy","xwud","awjk","dexs","dduf","eumy","grop",
+        "xunt","pjnp","tkps","ijjs","fhjm","oboo","alqy","vuwv","xbue","jdad","tnsw","nflp","xccq","xsqe","rwke","zcrr",
+        "mwuj","gidt","kpoa","yuog","hdxi","abip","lphg","rjzo","gtbg","flhb","rgjy","rljh","whyy","xxxv","gemg","iqso",
+        "goxb","iqjo","jnhv","oebv","tvgc","rrtu","rjxc","nuet","htpc","lhuk","bwll","ghdf","ttgs","pplg","hhmx","riry",
+        "gtjs","wthz","doho","tqad","nenp","kevf","njda","lwkz","ojyn","awih","banq","tsmf","vhtf","tlrp","xhcz","kubi",
+        "gcyw","mkmy","quvk","vxli","oicx","jzlz","lzpb","hxzi","puna","gekm","aziq","pugf","wfjy","unjg","xwbd","nguv",
+        "yemz","kfum","wina","jraa","ipoc","dbxp","nona","gekw","ltmk","ihzu","wsuw","qbas","tfki","dkbz","nyeg","lwqw",
+        "xvrx","rwqs","rorp","uems","ywnv","kfqy","xpcq","twme","ehmm","rwrb","zueb","okdl","xfbl","xvsu","nbxs","eoqp",
+        "zxqx","kcoy","rosp","yhhv","piov","nhoe","oday","wlyx","aqng","hlxq","tcki","gaxc","hzdu","ofrq","qbpk","itnx",
+        "suqw","tiap","fxob","xrrv","hwkn","crxc","ockx","erob","bdor","vixm","keea","vhes","rlqs","ushn","kslf","wppi",
+        "nifb","amyr","maco","wwlw","tvab","rlvm","uyxv","wvxh","zpzk","suxn","lwim","whmq","alga","ygok","rrcs","tohx",
+        "bapz","aabn","ptdn","ekqy","iwjw","fywc","vdzc","xpdr","lvsm","olnh","mxov","gkie","ihkb","nzai","rcqj","lncj",
+        "uydy","yylv","cgqx","zpbx","njjy","qxop","piti","aarj","rplx","ofhl","ltso","ihky","uivz","eiki","gqcq","xvqf",
+        "nygy","htry","mtje","pmzw","iwgk","ifhp","bvqz","fquo","likt","mmxu","futl","dhgv","fazy","gllp","tkcq","hobg",
+        "xcah","qfrt","zekg","xiyq","vuvj","umsp","rxaw","fsto","iimm","fjmw","snch","vunz","akwc","nsrd","jxys","wyuw",
+        "nboc","icqd","iujt","uolg","ifzl","fbzy","ovqd","sadx","ggrg","adbu","bwwg","kioi","wpea","uqrs","uynh","qoqv",
+        "zvev","ffhn","rnok","kugj","fzhv","jrng","onbz","vxpn","ekzi","oniw","qgxo","pnhy","ugfg","jbgv","pfyk","rdxx",
+        "pqqc","pjpp","tzef","oeto","imdv","yiif","qero","jmgz","clta","haje","bbhu","oros","nvkn","ecmy","coiv","tdml",
+        "cvou","tzre","bbeo","ksdq","lbxn","yofc","pkvp","jklf","gudf","lkbe","mzjq","dkpu","nxgi","rgbz","cqtu","qejf",
+        "gvgw","qjvv","hxnh","ijpq","rupx","yoxp","vqih","ayhy","scyb","qwwu","twvz","fzhk","ndcl","okao","frpu","kbzc",
+        "qyju","sivt","hrfi","dwtg","livd","hnxf","fedd","ohpy","phbo","mcgg","qqkl","bnok","noye","uqxo","cowh","wlqx",
+        "rgnn","zwda","bzip","wsxf","yoyw","iqrz","pgga","kzdt","rbdy","ickr","kaca","koun","zqwa","iuns","xjef","qvvw",
+        "cwul","kemx","stpc","mwpa","sjhy","kzgb","sjjr","qlzd","akhk","pnjz","whkr","hdcu","csir","figt","frez","rgoy",
+        "ichu","ninr","vthh","ifhw","spoa","kqsr","zoed","jemy","pdzy","dbre","trvt","nfui","gbkt","omoz","hgcz","doql",
+        "wnwk","myhx","spgx","ojon","qdnf","iatq","gemw","wrbq","xckk","dvvv","sksh","eqdl","agit","eocm","dvqy","irys",
+        "seix","mghz","jmsp","uhpq","uyqi","hxid","yycw","bkox","mnhy","wgvh","svmz","uicj","lyyg","zvlw","qivz","anbf",
+        "njvg","zugu","ozey","nycu","rill","tdfb","ahtf","ahhb","uikq","hbcq","tzns","oqrr","bhcj","teuw","riid","qgcu",
+        "gixd","gnsf","kjnt","ozul","ojnt","trqz","hkal","qjio","gyau","dlus","fvfi","kmgk","vfjc","ogaz","aezv","xovm",
+        "rhey","osoi","jftr","neoo","hyaa","yaos","scah","qyqs","kqnf","mjhb","ktnk","gqbb","bfqk","xrcn","yfqc","einv",
+        "asax","dsda","iswr","nsdw","gcxw","srer","wewz","nvtk","qwbl","bxli","rwph","fzug","yynq","kahd","fmfz","xoiw",
+        "ulrv","zrqj","jdra","iipq","mfvp","rgwt","xycd","tfqm","wxak","ecmd","tobc","byin","amzl","yrjn","uraw","dhzk",
+        "yvyj","zikb","ijih","nddl","mvyx","lkmg","sqqv","aphh","otjw","aftp","nnde","lmxl","gfnp","ravi","vank","prun",
+        "wtak","vrfd","yylr","wcht","ykul","mgnt","bjaf","tgqg","cxyl","iapp","xkjg","uzqy","iltk","qtoj","nrvj","hqqz",
+        "zbwy","lean","cqis","rgfv","ggih","jghs","enzu","jujw","uizi","gkhg","ehqz","oybp","kkfb","tmwk","xkdi","ulda",
+        "geuk","hvtt","rycv","iysj","imbh","pjzj","ledn","vdml","vinq","qyaf","ltwo","mzcf","hcrp","phqp","jpfv","gvkf",
+        "qnnj","wydc","wfbu","sxsm","njuv","ldte","momm","azkb","shtj","fxyg","eqak","sypx","psyb","ibuk","vjei","xvzf",
+        "iykm","lbah","egtz","xxrl","yskn","yjys","nlli","uufx","cpts","uzxv","cxkf","yxfo","edzq","amgw","gpxc","ehtv",
+        "vkpo","ufzu","rejv","vdrc","uxbc","xqje","doqx","psxx","mnaz","gvqd","bthh","pxxy","goyu","eroa","mgxx","vvni",
+        "dpan","opvu","ugdw","wfmh","hdpm","sunx","ycyw","ayle","luxs","kdwj","bpky","qfwi","rlix","akcw","iwmb","ozug",
+        "rani","wimc","fssl","agjz","uunm","nkwa","zwpi","srlh","derd","hntd","veyz","sgaq","zode","wgbd","adyu","xszs",
+        "gfun","qhts","xxcm","dbrr","szoq","ggxe","bkkl","uzzk","lvws","vjun","tvwo","qhpw","gqav","lopt","aobn","gxxe",
+        "gpwp","iqvd","coff","awwv","fpgv","zswg","bgsa","xqdx","xwrx","ooub","inqo","junv","jexj","vxqp","ztdb","drfg",
+        "cmds","qymt","ebbk","vwji","hafy","xfph","cqgf","zkrf","nkus","dtej","gdgu","oqhl","ywff","jfyv","lvix","ynlo",
+        "ontl","ezzb","wqjq","pvjl","picn","yccj","rltc","jpgj","xrkh","zzxl","hrja","gsqm","jqao","nrpt","eykn","xusu",
+        "mkkt","wcqy","zunj","ofai","kmmn","gqwm","vdwq","tots","jhid","wrhw","qdsk","eigo","gooh","rxdb","csza","epqp",
+        "npnk","tfoi","avho","mhcx","pndb","kgmu","ynoa","mggl","jyom","vgtz","ubbz","vhnz","eiwh","opci","pqmx","irtc",
+        "nvmu","whpq","qami","mght","nult","xvvq","ebfj","zizp","qofd","byyr","qtwi","amoz","jysx","qzhz","adio","zyvw",
+        "xbfy","kemh","wcil","juvp","heeb","cotv","mxng","tgfg","mkxs","eimp","pzcj","hbyq","vqor","mtbn","ckyb","whhw",
+        "whdk","hpra","jbjh","pnxp","bkpc","xgru","cjfn","fwdr","xfbx","azxj","cwrc","ipde","ibig","akwf","ivnd","qxhq",
+        "dyeg","vtfa","rfvv","scrd","tmty","gdui","hcra","hrbv","basr","xigc","blzt","nkbs","quww","blme","pfqy","xtdb",
+        "ooxq","gcbt","xqgx","vfae","nwvw","ipyt","efir","ayhe","ikek","pojc","jbvs","bryz","iodc","relu","ltip","xhgo",
+        "jijc","vjpi","qeeq","tmiv","offb","xfzp","okxy","rfhf","gjnn","xlzr","cfgz","mxgo","zglg","hdqe","dcrf","uabp",
+        "nveu","xwuw","ywct","byix","itsd","uwyr","wols","oiex","vykx","woqr","mvpx","icgt","mrmx","hsti","lajl","eouo",
+        "fyns","gqbv","iebw","yanx","kpfu","wieb","nucf","lavj","cgeg","cjco","qyss","eghg","tjas","kkqw","npvf","ajkc",
+        "wbnb","ogjr","zhmx","rjob","txnu","nxcv","ilbz","ajsw","bees","detf","gywe","grbn","ghok","wovc","brbh","ucyl",
+        "dlvw","yeah","buxz","jbli","bnvb","jbvz","exaa","ekbh","nhot","wlmq","ghlv","lkne","xumz","ngwl","vtak","zita",
+        "qthr","azig","luns","jvmi","rffd","eroy","nhhq","lojq","cuia","scec","adjs","kqma","itww","nmev","qmbd","sdfe",
+        "wras","dzrq","duyj","rcds","qnqa","iauv","kvdr","joit","fjnl","escc","iomk","uzpy","icay","cgzy","edzf","xdfd",
+        "gxyy","hrft","tjyh","dzob","xcvb","blhf","yzdb","fecr","nerh","xeex","tmhj","iuza","rlka","ueqe","svnu","exvi",
+        "yikb","qvhr","mnch","yjng","pufx","gzqd","nlxz","quxf","kcba","etow","piee","omno","yyfl","pdmh","lppw","owlk",
+        "gbrk","pmim","dqde","herm","igtt","ojem","kdmb","xiko","ablb","ykwd","oqmn","lxnd","sdbp","nykt","sgwa","rgkt",
+        "sujq","evxt","teaq","blbp","ghmz","gwmt","uswt","nxai","jmhw","qakn","bxqh","lpge","tajd","vbyl","dpdf","icdl",
+        "wsby","pral","swxp","jhyv","yrmx","qubx","gotc","uhoc","urgo","sdbn","vujo","gfbt","rgwo","mzgr","uamv","yzjq",
+        "ypol","pwzy","tbtc","dxsu","adnu","hmbk","ogka","lebh","jndp","ftaq","sfal","gepn","jgpo","gyke","xwun","ferf",
+        "hhmd","flgy","khnt","jqym","ypwr","vxfi","asnu","plnh","qkkc","bniq","rwpq","xrde","ilgd","ywwm","ienb","yqaw",
+        "ftez","eusy","bqvw","lpin","vwej","hopz","wphz","nbci","tskz","ctmx","ihju","mrsz","xfsi","dfsv","dslj","zvgk",
+        "ufvz","ogpr","uqhs","orgz","lxlt","qeys","nypp","xqqt","xtwn","dikx","cusx","ejga","oqgy","yych","yrxl","tono",
+        "uhfp","lfcj","hava","floj","ywiv","vake","tvyr","kuia","rddl","inqj","fins","xmcn","psyd","pnwl","fjos","zpua",
+        "mvjq","tziw","rmtz","ltyq","wasg","gbed","aibu","puxt","mzcz","pycr","zdlp","amdm","kcxk","ozaf","shrt","ppsu",
+        "kqfz","jrnf","yejo","lmzn","uums","haja","htju","qmbx","rhid","eedb","sspk","uewy","ppee","gypg","dukf","vxbk",
+        "ctbt","ypmh","paia","inwj","lnsd","dgxz","aacn","vxfk","xvmc","hcui","zunx","vtix","iyuk","dsio","hcgh","vrln",
+        "maxo","pjwe","eeni","gcpi","hljt","kpsg","rqfn","aqju","olyw","posi","vmdd","rdgm","cyvg","shxd","vhoq","fjqo",
+        "xgpx","mjdv","ziqn","nvin","yvlx","fpco","xuto","ltdo","revy","jlbq","dpvd","kocr","mpqb","hbrt","wvly","rctg",
+        "dxoi","rzil","ubhe","wnjz","cbff","wuuw","ftvw","erja","lmwb","bkwu","mupu","nbzi","cgha","hjxe","hvjk","igzl",
+        "rnch","pmod","ntck","mkui","dqbh","vogu","epzx","nsew","pkht","cthe","srok","jacs","gtjv","xttg","bbwr","krrf",
+        "bspg","deva","bdyd","unvr","crou","mrvx","slcz","zxct","qbib","ktgn","otgf","wcmq","ytwi","oeec","ptjt","efuq",
+        "zjbo","ielk","jspp","ybom","tihc","qtgv","mfrg","gunc","zqde","chax","rjdc","bfhj","pias","jnre","ntzl","ccvr",
+        "vdtk","hgmb","ywkv","ubig","oywm","gbyq","tfxw","dlon","oswp","dabv","qnzl","qrpo","dcuy","fers","ajuq","zmzd",
+        "uuah","wutt","xvjw","uvdc","hrbp","xiaq","ylxh","pmbd","mqeb","znyo","pagi","vnve","ryoa","yvgt","goyg","vazz",
+        "uvjl","hgoi","xlov","qkhm","fmwe","akvn","ctjh","jdlt","erpf","sxxx","hirg","odgy","mnig","dgbs","bcdq","hrrr",
+        "rswq","czpo","mmmt","cqgx","nsqd","vsvr","bbbg","mcrz","xtoa","rwtp","fppm","bjgd","pkwu","fgmg","dkuq","lrwy",
+        "dlcn","yrke","yexf","lqfa","yvol","bdqi","hxmk","zxgs","fttc","fsye","kctk","yyou","jufa","mkpi","donb","bhfk",
+        "iliu","vkts","rjod","ftit","rxpx","sffg","gqpc","jnyv","hzpt","anxi","xjtf","nblm","awoi","fgbu","qsaq","fewg",
+        "trbo","tysi","gkrb","oust","mezx","cagk","wfkk","alxj","kqih","jgjv","agmy","tulj","cqsa","ncyi","kdaa","owcg",
+        "zicc","uckj","kkar","jozy","eitq","qzfn","kdvx","zupg","zzmz","jezn","azzb","cclx","seov","wzuf","xxia","dypy",
+        "cuct","zilu","tkop","thsf","ohcf","hxdf","phns","rekg","sryx","mzfr","xghr","vyss","wybt","qucp","krvd","rkbd",
+        "vder","dgee","dmec","stgq","oxbf","fqsf","heut","ozbr","ixqn","nqgu","kufq","mcec","yggo","toun","ndfp","updc",
+        "rcoi","umcn","qpma","ocoo","tnor","ecaq","kwfh","bjyy","rlwf","apwl","pkem","jovr","kopd","rnky","pqpm","bmfi",
+        "yojg","agai","efuy","nkvm","wliu","hyzq","tyhu","fadk","hlui","qtig","bqli","ntue","ajgs","rfmn","lhwp","hhio",
+        "ljml","bnyb","xmdm","qhye","szrb","flfz","rndu","wybe","wcio","uqpe","zqqi","bags","nnzy","bgoj","ladi","gtpa",
+        "gzyo","vnox","kwek","iagq","fysx","vepy","ehva","stjz","ugjo","macf","bynl","ihuv","swlq","vdww","lktd","souz",
+        "xtpa","fkrg","lpsp","ganf","rrqk","qxcc","mntq","npjb","xlon","saut","zgnf","rthc","kfmm","whfl","glbd","frua",
+        "royk","psep","bept","laco","rfkq","oqhj","jesf","niss","dsrb","cwkx","ikje","mash","eurd","wbsk","rkjw","rulf",
+        "xtvn","kolb","gmns","zbjf","hgge","sgqd","jzey","ozjs","qzdm","uodk","vxxi","hxiu","ymop","vnau","jqme","bacy",
+        "hmrg","whnw","unio","icba","bixn","jdhi","cetg","fdvj","gjju","aaej","jpdo","iiix","vnfd","rfyn","rspv","cawh",
+        "hfjy","igbt","qqug","reoy","aenr","mbtk","bgot","eecl","gxzy","meca","lrqs","hnst","kuui","muex","nusy","rgka",
+        "lwra","flkq","ndwa","cfzn","strz","ilbd","rgxg","isfd","dsxq","zanx","ysmv","ixvp","gupj","jitm","quqx","wlwh",
+        "oypv","wzii","upxe","mmkt","ehcv","kmlr","ifqi","aban","znwo","szjo","lxbg","okpw","wcpf","ixkf","fypa","mjjf",
+        "gfng","gilq","nfwt","fitp","oumi","dchp","thvj","gtgo","dlot","tqcd","gvib","pqqi","xjte","riyb","dbxv","mfrb",
+        "dewv","zdex","giuo","ylsk","ceqc","baah","odql","fcru","mkmz","seea","siyy","tvjc","bnie","irip","sirg","octh",
+        "dvky","gnlr","yrgd","clwk","mcdr","fwwn","oveh","vcbf","ldcg","exet","krft","plpg","jrfb","ofxm","cyep","ubwm",
+        "ktat","bbtd","xtko","qozu","lwut","ujen","nyxx","xbnm","ohdq","kzbg","wqjc","uqec","skyl","gtub","bkoq","hlgt",
+        "twnr","xpds","wjle","fymi","qmlc","innz","fjhm","lzvl","zkpj","bysl","lulb","cszt","ossb","zobi","xusa","okqi",
+        "yrmw","vuda","bosh","yimv","ljdx","sfwi","viwj","wrsp","vskp","yctz","jxjd","lwud","fkzo","fkqf","jths","sgvh",
+        "iwps","osud","kojb","cedt","jlvv","vudh","xlog","zcik","licj","lrol","isey","aepy","uqty","bjkq","okbx","obih",
+        "bgmc","tgpm","ieoh","hjsd","edoe","cxsp","tzsv","qomr","zfxz","ivoh","dmmh","hylz","trqx","macl","kufu","wpwl",
+        "dgre","bhzw","bnur","haqp","dhte","ksni","idyj","vbal","minb","bhce","bphq","knpd","ggzq","urbe","fuwu","poip",
+        "mmfg","dwjb","tgcm","mwny","pzcx","ongc","zuoy","wrvh","ypso","frkx","erch","lptp","gzeg","rluk","ckhr","jwzb",
+        "fgro","zeec","xwtq","gajn","xdpr","sxzp","babk","qkks","yslx","mzpc","kycg","lvgp","rwor","ywwq","rqck","hhho",
+        "gftu","fzop","ogrv","htfs","ibmf","xodm","gpnb","wpae","gdqp","qnlv","xugp","nxnh","bcdl","ysfb","ljws","vdpn",
+        "iety","xywt","nvtm","viat","cdbh","jtev","kerb","vazi","cpdk","tmtl","fbgt","poqq","naje","cwzs","alhi","mbwn",
+        "kbcm","uxxt","zpba","thao","jonm","eunt","yhqj","gyyg","gmhp","bmtl","jgal","oilw","ucet","ihsq","vdph","evus",
+        "obqw","raff","cxtt","djdh","gdxw","ncza","fapv","qzrt","vhir","jfby","ogmk","fuin","yijf","oyqb","wryi","uhty",
+        "yqvl","ndad","ytys","dqyz","ojsm","qtcx","fcti","lwzb","qaye","qott","hohh","lhag","xqok","mijn","yunk","wmma",
+        "paxw","kxld","jgwy","qcun","mruc","tpjv","xzfl","wtxa","gtta","airy","cfzk","zuuk","lhcu","ktvb","fimb","kzrn",
+        "jgsc","crrt","kdxw","xptp","fdrq","ffrr","jkuu","cbmz","aodz","hurb","pexf","xftd","azqn","ypfv","nuxv","supw",
+        "zibp","itlv","drmf","xeic","xbrk","skbp","pijt","khka","vwrq","qsse","clyf","otvu","pgza","nodt","tntc","ljkv",
+        "mqxb","vkqu","xdii","kyti","gioi","dwuy","pfjz","evsp",
+};
+int global_keys_count = ARRAY_SIZE(global_keys);
+
+
+class ArtSpscOpGetFixture : public benchmark::Fixture {
+private:
+    art_tree tree = { nullptr };
+    char **_keys = (char**)global_keys;
+    int _keys_count = global_keys_count;
+public:
+    art_tree *GetArtTree() {
+        return &this->tree;
+    }
+
+    void SetUp(benchmark::State& state) override {
+        int res = art_tree_init(this->GetArtTree());
+
+        for (int index = 0; index < this->_keys_count; index++) {
+            char *key_dup = (char*)xalloc_alloc(strlen(_keys[index]) + 1);
+            strcpy(key_dup, _keys[index]);
+            key_dup[strlen(_keys[index])] = '\0';
+
+            art_insert(
+                    this->GetArtTree(),
+                    (const unsigned char *)key_dup,
+                    strlen(_keys[index]),
+                    _keys[index]);
+        }
+    }
+
+    void TearDown(const ::benchmark::State &state) override {
+        art_tree_destroy(this->GetArtTree());
+    }
+};
+
+BENCHMARK_DEFINE_F(ArtSpscOpGetFixture, FindTokenInHashtableWorstCase1Benchmark)(benchmark::State& state) {
+    char *non_existing_key = "0000";
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(art_search(
+                this->GetArtTree(),
+                (const unsigned char*)non_existing_key,
+                strlen(non_existing_key)));
+    }
+}
+
+BENCHMARK_DEFINE_F(ArtSpscOpGetFixture, FindTokenInHashtableAvgCase1Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[0];
+    size_t key_length = strlen(global_keys[0]);
+    art_tree *art_tree = this->GetArtTree();
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(art_search(
+                art_tree,
+                (const unsigned char*)key,
+                key_length));
+    }
+}
+
+BENCHMARK_DEFINE_F(ArtSpscOpGetFixture, FindTokenInHashtableAvgCase2Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[3000];
+    size_t key_length = strlen(global_keys[3000]);
+    art_tree *art_tree = this->GetArtTree();
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(art_search(
+                art_tree,
+                (const unsigned char*)key,
+                key_length));
+    }
+}
+
+static void BenchArguments(benchmark::internal::Benchmark* b) {
+    b->Iterations(1000000);
+}
+
+BENCHMARK_REGISTER_F(ArtSpscOpGetFixture, FindTokenInHashtableWorstCase1Benchmark)
+    ->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(ArtSpscOpGetFixture, FindTokenInHashtableAvgCase1Benchmark)
+    ->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(ArtSpscOpGetFixture, FindTokenInHashtableAvgCase2Benchmark)
+    ->Apply(BenchArguments);

--- a/benches/bench-hashtable-mpmc-old-op-get.cpp
+++ b/benches/bench-hashtable-mpmc-old-op-get.cpp
@@ -75,66 +75,6 @@ static void hashtable_op_get_not_found_key(benchmark::State& state) {
     }
 }
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-static void hashtable_op_get_single_key_inline(benchmark::State& state) {
-    static hashtable_t* hashtable;
-    static hashtable_bucket_index_t bucket_index;
-    static hashtable_chunk_index_t chunk_index;
-    static hashtable_chunk_slot_index_t chunk_slot_index;
-    hashtable_value_data_t value;
-    bool result;
-    char error_message[150] = {0};
-    worker_context_t worker_context = { 0 };
-
-    worker_context.worker_index = state.thread_index();
-    worker_context_set(&worker_context);
-    transaction_set_worker_index(worker_context.worker_index);
-
-    if (state.thread_index() == 0) {
-        hashtable = test_support_init_hashtable(state.range(0));
-
-        bucket_index = test_key_1_hash % hashtable->ht_current->buckets_count;
-        chunk_index = HASHTABLE_TO_CHUNK_INDEX(bucket_index);
-        chunk_slot_index = 0;
-
-        HASHTABLE_SET_KEY_INLINE_BY_INDEX(
-                chunk_index,
-                chunk_slot_index,
-                test_key_1_hash,
-                test_key_1,
-                test_key_1_len,
-                test_value_1);
-    }
-
-    test_support_set_thread_affinity(state.thread_index());
-
-    for (auto _ : state) {
-        benchmark::DoNotOptimize((result = hashtable_mcmp_op_get(
-                hashtable,
-                test_key_1,
-                test_key_1_len,
-                &value)));
-
-        if (!result) {
-            sprintf(
-                    error_message,
-                    "Unable to get the key <%s> with bucket index <%lu>, chunk index <%lu> and chunk slot index <%u> for the thread <%d>",
-                    test_key_1,
-                    bucket_index,
-                    chunk_index,
-                    chunk_slot_index,
-                    state.thread_index());
-            state.SkipWithError(error_message);
-            break;
-        }
-    }
-
-    if (state.thread_index() == 0) {
-        hashtable_mcmp_free(hashtable);
-    }
-}
-#endif
-
 static void hashtable_op_get_single_key_external(benchmark::State& state) {
     static hashtable_t* hashtable;
     static hashtable_bucket_index_t bucket_index;
@@ -158,7 +98,7 @@ static void hashtable_op_get_single_key_external(benchmark::State& state) {
         char *test_key_1_clone = (char*)xalloc_alloc(test_key_1_len + 1);
         strncpy(test_key_1_clone, test_key_1, test_key_1_len);
 
-        HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+        HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                 chunk_index,
                 chunk_slot_index,
                 test_key_1_hash,
@@ -205,11 +145,6 @@ static void BenchArguments(benchmark::internal::Benchmark* b) {
 
 BENCHMARK(hashtable_op_get_not_found_key)
         ->Apply(BenchArguments);
-
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-BENCHMARK(hashtable_op_get_single_key_inline)
-        ->Apply(BenchArguments);
-#endif
 
 BENCHMARK(hashtable_op_get_single_key_external)
         ->Apply(BenchArguments);

--- a/benches/bench-hashtable-mpmc-old-op-set.cpp
+++ b/benches/bench-hashtable-mpmc-old-op-set.cpp
@@ -387,19 +387,6 @@ public:
         }
 
         if (state.thread_index() == 0) {
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-            // Free up the memory allocated for the first keyset slots generated
-            test_support_free_keyset_slots((test_support_keyset_slot_t *)static_keyset_slots);
-
-            // Re-initialize the keyset, the random generator in use will re-generate exactly the same set as we are
-            // using the same random seed (although the generator will not generate them in the same order because
-            // threads are used but that's doesn't matter)
-            static_keyset_slots = test_support_init_keyset_slots(
-                    this->_requested_keyset_size,
-                    KEYSET_GENERATOR_METHOD,
-                    544498304);
-#endif
-
             static_storage_db_populated = true;
             MEMORY_FENCE_STORE();
         }

--- a/benches/bench-hashtable-spsc-op-get.cpp
+++ b/benches/bench-hashtable-spsc-op-get.cpp
@@ -9,7 +9,13 @@
 #include <cstring>
 #include <benchmark/benchmark.h>
 
-#include "benchmark-program.hpp"
+#include "exttypes.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "memory_allocator/ffma.h"
+#include "xalloc.h"
+
+#include "benchmark-program-simple.hpp"
 
 #include "data_structures/hashtable/spsc/hashtable_spsc.h"
 
@@ -17,53 +23,321 @@
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
 char *global_keys[] = {
-        "SET", "ACL", "ACL CAT", "ACL DELUSER", "ACL DRYRUN", "ACL GENPASS", "ACL GETUSER", "ACL HELP", "ACL LIST", "ACL LOAD",
-        "ACL LOG", "ACL SAVE", "ACL SETUSER", "ACL USERS", "ACL WHOAMI", "APPEND", "ASKING", "AUTH", "BGREWRITEAOF",
-        "BGSAVE", "BITCOUNT", "BITFIELD", "BITFIELD_RO", "BITOP", "BITPOS", "BLMOVE", "BLMPOP", "BLPOP", "BRPOP",
-        "BRPOPLPUSH", "BZMPOP", "BZPOPMAX", "BZPOPMIN", "CLIENT", "CLIENT CACHING", "CLIENT GETNAME", "CLIENT GETREDIR",
-        "CLIENT HELP", "CLIENT ID", "CLIENT INFO", "CLIENT KILL", "CLIENT LIST", "CLIENT NO-EVICT", "CLIENT PAUSE",
-        "CLIENT REPLY", "CLIENT SETNAME", "CLIENT TRACKING", "CLIENT TRACKINGINFO", "CLIENT UNBLOCK", "CLIENT UNPAUSE",
-        "CLUSTER", "CLUSTER ADDSLOTS", "CLUSTER ADDSLOTSRANGE", "CLUSTER BUMPEPOCH", "CLUSTER COUNT-FAILURE-REPORTS",
-        "CLUSTER COUNTKEYSINSLOT", "CLUSTER DELSLOTS", "CLUSTER DELSLOTSRANGE", "CLUSTER FAILOVER", "CLUSTER FLUSHSLOTS",
-        "CLUSTER FORGET", "CLUSTER GETKEYSINSLOT", "CLUSTER HELP", "CLUSTER INFO", "CLUSTER KEYSLOT", "CLUSTER LINKS",
-        "CLUSTER MEET", "CLUSTER MYID", "CLUSTER NODES", "CLUSTER REPLICAS", "CLUSTER REPLICATE", "CLUSTER RESET",
-        "CLUSTER SAVECONFIG", "CLUSTER SET-CONFIG-EPOCH", "CLUSTER SETSLOT", "CLUSTER SHARDS", "CLUSTER SLAVES",
-        "CLUSTER SLOTS", "COMMAND", "COMMAND COUNT", "COMMAND DOCS", "COMMAND GETKEYS", "COMMAND GETKEYSANDFLAGS",
-        "COMMAND HELP", "COMMAND INFO", "COMMAND LIST", "CONFIG", "CONFIG GET", "CONFIG HELP", "CONFIG RESETSTAT",
-        "CONFIG REWRITE", "CONFIG SET", "COPY", "DBSIZE", "DEBUG", "DECR", "DECRBY", "DEL", "DISCARD", "DUMP", "ECHO",
-        "EVAL", "EVALSHA", "EVALSHA_RO", "EVAL_RO", "EXEC", "EXISTS", "EXPIRE", "EXPIREAT", "EXPIRETIME", "FAILOVER",
-        "FCALL", "FCALL_RO", "FLUSHALL", "FLUSHDB", "FUNCTION", "FUNCTION DELETE", "FUNCTION DUMP", "FUNCTION FLUSH",
-        "FUNCTION HELP", "FUNCTION KILL", "FUNCTION LIST", "FUNCTION LOAD", "FUNCTION RESTORE", "FUNCTION STATS", "GEOADD",
-        "GEODIST", "GEOHASH", "GEOPOS", "GEORADIUS", "GEORADIUSBYMEMBER", "GEORADIUSBYMEMBER_RO", "GEORADIUS_RO",
-        "GEOSEARCH", "GEOSEARCHSTORE", "GET", "GETBIT", "GETDEL", "GETEX", "GETRANGE", "GETSET", "HDEL", "HELLO",
-        "HEXISTS", "HGET", "HGETALL", "HINCRBY", "HINCRBYFLOAT", "HKEYS", "HLEN", "HMGET", "HMSET", "HRANDFIELD",
-        "HSCAN", "HSET", "HSETNX", "HSTRLEN", "HVALS", "INCR", "INCRBY", "INCRBYFLOAT", "INFO", "KEYS", "LASTSAVE",
-        "LATENCY", "LATENCY DOCTOR", "LATENCY GRAPH", "LATENCY HELP", "LATENCY HISTOGRAM", "LATENCY HISTORY",
-        "LATENCY LATEST", "LATENCY RESET", "LCS", "LINDEX", "LINSERT", "LLEN", "LMOVE", "LMPOP", "LOLWUT", "LPOP",
-        "LPOS", "LPUSH", "LPUSHX", "LRANGE", "LREM", "LSET", "LTRIM", "MEMORY", "MEMORY DOCTOR", "MEMORY HELP",
-        "MEMORY MALLOC-STATS", "MEMORY PURGE", "MEMORY STATS", "MEMORY USAGE", "MGET", "MIGRATE", "MODULE", "MODULE HELP",
-        "MODULE LIST", "MODULE LOAD", "MODULE LOADEX", "MODULE UNLOAD", "MONITOR", "MOVE", "MSET", "MSETNX", "MULTI",
-        "OBJECT", "OBJECT ENCODING", "OBJECT FREQ", "OBJECT HELP", "OBJECT IDLETIME", "OBJECT REFCOUNT", "PERSIST",
-        "PEXPIRE", "PEXPIREAT", "PEXPIRETIME", "PFADD", "PFCOUNT", "PFDEBUG", "PFMERGE", "PFSELFTEST", "PING", "PSETEX",
-        "PSUBSCRIBE", "PSYNC", "PTTL", "PUBLISH", "PUBSUB", "PUBSUB CHANNELS", "PUBSUB HELP", "PUBSUB NUMPAT", "PUBSUB NUMSUB",
-        "PUBSUB SHARDCHANNELS", "PUBSUB SHARDNUMSUB", "PUNSUBSCRIBE", "QUIT", "RANDOMKEY", "READONLY", "READWRITE", "RENAME",
-        "RENAMENX", "REPLCONF", "REPLICAOF", "RESET", "RESTORE", "RESTORE-ASKING", "ROLE", "RPOP", "RPOPLPUSH", "RPUSH",
-        "RPUSHX", "SADD", "SAVE", "SCAN", "SCARD", "SCRIPT", "SCRIPT DEBUG", "SCRIPT EXISTS", "SCRIPT FLUSH", "SCRIPT HELP",
-        "SCRIPT KILL", "SCRIPT LOAD", "SDIFF", "SDIFFSTORE", "SELECT", "SETBIT", "SETEX", "SETNX", "SETRANGE", "SHUTDOWN",
-        "SINTER", "SINTERCARD", "SINTERSTORE", "SISMEMBER", "SLAVEOF", "SLOWLOG", "SLOWLOG GET", "SLOWLOG HELP", "SLOWLOG LEN",
-        "SLOWLOG RESET", "SMEMBERS", "SMISMEMBER", "SMOVE", "SORT", "SORT_RO", "SPOP", "SPUBLISH", "SRANDMEMBER", "SREM",
-        "SSCAN", "SSUBSCRIBE", "STRLEN", "SUBSCRIBE", "SUBSTR", "SUNION", "SUNIONSTORE", "SUNSUBSCRIBE", "SWAPDB", "SYNC",
-        "TIME", "TOUCH", "TTL", "TYPE", "UNLINK", "UNSUBSCRIBE", "UNWATCH", "WAIT", "WATCH", "XACK", "XADD", "XAUTOCLAIM",
-        "XCLAIM", "XDEL", "XGROUP", "XGROUP CREATE", "XGROUP CREATECONSUMER", "XGROUP DELCONSUMER", "XGROUP DESTROY",
-        "XGROUP HELP", "XGROUP SETID", "XINFO", "XINFO CONSUMERS", "XINFO GROUPS", "XINFO HELP", "XINFO STREAM", "XLEN",
-        "XPENDING", "XRANGE", "XREAD", "XREADGROUP", "XREVRANGE", "XSETID", "XTRIM", "ZADD", "ZCARD", "ZCOUNT", "ZDIFF",
-        "ZDIFFSTORE", "ZINCRBY", "ZINTER", "ZINTERCARD", "ZINTERSTORE", "ZLEXCOUNT", "ZMPOP", "ZMSCORE", "ZPOPMAX", "ZPOPMIN",
-        "ZRANDMEMBER", "ZRANGE", "ZRANGEBYLEX", "ZRANGEBYSCORE", "ZRANGESTORE", "ZRANK", "ZREM", "ZREMRANGEBYLEX",
-        "ZREMRANGEBYRANK", "ZREMRANGEBYSCORE", "ZREVRANGE", "ZREVRANGEBYLEX", "ZREVRANGEBYSCORE", "ZREVRANK", "ZSCAN",
-        "ZSCORE", "ZUNION", "ZUNIONSTORE",
+        "oemd","jluy","mriw","phqu","bxzm","jaqi","hopc","deqk","rmje","lyvx","mlqq","bfqc","vncj","laxm","mtms","lrvy",
+        "goxz","skvl","rtmm","vjno","bwvg","nllk","cgad","wfot","wckw","zlby","hejy","kcud","esny","dbcn","dvcm","ivzy",
+        "bcvf","kmbs","dasp","ncbo","ebkz","yvfb","xjvu","qdnd","ikyn","zztf","svkz","nnkf","hywx","thhr","hnkp","yvkl",
+        "ctte","fqvl","lymx","gbdw","njdl","wdqb","rdfj","eiky","zdcg","tsww","umgu","qaif","yvjx","tmxj","bgld","abms",
+        "krva","qnuz","qumy","jplz","gsao","cqlb","ebaq","renk","budf","mavg","nghe","wzop","kvju","cmha","deaz","xwdu",
+        "npvg","mgtu","cpxq","teuy","rjej","omst","elrv","olfy","wvma","pvkb","tnob","jxzg","ttud","udpd","ltgr","odop",
+        "soei","towc","cmun","xxrj","jvvr","uolj","rcyn","rlhm","ktdh","krsh","syyp","zmro","kqsm","klec","gtkx","ztus",
+        "mwes","dmob","vtqm","jpid","addl","ubxm","wjgk","vafc","zwjv","xxfk","drie","xwrw","zzmn","cjij","paaq","wbgi",
+        "mdtn","fnat","uuun","mkzx","btco","gpsi","lses","icza","sqqa","bdes","xtao","vshn","wurp","ywam","axpy","ekke",
+        "rmwc","fdzt","rumb","jwyt","ijgv","hzqq","tpki","gjbn","fxqi","vfic","cfrt","uyza","proc","ocje","bddi","vfgu",
+        "poaw","wixj","odlh","lxhv","valg","edss","greq","kwez","jmup","vgfc","pocj","dwwe","xmfh","eeke","zlte","ynqv",
+        "fanw","tssc","fuzn","dmgb","rkbc","yzqb","pvdu","iypk","aqws","guub","dant","rlfj","jhgx","rosg","vmwz","pfbt",
+        "wxms","tfzk","ucfb","ioyi","zsqp","xpcj","pgtz","manv","dvyv","cncx","vjvs","jhvv","djyq","kskr","txxh","vzjy",
+        "uzdt","iino","dtcs","kxte","oizl","moqq","fkej","ddoa","tjov","aebb","ovbc","sris","lcqs","swhi","ndlm","spla",
+        "tmgm","urmd","lxmo","rpmh","kkyt","llnq","vvdu","egsx","fsma","htvu","yyxj","peru","pfpk","jdmp","fcvd","rhsc",
+        "ajqg","maba","hhor","pjwg","yonp","bpdl","utmz","zmpb","hswe","zzgn","yfgr","srwa","qxnk","jgif","mrlv","puvr",
+        "ryhs","htyd","hiuh","vuvc","bdzn","fpyg","mqgk","haik","nebx","jywe","jcij","zmlw","hznm","jrfj","krlv","aeaa",
+        "mpeh","whzw","pzfb","zllb","pgvt","kspt","argm","zubb","itoj","ryhy","ehvk","kufp","awpa","cnsu","jzzd","zfbd",
+        "rbns","jduj","gjeg","grvp","yjmo","rrfc","puad","ovaa","xwgw","cbfp","nzxn","hnxy","mlqb","wexf","ltbi","mcdk",
+        "vdkj","tkme","pivb","ggra","qnrg","ggky","gbck","ccdj","rcgr","icjx","vdub","zxfm","lcry","whxk","kxll","bxlk",
+        "yiqo","zfqk","ywmc","pyod","vcoy","depw","mmoa","rxlm","wxdn","ocif","glyb","kbty","fqyv","dtcz","ghcf","fydf",
+        "ejey","egrq","mpmg","mpom","mgst","xcwz","jxqd","lrzi","hytx","nudh","jtbd","gbqj","lqqx","kdbn","xaul","ytbg",
+        "aiep","hjii","ndyp","uskt","tprd","lvzo","rmpo","vejd","bpqu","arbh","qawk","mdxw","amkj","yhax","redc","ncfd",
+        "tjuc","ylti","nfpa","jdql","txix","dwnm","fzrb","bfvr","sudc","zsor","etun","diry","xtxn","mwbo","oylw","wpki",
+        "eogv","mnrf","lrug","agdv","rtnv","orbz","otgn","iaza","rghl","dfoe","ppqz","cjry","gdtu","wtko","pppg","mltr",
+        "uzlt","xqcy","qsll","seme","scvz","ikno","evoa","mfpc","ueku","cuqf","dske","ugbf","onga","zkxm","biuk","swvl",
+        "njkv","oxrq","surs","uucf","seug","zjjy","ewbo","msgp","izwz","ktrj","yagb","jstk","wfzi","tqcw","egvs","txqp",
+        "jahk","xzrl","jnor","ekno","ralq","njxr","uqhd","vyze","hgwm","kqbn","cmnw","cgkg","uadg","zcqw","rflf","efev",
+        "zzvx","gvxk","ufsh","fcsj","tpyj","waee","mvtn","pxkz","kqms","anom","egxv","kiyq","oovy","gare","uafm","knav",
+        "tsnb","ccuq","mcsc","mkzv","qodw","nici","rrgx","glzz","ntko","aimx","kbqg","dxeu","aabh","mfsw","vdbz","tidh",
+        "pkmo","hhkr","oobg","clkh","kzfj","dgqj","kdes","thia","ymue","rplf","mweh","ehkw","wyjt","qpmb","snmv","zbkm",
+        "zwyc","mqii","rwhm","buzi","afdn","uzek","ftlz","pkvi","mjwn","cikp","mwea","cday","hwur","axpw","gmrv","nxom",
+        "ppwp","fabw","kvbv","rntf","lxaz","iiab","hxix","iqjv","fssw","hzty","mgwp","rckr","fler","cmal","tuuo","iiux",
+        "jlhd","euzm","zqwl","weai","pylq","tctt","cdrj","vrkg","ppni","dfjj","jwgw","itwj","nmcf","kfpf","gcnw","dfpp",
+        "bueh","nlhn","isys","skko","lqrf","lieu","ijgp","eeqg","cnym","wkev","kqly","papp","aifu","ctve","bnlp","polx",
+        "ktim","ftcd","puse","xsrm","rmvi","hify","peyq","tnhq","ugvo","anpy","tbch","igul","ztxe","kaop","alwy","kiyx",
+        "bpaf","qahf","nfck","qirn","qbzq","kzeg","objq","cjzi","jzfa","pztu","ftlo","rose","zprv","rvio","jgks","dvic",
+        "vlli","fgqx","vrxb","ngif","bueu","ceiy","hnxj","jnug","oqvo","muqs","ryhx","ujke","jipn","jujb","zxye","furs",
+        "wpmh","ehlx","nlfx","eapi","scgx","qaup","uwpb","hlqb","fqgy","nlso","mcrn","jiyh","tigp","ijgs","eadj","jcsm",
+        "mdsa","skku","gnnh","uyau","pims","ybxo","sptc","jxrw","fqxf","ecvm","plxf","lucb","neak","cecr","wvkv","mntk",
+        "gysu","fnsr","ikpo","zegm","jxer","znqp","mhts","oykt","elih","jaad","ihec","bthu","mmor","cekh","okmu","wrac",
+        "lfxr","zeus","kced","svnc","qfox","wxvl","uqrt","msib","nmox","qrcj","avyc","elya","urul","qkci","wioi","zxzr",
+        "urtw","tccb","oqja","ejlr","iahc","ingv","yjju","ehvl","plty","coie","yzta","itad","rxkx","rxnk","lrgq","qlyh",
+        "sgfq","ebyq","akad","jjog","ssee","bszh","wkcx","lgap","nxkx","anzk","fzrh","bgdk","srzo","xfqc","mjoy","rusr",
+        "bcfs","xywe","ncnu","fyyv","mfze","fhba","shht","xros","rfxr","gpxk","tgjh","vgmo","rllu","gogb","gdbd","bhob",
+        "szxd","yamh","aeyy","jxkd","wnmw","nxhm","uolt","ymph","zdms","vdwe","jvmu","hshc","xoze","dkvx","ewsc","wmjl",
+        "nckk","itzb","zunq","orjg","zidy","wvas","cyij","khra","clqo","erwb","mamb","tsch","zuir","icrb","wwwu","xkod",
+        "xeeo","ugfu","fihz","osxd","baij","jcoo","zogt","orib","gmnd","wwmg","eilb","bcll","blbt","ucjy","tnto","dfdz",
+        "rrtp","kjdj","ynxu","aswn","aztn","gvdp","jcsf","aceh","yalp","ayga","znjd","thes","sxmk","sqze","vlbt","ztny",
+        "rfby","dlob","wxqy","hdnm","jlxz","zmvo","wizg","rbfv","vvyu","sdzi","uaiw","cslo","tycf","rlrs","wiis","lkeh",
+        "pmtq","rkoi","ewbd","uokr","dist","hqjn","uqce","zafy","smdu","aebz","rcuo","msdh","krtu","xkjt","dgxj","eova",
+        "qqct","iefq","ylys","bwrl","hjmj","tgmy","fegx","eqvz","ldil","jypr","kzgw","ndzh","vsig","xpub","jfcb","bkmb",
+        "eerj","qoih","jptr","hhih","vxie","qbbm","taro","pqwc","gkft","vzam","ytxb","wanh","skiy","shld","ihog","jzdb",
+        "igkq","bjvp","fqvt","hufv","qarc","kvnj","qykk","jcrc","aocd","uuqr","huve","rosu","ejdo","knku","oreb","qlnr",
+        "krmk","dpid","eevy","ibhx","dceq","rqrr","vgcw","azfg","xhxh","patu","bzcu","xslu","wsoc","pzhg","jbla","yxih",
+        "ptyw","egfl","syrw","fbhz","hsyy","tabv","vpqi","lphw","iydc","swdw","fbrs","eovg","eaqu","uftg","kryd","lsnw",
+        "ddji","ulxe","ajsu","zixr","rqwc","cavl","anzt","coki","qcis","hliq","txoq","jysr","cfum","tquw","imcv","zijo",
+        "zooe","nlzi","wvwu","unfz","dzcf","sofe","hmmd","hdef","lbbc","zmox","kvmi","qzkf","raxm","dbiv","mbwm","yyod",
+        "eyph","fbto","egfs","mfcc","caww","gooq","pqlo","thjk","umjo","htga","ygtx","pqib","lpvw","tlli","xhhj","glfn",
+        "jwme","soro","cquc","jpxp","hgkh","ftol","ohmr","hggd","evhs","fmlv","dtiw","wgpx","pnqe","kmrq","xymm","gfeb",
+        "oonx","hjei","xugd","bzcw","jpck","qarp","zead","zxbx","okeo","fvxk","rgni","wufi","zjbe","hsby","riyl","rukc",
+        "tjal","zias","otwz","mkdj","hdpg","utpb","hhoz","olum","cvji","jtfp","tsua","dunx","voqy","roho","dgen","mtod",
+        "kwpo","sidd","hkfk","ugjj","file","krnn","lgxe","xbjk","vwbr","xngh","aciq","klyi","kcpe","hcby","iucu","cbep",
+        "orbr","iqbk","ktyl","iuzd","wuzo","uptg","bzoa","yvzu","ybdv","bvir","kmwc","evuq","ihnk","pkyn","arqd","hllf",
+        "gjpi","uxxo","qoni","epoc","ypzx","tmhi","umxn","swcx","elqe","utrk","blkv","htrw","tqai","foje","clna","wckj",
+        "avrh","lcct","ckpn","hpry","subk","lpzp","wdzy","cgxa","fqps","lwol","anvc","fsvn","oqyy","cfhy","tqmv","ntbb",
+        "dmqy","wjmh","qmsq","dxfr","ojuu","xgwj","ygmc","zrqv","bzwj","xvvu","cpdf","wavs","crkq","kjmj","lxpz","eayw",
+        "hscj","yaen","pvkl","qumo","nnuw","mfdm","vknm","monj","vdjb","hitv","llgf","tmte","npio","jpcs","qacb","iuge",
+        "gzgt","awui","ckxy","bnhj","kruy","ylwi","ylnm","cczc","ifih","zyxt","lftj","dwhc","osxv","tffo","hxzr","ggxx",
+        "jpwn","nfhg","rpra","mvvu","pzxf","xias","xlme","tuvr","ucav","sdbj","twks","lthw","fkpd","lljq","xekl","zgre",
+        "uqnw","lxgo","xtwo","fbrd","bksr","idvy","mozy","ynfp","lxkk","ylym","gffy","qdfb","yhmm","ffof","fzzj","ifry",
+        "ktkr","pbat","bhqa","zmqc","iqjz","ffpe","ezxw","yirm","hsak","fwfg","rplh","dfmh","ajti","gpkw","iveh","hlcy",
+        "ymbr","vsiy","eqns","ludj","qrfn","vwvq","ozyp","xedq","cvpl","wnoi","ixqy","yjpn","gtvh","vmaa","ausi","vkui",
+        "mtgt","zbeh","oybb","pcvf","gpms","ntyf","kdry","datm","cihh","njtk","apgk","xyoq","aibs","cgzk","qovd","hjdx",
+        "hvwy","vgto","eauz","nawq","kjzn","bayg","xmzx","vztz","fbie","nnmi","pwus","ktjz","zvdw","lrmq","uqqx","qthl",
+        "mxki","xirf","ytck","skhg","jzkl","ejnw","ifdp","eohv","klxa","dwqp","gdhk","mfod","afaz","hjjy","fbtx","mmrl",
+        "mcgl","tilp","qsjn","wnfv","tijk","rrmj","byei","mfqp","eixo","kqxx","jzja","hnmg","oiev","ijtk","osqq","stfy",
+        "dnib","iwsp","xvtk","mdrp","cxta","jhqn","wrjw","kdib","flql","gkia","hmln","zxce","wytl","shiv","ugou","vhtn",
+        "rgja","riqq","gxgg","fsfq","uyrq","ecco","yehc","flll","yycv","jxvt","zhni","rzqk","absd","fpop","dubv","ctqn",
+        "terv","hrgl","updu","zfsl","xuym","cour","acua","fnhp","dzix","ofqt","bpax","ityp","eqpv","cebw","ndoa","bclk",
+        "eeie","frry","paex","vglz","sfzf","iwus","nivz","pcfo","dftm","eils","udll","tyih","quku","adkj","jcsx","vnjf",
+        "oqot","pnfb","jatg","wbqc","sisn","dign","pbdy","wfrw","dldb","ngsb","ivzp","umsc","buqf","fzfh","pwef","qief",
+        "dvft","mbpx","qeln","punk","kmcw","fmxr","kaqa","ocra","lmub","vqam","ouyu","utrr","zpre","saay","kryo","room",
+        "xjoh","hhwq","kagt","qhkc","dnxe","zoal","pwal","ccbg","kcze","ujcm","blwq","rfke","etou","olnm","kvqw","iyzt",
+        "avuz","cwsq","isbr","ibwu","gkat","oxif","uobc","lrqm","uzur","hqxo","dfuw","bimp","imrb","tdcq","ednj","ktbn",
+        "yzeu","iaay","bfko","dvlf","atso","jthx","olyq","rpnp","dhke","iaqu","pkdh","jrkz","neyo","skdf","cylk","zjyu",
+        "juzu","svhn","scmy","jvvz","pdby","kecz","bhxv","ksjz","dtjp","hdvb","ewhf","ezbh","kyak","csxn","nfxj","ymwq",
+        "bkja","fjvw","masy","iqod","zmbf","jrsd","ugri","smaz","lbvd","fjrp","pdir","ngos","qyek","hyoq","vdkw","rtad",
+        "skau","cstw","rgkw","ywmq","zuye","iahe","faev","dayd","isvt","uyag","hpun","sldi","oakd","orgy","spij","tici",
+        "pylx","ffaf","bjsz","wezk","ciur","clzx","ajjw","lekj","wseq","ramw","yogk","owmy","wdsc","wsnw","kprw","fwar",
+        "ekjt","lqyf","wold","gvvx","qoiz","gstf","sakk","whmm","odrk","edeu","vyjk","wnyg","ovau","xzaw","reqw","hygn",
+        "iteu","jfsj","eluz","brwi","iwzn","dneh","byjk","fnhy","mpar","fsbr","lyjl","yxmx","zhng","xneh","ckna","ucuy",
+        "gsrm","krwp","mxfz","buza","rocv","qqlm","gxwc","sevz","azpx","fyzg","ouwg","rxqs","txae","ubbf","osia","zrdk",
+        "erew","sdiu","jbeq","rmfb","rlgz","pamm","ainv","jfeu","wyxt","bknw","ttnp","xebm","untc","rbpx","hjts","ovev",
+        "wkcn","lgno","qlmp","wiuv","oxll","mkqj","hxqf","iffk","dlnq","lqva","enef","njmj","rrhi","gvna","aitb","iudf",
+        "fmdl","jdey","ojyq","ygyz","rlgc","lura","ashh","cewj","sccz","miwr","mwnn","wgjx","syft","vadj","cgrr","kxjg",
+        "xogw","mzph","eioy","wzim","srfx","xnjd","nqtr","xfox","dege","fhic","gwku","vwwp","king","lxqq","aluo","hqmb",
+        "avpe","ggjj","tvug","cbna","hpkf","irqy","kaqm","rcqi","vmme","xwcq","joya","djpg","ajba","hpsp","prkk","soxw",
+        "lyze","pjcs","rjmu","bofg","othd","qynp","aqeo","alyl","uybe","mjsn","zwpo","gvpw","zzqp","qxet","fvgw","lcnu",
+        "cekt","xknz","wfox","ulhx","yrdp","ozuj","bvjg","zoup","wajy","cqms","ujxn","sdam","ijwe","fjbl","fmnq","jheu",
+        "ukas","wdgg","rwzi","pcob","vlig","wdcc","gwnq","apej","hlso","agym","fexf","viww","fzjh","ukky","jerk","hwbh",
+        "tpzr","uwaw","eznu","ryod","tzhk","kcne","uepv","owxy","rgxc","clfh","dkrb","yloh","pwhq","ceuo","hnpy","qlnj",
+        "kkaz","dyps","yfjf","skqb","chgw","ddvg","sjpx","xuhp","gimq","bdaf","kuel","efar","wrtr","gigx","chfs","zzkv",
+        "jrhz","thjx","ujvl","smbe","nese","sxli","iknp","evkb","mrlp","urob","wcoz","hfmu","tilx","bhhj","zwyy","wotu",
+        "pntt","ozow","ynpb","jrsm","pcxq","cgqd","cqru","lwgw","dhjo","ubze","zvsj","zkoc","qktb","xvbt","fbms","yoxc",
+        "llkm","bsef","anjf","lfcy","jdhq","hvka","ubzb","fwyt","vfhm","apyh","ytng","ysyk","npqi","ofgr","cnac","tuze",
+        "vcrf","ayla","hkrq","lyej","seww","eqvn","wtab","ywmw","ukgk","gmqm","ople","pmdn","vzop","cxhr","wpta","kycz",
+        "lrat","flku","xlld","ztxr","ehyn","mgoc","keed","dcgf","twjm","gptz","pzrc","jcet","othq","uhyh","uqro","fkql",
+        "tujs","amjb","mxif","arrs","abiu","yuud","vdwi","ldnp","pczb","yxjn","xyzp","kiac","tslv","elza","lgcp","vbaz",
+        "woli","lmhw","jkyy","pqqu","dblv","doem","hffd","agem","zmah","obpn","lleh","ecuk","reah","twnq","qlzg","bvcc",
+        "zrqa","vxqs","ojea","hvjq","aihk","cann","cugx","syar","izib","hmlr","wrsz","yewl","rbur","qmms","jbqi","ovpm",
+        "hulk","omyy","kfzx","zzgp","hkha","jqod","fylu","abzg","jjzg","obft","owug","yefs","avhr","ieuu","favr","sclk",
+        "ufvd","mkaw","rtoz","qzle","cvah","ltbh","asyq","gszi","dfry","uioi","soxa","ozjq","acga","smef","kgzy","wzrh",
+        "eibw","pblp","qthp","yxuf","qmqk","zmjq","gwvh","uedj","rkxk","pvaj","hrhz","tnha","cgxe","tfyy","lbuq","jycl",
+        "anca","uehf","qvnj","etwq","xfid","gqlg","rooz","gbgi","cppp","jpcp","gfdy","tpld","ragl","acmn","rndj","blkn",
+        "bcux","ndud","gbho","blug","bpub","takl","qozb","zlbz","vfbv","iiyn","swbe","kocp","yeyo","fatp","kzup","bdxk",
+        "wyog","wxkh","ixez","ghpj","vstx","otio","yqfz","zxdd","fvbs","uiok","hnka","orav","uzbw","mbhf","lcam","jrkj",
+        "aobd","izum","hixs","qolb","bewj","qxjq","bxtu","mcip","zfxu","oghs","opza","mqtu","xtpo","etva","pmkm","vzfc",
+        "icdm","dkap","nyuk","wpfc","payu","eowd","tpen","lveg","kuxi","zahi","kzqf","tegy","cfmw","owqh","dueh","hddn",
+        "xjdg","appy","zmat","ufzi","swhn","btqb","jqcs","fjid","yylk","zhcf","rmvl","jsgb","qmjc","tfwx","rnaf","mvgf",
+        "amyp","nxbp","cium","ollm","dcyq","hict","zdfp","srmz","vyla","eiso","dcbp","mrcm","peji","fysw","reoo","gcoi",
+        "dapd","xzkw","ppvy","petd","tbpz","lttc","owup","mfbz","winh","xige","soju","yjzd","gjph","appk","leth","etsi",
+        "nlot","ppcb","nuze","soqr","uqoa","pspz","rfrp","tmqw","wkwh","uewr","otrk","ymca","epaf","qpwz","hmjz","abbj",
+        "vehp","ndeb","edik","ogah","nmuu","pmmz","hcgy","xmtg","ygkn","akmu","edux","bemp","fmrb","fyjj","tzoo","kwcz",
+        "ssfc","zrqp","jgys","zvkz","zbmd","miss","lyqq","orkm","oawv","abgm","xujs","tnbe","qbgt","bdmn","fvib","uiai",
+        "cthk","zrfo","toia","ayko","ejae","lofb","dwmk","hpvs","egql","lumn","kxwf","ayvb","nwhb","pfrk","yand","zuyf",
+        "fkdd","lksd","gwxb","sdcd","wzrd","zdhw","awen","kvxh","cvsq","tyvl","omhk","kqyh","phlu","ppew","uurs","zhkr",
+        "iycu","htlq","xxpe","uasu","komp","xbki","duev","uyhi","ntcq","tfgr","gnwj","vbwm","xhsr","yata","qzyx","mdmq",
+        "kbuy","pvmm","lvbh","pnlq","nuar","nwsg","skxf","dfid","rvjw","nukc","tmhd","kykk","epdi","ykpv","jpkr","jbyf",
+        "bifz","ukex","jcsj","vfvp","usis","ytlh","insk","lrax","iykv","guqk","tjmx","adcr","vxlq","amsn","zctm","rbzr",
+        "dslq","rihj","lqil","yler","dftv","zrsx","udxv","qtbk","lzyh","lagr","kfin","itrm","huke","yudp","zrdn","wtmk",
+        "lgfc","mtsp","zgbm","yjut","ryqe","xgan","zpwd","pshd","xmzw","webv","wydg","zkma","pmso","btqj","ezjr","unas",
+        "yqkj","phls","lxdh","gzsu","fgvy","vyqs","jsux","tiit","laij","nkwd","dhgi","cmtm","ukrt","ftte","osoa","sflc",
+        "kyyg","hlid","bbdl","brwh","vkak","htqw","wfoy","arab","rebw","dgki","mfai","xfer","exob","dmyj","suvx","usiw",
+        "iper","fzpg","xtib","vaqo","pgnw","pece","gbzd","inpj","sgpy","jhjn","vfmy","grxd","uqna","qhfe","pnrs","wwtn",
+        "byub","nmcj","retp","rmjm","wwlz","hlrm","itfv","tync","kzki","wgtw","sptf","motk","gdpa","aldo","jobt","uxqw",
+        "sxkf","wtnt","mdde","sfqd","gusb","dzmq","ngrc","iusg","kmfk","qmjn","xnmm","imtg","hqqf","gwlg","vgrl","bduv",
+        "ybgd","prsv","hamq","hjrt","dove","uffl","qeks","ulpp","hnfm","oxjx","kljd","dnee","stgx","avhc","knom","ddho",
+        "jhlx","wecr","bmlx","ozdq","xtki","ipnk","ivsb","jjdr","yljp","qxst","rsgz","pbdu","eopu","oaxs","lnxe","syyh",
+        "pukc","umrh","zkuj","admk","ocdm","gntx","mnlf","eivu","zgyc","kyoj","rsjd","njne","ermf","nzma","plvt","zoml",
+        "fjen","sliu","sdid","xdub","javj","cwqt","mzwb","gvjc","coza","xcpc","eivy","qzve","wbbi","btrl","ttap","kfvg",
+        "fmev","njvt","trki","mfgp","kgmj","reul","mabk","gmbh","nppq","suoh","yxzs","syws","xrlr","nhry","mwye","gukm",
+        "zazm","lxvl","ixzb","texm","gypu","luqv","heun","gmuf","aenk","ituu","vhev","wztk","rmcr","dogm","fgzq","hbbp",
+        "cqlr","bokw","wlfo","snrb","ysaw","bbej","xacm","gkmy","vfuq","hoga","sacb","uvml","xigg","bfyw","xigf","oqan",
+        "olpy","jfhs","bcvc","otrf","dnmx","ekvt","onlr","zfei","bqze","ckoz","wava","nalz","alas","nyre","dndm","uzwy",
+        "tuab","qqkf","yuaj","yoje","skzo","febt","mrbt","uxox","flyi","vzyv","kslu","awfd","uxag","xmjx","uibt","hpvf",
+        "pssh","vpzc","ashn","qojz","gmbw","xtyp","mmup","appl","luab","zjhg","ijai","tbyf","upvx","ibfw","ynxp","geno",
+        "oyiq","gzkv","iyne","bkog","oimi","uoxg","askc","ocyb","agkr","kdcl","rzpn","ajgc","doaa","dvul","nxzo","waer",
+        "tsta","crfo","birp","hlmk","kejk","zcmj","lfpy","aubx","gjgc","mdyu","psmc","tunz","dirf","oshv","tjft","qiln",
+        "vhnl","yvky","gycu","tkbx","hufk","qwob","qlxh","wwbf","zzij","aklj","pmoi","cees","qfjk","zipy","hzzx","nrre",
+        "fxgf","nbta","gova","rlnt","xect","vbgs","bqex","tlrz","oalh","sjkr","ljfx","fove","mppt","ankv","wlto","qvkb",
+        "ymvl","zuii","pmzd","efoy","ceri","epsq","laeg","mdjt","ohde","ywvx","hoxa","whmc","vhfc","wsxt","bdez","jwba",
+        "yttf","dsai","gmjj","bkdn","brih","qyum","ljbh","jqsp","fmaa","axcw","uivx","ehxf","ouyv","zkkb","dmik","dhst",
+        "mede","hfkr","ihuj","scoh","axpe","ufvy","sfnr","aaaj","pwcw","mzhw","fcot","ailp","ddym","egtr","rlkj","ovel",
+        "ahhf","hjnx","azri","kjox","aavt","xeqh","djya","vzmy","lswh","nmun","bxzc","mwbi","mipy","kcpg","cbut","eldf",
+        "ylub","lunk","xkue","xuen","sffp","euau","hgoz","qotv","coct","htof","ecsa","bvee","wmyr","ruhl","wrpc","pazy",
+        "atew","bhff","izvw","ogfy","pfsg","gikl","iyhm","uhhc","glvk","gapt","biio","cnyy","ilbq","vkzq","voke","hdbo",
+        "jcwk","cmpu","seem","ailm","eewd","tagh","hebi","pqbn","hrew","dbtx","iupz","ycoj","lave","uwnd","muwy","vwxe",
+        "lteg","mklz","apel","cwty","btdj","pnoc","gnzj","vvir","rekn","kvfy","tkwj","ldje","yydx","xubu","tszv","jkpb",
+        "xngx","nnat","cdwr","jigk","obkv","aibt","cmco","ajaw","jhpv","eevv","rgpz","kgqn","ktsf","sdqx","hgmq","utvu",
+        "tuxz","ayyd","vubo","cihl","mkqi","zlgm","hqlq","ilvt","hjgr","bgmu","mlga","ugim","rgwb","joma","xoig","evze",
+        "ukvq","mcou","ugna","lbok","ldzh","atgx","ewyb","htnc","iwwc","bfea","fptk","sxtn","krmi","xglf","rmyj","hhfk",
+        "jpot","zfyw","atik","cwaw","eqnt","fzgm","tdmz","bolw","trdk","kehv","cjyo","anyl","qkxb","lice","ejxf","ewma",
+        "gxcf","miqb","ojay","ircg","tpvp","dgbi","vqzk","rlwd","qjas","xgck","bmus","kvka","oria","bxkl","fswp","xbzb",
+        "ynlx","ttba","ctkr","dnld","rfgz","qufd","aora","bhnn","rcby","axpx","jwam","ocuh","vtqk","ryqp","cuex","xvlz",
+        "dkbf","uoeh","cuiy","quva","sbvu","hrrd","ptbw","pqtx","abqe","azrv","ljup","hfmn","hkib","rtxw","ajxf","llwv",
+        "jmxr","pjow","wfth","gkbh","coae","kbsk","zara","sdap","oigi","cybg","saej","mybo","qmer","wmlb","acyo","lqsn",
+        "zlpu","ccun","wqgg","bfxr","qzpg","iqnd","pkqz","iwmg","iizf","bjki","xgic","civp","dure","sywi","onuv","ozfy",
+        "lotu","sucg","fhpu","fhmr","aazn","skkr","stwy","vmjr","ilym","wqql","jjer","sggx","imwe","ixsg","udfs","pwbj",
+        "usyl","jmnb","yehm","wneg","lkgz","lfac","anai","dwdg","ojrw","vkuq","vdse","yjqk","pije","uhmg","bwbc","svzw",
+        "vqae","gsjp","abvz","aqtt","zald","qoey","rcno","lkcw","doyv","ablc","mlbw","dxzv","vlql","ixrn","nawn","kpug",
+        "tupn","rwde","uycp","zsbs","dhec","cnth","fqrc","bqst","yclg","mafh","rqqd","juwh","fimw","sbja","pzjo","fefs",
+        "zvgw","pzeo","yayl","wdko","ginn","ygrz","nppm","gjnu","fety","iwot","pdbk","xmxc","sqjh","ohqi","xkzq","tnnb",
+        "gizs","mdnl","fdrd","selp","ezhy","uhxa","tnfk","sptj","ywer","qdms","xogh","swby","vwli","kjxo","czwr","auyu",
+        "sfpx","pvse","nktu","usgf","ypgw","fdjb","yguk","bkxh","frwj","cyvm","xmgv","xndf","wpwd","jpmv","iexg","pxtb",
+        "xtyj","zfsh","wlox","xfon","jtpe","jkwr","egku","adxt","zieb","lwmr","ijxe","qsnd","xocf","bqaj","tufx","ixrr",
+        "yexb","hyao","rmqb","kgvy","vlrt","gqqj","ajjc","enhc","aqpu","duoo","adrx","ryfn","zqwj","hiln","vyfy","wnpu",
+        "gfqj","pzlh","klzc","viyd","arfm","htuy","pjyz","rzce","xkal","ktsr","fari","gyvc","xifu","hxna","pdqt","lrgw",
+        "ldcr","qcyu","ippc","qmme","myyd","hegg","efkz","rutq","uzlx","kfus","plea","pcbo","gzjz","bcnm","zjei","jcob",
+        "vgbw","fanc","iyix","smgd","ljmk","sbgn","jcfq","skjc","qjgb","cytl","uhqs","kqmt","bnqf","iawi","fncb","sdnt",
+        "soji","uctx","eqer","idhm","lqua","nfvd","nwdh","igjb","xamb","lgrb","lmju","hzlp","nmpv","myza","xxwd","hbyl",
+        "lczu","ddua","eovd","gtbp","mldr","wbnv","cnho","xcai","rreu","fbdz","ixrl","hfyx","xoxa","dvcd","bxcp","xfia",
+        "fvjt","duxs","yyar","iagh","eadf","kkbw","uesl","hfca","jkwb","dseg","ubec","jmux","ceqb","vdqa","psnb","zykh",
+        "iozg","nlcc","ksva","bptt","hcxk","azal","aqbt","fymr","pvfo","bxlm","jblc","hchn","ftwt","ppny","frrv","zuxd",
+        "wdsk","falw","redk","kwij","puri","vwfe","hbjb","krpm","ujiu","cdwi","pddm","szkr","well","ojty","cnpk","pizj",
+        "xnsl","asev","euly","fzrv","lysr","xxjt","pifp","azto","okcg","oels","ffwj","tsre","btwb","nuaf","fnxv","nzdc",
+        "wwbm","krnl","wwfd","hxun","fjgv","ppgx","nwfl","tgnv","ancp","nvnf","pelh","dbjd","snlu","jcgq","gtzj","ilnh",
+        "gknx","dici","oogz","zomt","jreq","tzpa","mhhu","qfsi","zopc","xqhx","mota","yjnj","wxmb","aoxk","pzco","ppox",
+        "yrno","xwae","soct","umbc","djsz","bino","qlek","grhl","knzq","ircj","hchw","zjem","hjof","rmip","xctx","cvpn",
+        "oirm","ifsk","abgc","huqc","rcmz","mgek","yfqi","bpiw","iesq","jxty","ftke","izve","hhby","hzlk","inwy","qzfb",
+        "tkmx","zvts","heio","fayn","kmqv","mlor","vhtc","nhpd","haau","qbhl","jbnn","olgb","unfj","fllc","ovoe","ynbf",
+        "ljcw","dxna","prvm","cojn","mepj","utbv","funa","yyyr","ccmx","xkdn","bwjp","coqn","ubvs","pdan","jkba","axts",
+        "rxsn","quck","tgkf","cfrs","uaxs","rmjv","lsev","sywy","jmym","uoml","wasd","tuzc","chgr","wdva","flfi","xfjk",
+        "zhdb","tnlo","byng","kitq","kjwu","hawe","rdzh","tspn","qlwl","vhta","dcdo","wbpn","wxpd","gzga","ijal","etco",
+        "ekaw","hkwx","btmd","kvxe","cxqu","ecpv","dfyx","evrc","klrs","mxql","ekfm","vpbx","cqte","phan","dqnw","pcft",
+        "pbcf","qqpf","xdce","dspe","vnhy","gjvz","unxt","tect","gotg","jojy","xwud","awjk","dexs","dduf","eumy","grop",
+        "xunt","pjnp","tkps","ijjs","fhjm","oboo","alqy","vuwv","xbue","jdad","tnsw","nflp","xccq","xsqe","rwke","zcrr",
+        "mwuj","gidt","kpoa","yuog","hdxi","abip","lphg","rjzo","gtbg","flhb","rgjy","rljh","whyy","xxxv","gemg","iqso",
+        "goxb","iqjo","jnhv","oebv","tvgc","rrtu","rjxc","nuet","htpc","lhuk","bwll","ghdf","ttgs","pplg","hhmx","riry",
+        "gtjs","wthz","doho","tqad","nenp","kevf","njda","lwkz","ojyn","awih","banq","tsmf","vhtf","tlrp","xhcz","kubi",
+        "gcyw","mkmy","quvk","vxli","oicx","jzlz","lzpb","hxzi","puna","gekm","aziq","pugf","wfjy","unjg","xwbd","nguv",
+        "yemz","kfum","wina","jraa","ipoc","dbxp","nona","gekw","ltmk","ihzu","wsuw","qbas","tfki","dkbz","nyeg","lwqw",
+        "xvrx","rwqs","rorp","uems","ywnv","kfqy","xpcq","twme","ehmm","rwrb","zueb","okdl","xfbl","xvsu","nbxs","eoqp",
+        "zxqx","kcoy","rosp","yhhv","piov","nhoe","oday","wlyx","aqng","hlxq","tcki","gaxc","hzdu","ofrq","qbpk","itnx",
+        "suqw","tiap","fxob","xrrv","hwkn","crxc","ockx","erob","bdor","vixm","keea","vhes","rlqs","ushn","kslf","wppi",
+        "nifb","amyr","maco","wwlw","tvab","rlvm","uyxv","wvxh","zpzk","suxn","lwim","whmq","alga","ygok","rrcs","tohx",
+        "bapz","aabn","ptdn","ekqy","iwjw","fywc","vdzc","xpdr","lvsm","olnh","mxov","gkie","ihkb","nzai","rcqj","lncj",
+        "uydy","yylv","cgqx","zpbx","njjy","qxop","piti","aarj","rplx","ofhl","ltso","ihky","uivz","eiki","gqcq","xvqf",
+        "nygy","htry","mtje","pmzw","iwgk","ifhp","bvqz","fquo","likt","mmxu","futl","dhgv","fazy","gllp","tkcq","hobg",
+        "xcah","qfrt","zekg","xiyq","vuvj","umsp","rxaw","fsto","iimm","fjmw","snch","vunz","akwc","nsrd","jxys","wyuw",
+        "nboc","icqd","iujt","uolg","ifzl","fbzy","ovqd","sadx","ggrg","adbu","bwwg","kioi","wpea","uqrs","uynh","qoqv",
+        "zvev","ffhn","rnok","kugj","fzhv","jrng","onbz","vxpn","ekzi","oniw","qgxo","pnhy","ugfg","jbgv","pfyk","rdxx",
+        "pqqc","pjpp","tzef","oeto","imdv","yiif","qero","jmgz","clta","haje","bbhu","oros","nvkn","ecmy","coiv","tdml",
+        "cvou","tzre","bbeo","ksdq","lbxn","yofc","pkvp","jklf","gudf","lkbe","mzjq","dkpu","nxgi","rgbz","cqtu","qejf",
+        "gvgw","qjvv","hxnh","ijpq","rupx","yoxp","vqih","ayhy","scyb","qwwu","twvz","fzhk","ndcl","okao","frpu","kbzc",
+        "qyju","sivt","hrfi","dwtg","livd","hnxf","fedd","ohpy","phbo","mcgg","qqkl","bnok","noye","uqxo","cowh","wlqx",
+        "rgnn","zwda","bzip","wsxf","yoyw","iqrz","pgga","kzdt","rbdy","ickr","kaca","koun","zqwa","iuns","xjef","qvvw",
+        "cwul","kemx","stpc","mwpa","sjhy","kzgb","sjjr","qlzd","akhk","pnjz","whkr","hdcu","csir","figt","frez","rgoy",
+        "ichu","ninr","vthh","ifhw","spoa","kqsr","zoed","jemy","pdzy","dbre","trvt","nfui","gbkt","omoz","hgcz","doql",
+        "wnwk","myhx","spgx","ojon","qdnf","iatq","gemw","wrbq","xckk","dvvv","sksh","eqdl","agit","eocm","dvqy","irys",
+        "seix","mghz","jmsp","uhpq","uyqi","hxid","yycw","bkox","mnhy","wgvh","svmz","uicj","lyyg","zvlw","qivz","anbf",
+        "njvg","zugu","ozey","nycu","rill","tdfb","ahtf","ahhb","uikq","hbcq","tzns","oqrr","bhcj","teuw","riid","qgcu",
+        "gixd","gnsf","kjnt","ozul","ojnt","trqz","hkal","qjio","gyau","dlus","fvfi","kmgk","vfjc","ogaz","aezv","xovm",
+        "rhey","osoi","jftr","neoo","hyaa","yaos","scah","qyqs","kqnf","mjhb","ktnk","gqbb","bfqk","xrcn","yfqc","einv",
+        "asax","dsda","iswr","nsdw","gcxw","srer","wewz","nvtk","qwbl","bxli","rwph","fzug","yynq","kahd","fmfz","xoiw",
+        "ulrv","zrqj","jdra","iipq","mfvp","rgwt","xycd","tfqm","wxak","ecmd","tobc","byin","amzl","yrjn","uraw","dhzk",
+        "yvyj","zikb","ijih","nddl","mvyx","lkmg","sqqv","aphh","otjw","aftp","nnde","lmxl","gfnp","ravi","vank","prun",
+        "wtak","vrfd","yylr","wcht","ykul","mgnt","bjaf","tgqg","cxyl","iapp","xkjg","uzqy","iltk","qtoj","nrvj","hqqz",
+        "zbwy","lean","cqis","rgfv","ggih","jghs","enzu","jujw","uizi","gkhg","ehqz","oybp","kkfb","tmwk","xkdi","ulda",
+        "geuk","hvtt","rycv","iysj","imbh","pjzj","ledn","vdml","vinq","qyaf","ltwo","mzcf","hcrp","phqp","jpfv","gvkf",
+        "qnnj","wydc","wfbu","sxsm","njuv","ldte","momm","azkb","shtj","fxyg","eqak","sypx","psyb","ibuk","vjei","xvzf",
+        "iykm","lbah","egtz","xxrl","yskn","yjys","nlli","uufx","cpts","uzxv","cxkf","yxfo","edzq","amgw","gpxc","ehtv",
+        "vkpo","ufzu","rejv","vdrc","uxbc","xqje","doqx","psxx","mnaz","gvqd","bthh","pxxy","goyu","eroa","mgxx","vvni",
+        "dpan","opvu","ugdw","wfmh","hdpm","sunx","ycyw","ayle","luxs","kdwj","bpky","qfwi","rlix","akcw","iwmb","ozug",
+        "rani","wimc","fssl","agjz","uunm","nkwa","zwpi","srlh","derd","hntd","veyz","sgaq","zode","wgbd","adyu","xszs",
+        "gfun","qhts","xxcm","dbrr","szoq","ggxe","bkkl","uzzk","lvws","vjun","tvwo","qhpw","gqav","lopt","aobn","gxxe",
+        "gpwp","iqvd","coff","awwv","fpgv","zswg","bgsa","xqdx","xwrx","ooub","inqo","junv","jexj","vxqp","ztdb","drfg",
+        "cmds","qymt","ebbk","vwji","hafy","xfph","cqgf","zkrf","nkus","dtej","gdgu","oqhl","ywff","jfyv","lvix","ynlo",
+        "ontl","ezzb","wqjq","pvjl","picn","yccj","rltc","jpgj","xrkh","zzxl","hrja","gsqm","jqao","nrpt","eykn","xusu",
+        "mkkt","wcqy","zunj","ofai","kmmn","gqwm","vdwq","tots","jhid","wrhw","qdsk","eigo","gooh","rxdb","csza","epqp",
+        "npnk","tfoi","avho","mhcx","pndb","kgmu","ynoa","mggl","jyom","vgtz","ubbz","vhnz","eiwh","opci","pqmx","irtc",
+        "nvmu","whpq","qami","mght","nult","xvvq","ebfj","zizp","qofd","byyr","qtwi","amoz","jysx","qzhz","adio","zyvw",
+        "xbfy","kemh","wcil","juvp","heeb","cotv","mxng","tgfg","mkxs","eimp","pzcj","hbyq","vqor","mtbn","ckyb","whhw",
+        "whdk","hpra","jbjh","pnxp","bkpc","xgru","cjfn","fwdr","xfbx","azxj","cwrc","ipde","ibig","akwf","ivnd","qxhq",
+        "dyeg","vtfa","rfvv","scrd","tmty","gdui","hcra","hrbv","basr","xigc","blzt","nkbs","quww","blme","pfqy","xtdb",
+        "ooxq","gcbt","xqgx","vfae","nwvw","ipyt","efir","ayhe","ikek","pojc","jbvs","bryz","iodc","relu","ltip","xhgo",
+        "jijc","vjpi","qeeq","tmiv","offb","xfzp","okxy","rfhf","gjnn","xlzr","cfgz","mxgo","zglg","hdqe","dcrf","uabp",
+        "nveu","xwuw","ywct","byix","itsd","uwyr","wols","oiex","vykx","woqr","mvpx","icgt","mrmx","hsti","lajl","eouo",
+        "fyns","gqbv","iebw","yanx","kpfu","wieb","nucf","lavj","cgeg","cjco","qyss","eghg","tjas","kkqw","npvf","ajkc",
+        "wbnb","ogjr","zhmx","rjob","txnu","nxcv","ilbz","ajsw","bees","detf","gywe","grbn","ghok","wovc","brbh","ucyl",
+        "dlvw","yeah","buxz","jbli","bnvb","jbvz","exaa","ekbh","nhot","wlmq","ghlv","lkne","xumz","ngwl","vtak","zita",
+        "qthr","azig","luns","jvmi","rffd","eroy","nhhq","lojq","cuia","scec","adjs","kqma","itww","nmev","qmbd","sdfe",
+        "wras","dzrq","duyj","rcds","qnqa","iauv","kvdr","joit","fjnl","escc","iomk","uzpy","icay","cgzy","edzf","xdfd",
+        "gxyy","hrft","tjyh","dzob","xcvb","blhf","yzdb","fecr","nerh","xeex","tmhj","iuza","rlka","ueqe","svnu","exvi",
+        "yikb","qvhr","mnch","yjng","pufx","gzqd","nlxz","quxf","kcba","etow","piee","omno","yyfl","pdmh","lppw","owlk",
+        "gbrk","pmim","dqde","herm","igtt","ojem","kdmb","xiko","ablb","ykwd","oqmn","lxnd","sdbp","nykt","sgwa","rgkt",
+        "sujq","evxt","teaq","blbp","ghmz","gwmt","uswt","nxai","jmhw","qakn","bxqh","lpge","tajd","vbyl","dpdf","icdl",
+        "wsby","pral","swxp","jhyv","yrmx","qubx","gotc","uhoc","urgo","sdbn","vujo","gfbt","rgwo","mzgr","uamv","yzjq",
+        "ypol","pwzy","tbtc","dxsu","adnu","hmbk","ogka","lebh","jndp","ftaq","sfal","gepn","jgpo","gyke","xwun","ferf",
+        "hhmd","flgy","khnt","jqym","ypwr","vxfi","asnu","plnh","qkkc","bniq","rwpq","xrde","ilgd","ywwm","ienb","yqaw",
+        "ftez","eusy","bqvw","lpin","vwej","hopz","wphz","nbci","tskz","ctmx","ihju","mrsz","xfsi","dfsv","dslj","zvgk",
+        "ufvz","ogpr","uqhs","orgz","lxlt","qeys","nypp","xqqt","xtwn","dikx","cusx","ejga","oqgy","yych","yrxl","tono",
+        "uhfp","lfcj","hava","floj","ywiv","vake","tvyr","kuia","rddl","inqj","fins","xmcn","psyd","pnwl","fjos","zpua",
+        "mvjq","tziw","rmtz","ltyq","wasg","gbed","aibu","puxt","mzcz","pycr","zdlp","amdm","kcxk","ozaf","shrt","ppsu",
+        "kqfz","jrnf","yejo","lmzn","uums","haja","htju","qmbx","rhid","eedb","sspk","uewy","ppee","gypg","dukf","vxbk",
+        "ctbt","ypmh","paia","inwj","lnsd","dgxz","aacn","vxfk","xvmc","hcui","zunx","vtix","iyuk","dsio","hcgh","vrln",
+        "maxo","pjwe","eeni","gcpi","hljt","kpsg","rqfn","aqju","olyw","posi","vmdd","rdgm","cyvg","shxd","vhoq","fjqo",
+        "xgpx","mjdv","ziqn","nvin","yvlx","fpco","xuto","ltdo","revy","jlbq","dpvd","kocr","mpqb","hbrt","wvly","rctg",
+        "dxoi","rzil","ubhe","wnjz","cbff","wuuw","ftvw","erja","lmwb","bkwu","mupu","nbzi","cgha","hjxe","hvjk","igzl",
+        "rnch","pmod","ntck","mkui","dqbh","vogu","epzx","nsew","pkht","cthe","srok","jacs","gtjv","xttg","bbwr","krrf",
+        "bspg","deva","bdyd","unvr","crou","mrvx","slcz","zxct","qbib","ktgn","otgf","wcmq","ytwi","oeec","ptjt","efuq",
+        "zjbo","ielk","jspp","ybom","tihc","qtgv","mfrg","gunc","zqde","chax","rjdc","bfhj","pias","jnre","ntzl","ccvr",
+        "vdtk","hgmb","ywkv","ubig","oywm","gbyq","tfxw","dlon","oswp","dabv","qnzl","qrpo","dcuy","fers","ajuq","zmzd",
+        "uuah","wutt","xvjw","uvdc","hrbp","xiaq","ylxh","pmbd","mqeb","znyo","pagi","vnve","ryoa","yvgt","goyg","vazz",
+        "uvjl","hgoi","xlov","qkhm","fmwe","akvn","ctjh","jdlt","erpf","sxxx","hirg","odgy","mnig","dgbs","bcdq","hrrr",
+        "rswq","czpo","mmmt","cqgx","nsqd","vsvr","bbbg","mcrz","xtoa","rwtp","fppm","bjgd","pkwu","fgmg","dkuq","lrwy",
+        "dlcn","yrke","yexf","lqfa","yvol","bdqi","hxmk","zxgs","fttc","fsye","kctk","yyou","jufa","mkpi","donb","bhfk",
+        "iliu","vkts","rjod","ftit","rxpx","sffg","gqpc","jnyv","hzpt","anxi","xjtf","nblm","awoi","fgbu","qsaq","fewg",
+        "trbo","tysi","gkrb","oust","mezx","cagk","wfkk","alxj","kqih","jgjv","agmy","tulj","cqsa","ncyi","kdaa","owcg",
+        "zicc","uckj","kkar","jozy","eitq","qzfn","kdvx","zupg","zzmz","jezn","azzb","cclx","seov","wzuf","xxia","dypy",
+        "cuct","zilu","tkop","thsf","ohcf","hxdf","phns","rekg","sryx","mzfr","xghr","vyss","wybt","qucp","krvd","rkbd",
+        "vder","dgee","dmec","stgq","oxbf","fqsf","heut","ozbr","ixqn","nqgu","kufq","mcec","yggo","toun","ndfp","updc",
+        "rcoi","umcn","qpma","ocoo","tnor","ecaq","kwfh","bjyy","rlwf","apwl","pkem","jovr","kopd","rnky","pqpm","bmfi",
+        "yojg","agai","efuy","nkvm","wliu","hyzq","tyhu","fadk","hlui","qtig","bqli","ntue","ajgs","rfmn","lhwp","hhio",
+        "ljml","bnyb","xmdm","qhye","szrb","flfz","rndu","wybe","wcio","uqpe","zqqi","bags","nnzy","bgoj","ladi","gtpa",
+        "gzyo","vnox","kwek","iagq","fysx","vepy","ehva","stjz","ugjo","macf","bynl","ihuv","swlq","vdww","lktd","souz",
+        "xtpa","fkrg","lpsp","ganf","rrqk","qxcc","mntq","npjb","xlon","saut","zgnf","rthc","kfmm","whfl","glbd","frua",
+        "royk","psep","bept","laco","rfkq","oqhj","jesf","niss","dsrb","cwkx","ikje","mash","eurd","wbsk","rkjw","rulf",
+        "xtvn","kolb","gmns","zbjf","hgge","sgqd","jzey","ozjs","qzdm","uodk","vxxi","hxiu","ymop","vnau","jqme","bacy",
+        "hmrg","whnw","unio","icba","bixn","jdhi","cetg","fdvj","gjju","aaej","jpdo","iiix","vnfd","rfyn","rspv","cawh",
+        "hfjy","igbt","qqug","reoy","aenr","mbtk","bgot","eecl","gxzy","meca","lrqs","hnst","kuui","muex","nusy","rgka",
+        "lwra","flkq","ndwa","cfzn","strz","ilbd","rgxg","isfd","dsxq","zanx","ysmv","ixvp","gupj","jitm","quqx","wlwh",
+        "oypv","wzii","upxe","mmkt","ehcv","kmlr","ifqi","aban","znwo","szjo","lxbg","okpw","wcpf","ixkf","fypa","mjjf",
+        "gfng","gilq","nfwt","fitp","oumi","dchp","thvj","gtgo","dlot","tqcd","gvib","pqqi","xjte","riyb","dbxv","mfrb",
+        "dewv","zdex","giuo","ylsk","ceqc","baah","odql","fcru","mkmz","seea","siyy","tvjc","bnie","irip","sirg","octh",
+        "dvky","gnlr","yrgd","clwk","mcdr","fwwn","oveh","vcbf","ldcg","exet","krft","plpg","jrfb","ofxm","cyep","ubwm",
+        "ktat","bbtd","xtko","qozu","lwut","ujen","nyxx","xbnm","ohdq","kzbg","wqjc","uqec","skyl","gtub","bkoq","hlgt",
+        "twnr","xpds","wjle","fymi","qmlc","innz","fjhm","lzvl","zkpj","bysl","lulb","cszt","ossb","zobi","xusa","okqi",
+        "yrmw","vuda","bosh","yimv","ljdx","sfwi","viwj","wrsp","vskp","yctz","jxjd","lwud","fkzo","fkqf","jths","sgvh",
+        "iwps","osud","kojb","cedt","jlvv","vudh","xlog","zcik","licj","lrol","isey","aepy","uqty","bjkq","okbx","obih",
+        "bgmc","tgpm","ieoh","hjsd","edoe","cxsp","tzsv","qomr","zfxz","ivoh","dmmh","hylz","trqx","macl","kufu","wpwl",
+        "dgre","bhzw","bnur","haqp","dhte","ksni","idyj","vbal","minb","bhce","bphq","knpd","ggzq","urbe","fuwu","poip",
+        "mmfg","dwjb","tgcm","mwny","pzcx","ongc","zuoy","wrvh","ypso","frkx","erch","lptp","gzeg","rluk","ckhr","jwzb",
+        "fgro","zeec","xwtq","gajn","xdpr","sxzp","babk","qkks","yslx","mzpc","kycg","lvgp","rwor","ywwq","rqck","hhho",
+        "gftu","fzop","ogrv","htfs","ibmf","xodm","gpnb","wpae","gdqp","qnlv","xugp","nxnh","bcdl","ysfb","ljws","vdpn",
+        "iety","xywt","nvtm","viat","cdbh","jtev","kerb","vazi","cpdk","tmtl","fbgt","poqq","naje","cwzs","alhi","mbwn",
+        "kbcm","uxxt","zpba","thao","jonm","eunt","yhqj","gyyg","gmhp","bmtl","jgal","oilw","ucet","ihsq","vdph","evus",
+        "obqw","raff","cxtt","djdh","gdxw","ncza","fapv","qzrt","vhir","jfby","ogmk","fuin","yijf","oyqb","wryi","uhty",
+        "yqvl","ndad","ytys","dqyz","ojsm","qtcx","fcti","lwzb","qaye","qott","hohh","lhag","xqok","mijn","yunk","wmma",
+        "paxw","kxld","jgwy","qcun","mruc","tpjv","xzfl","wtxa","gtta","airy","cfzk","zuuk","lhcu","ktvb","fimb","kzrn",
+        "jgsc","crrt","kdxw","xptp","fdrq","ffrr","jkuu","cbmz","aodz","hurb","pexf","xftd","azqn","ypfv","nuxv","supw",
+        "zibp","itlv","drmf","xeic","xbrk","skbp","pijt","khka","vwrq","qsse","clyf","otvu","pgza","nodt","tntc","ljkv",
+        "mqxb","vkqu","xdii","kyti","gioi","dwuy","pfjz","evsp",
 };
 int global_keys_count = ARRAY_SIZE(global_keys);
-
 
 class HashtableSpscOpGetFixture : public benchmark::Fixture {
 private:
@@ -77,16 +351,81 @@ public:
 
     void SetUp(benchmark::State& state) override {
         this->_hashtable = hashtable_spsc_new(
-                HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
-                this->_keys_count);
+                100,
+                24,
+                true);
 
         for (int index = 0; index < this->_keys_count; index++) {
-            if (!hashtable_spsc_op_set(this->_hashtable, _keys[index], strlen(_keys[index]), _keys[index])) {
-                char message[250] = { 0 };
-                snprintf(message, sizeof(message) - 1, "Unable to insert the token '%s'", _keys[index]);
-                state.SkipWithError(message);
-                return;
+            char *key_dup = (char*)ffma_mem_alloc(strlen(_keys[index]) + 1);
+            strcpy(key_dup, _keys[index]);
+            key_dup[strlen(_keys[index])] = '\0';
+
+            if (!hashtable_spsc_op_try_set_cs(this->_hashtable, key_dup, strlen(_keys[index]), _keys[index])) {
+                // Move back the pointer of the keys array
+                index--;
+
+                // Resize the hashtable
+                uint32_t current_size = this->_hashtable->buckets_count_real;
+                this->_hashtable = hashtable_spsc_uspize(this->_hashtable);
+            }
+        }
+
+        // Validate that all the keys are in the hashtable and can be found
+        for (int index = 0; index < this->_keys_count; index++) {
+            char *key = (char*)global_keys[index];
+            size_t key_length = strlen(global_keys[index]);
+            if (hashtable_spsc_op_get_cs(
+                    this->_hashtable,
+                    key,
+                    key_length) != key) {
+                state.SkipWithError("Failed to find key in hashtable");
+            }
+        }
+    }
+
+    void TearDown(const ::benchmark::State &state) override {
+        hashtable_spsc_free(this->_hashtable);
+    }
+};
+
+class HashtableSpscOpGetKeyAsIntFixture : public benchmark::Fixture {
+private:
+    hashtable_spsc_t *_hashtable = nullptr;
+    char **_keys = (char**)global_keys;
+    int _keys_count = global_keys_count;
+public:
+    hashtable_spsc_t *GetHashtable() {
+        return this->_hashtable;
+    }
+
+    void SetUp(benchmark::State& state) override {
+        this->_hashtable = hashtable_spsc_new(
+                100,
+                24,
+                false);
+
+        for (int index = 0; index < this->_keys_count; index++) {
+            if (!hashtable_spsc_op_try_set_by_hash_and_key_uint32(
+                    this->_hashtable,
+                    *(uint32_t*)_keys[index],
+                    *(uint32_t*)_keys[index],
+                    _keys[index])) {
+                // Move back the pointer of the keys array
+                index--;
+
+                // Resize the hashtable
+                uint32_t current_size = this->_hashtable->buckets_count_real;
+                this->_hashtable = hashtable_spsc_uspize(this->_hashtable);
+            }
+        }
+
+        // Validate that all the keys are in the hashtable and can be found
+        for (int index = 0; index < this->_keys_count; index++) {
+            if (hashtable_spsc_op_get_by_hash_and_key_uint32(
+                    this->_hashtable,
+                    *(uint32_t*)_keys[index],
+                    *(uint32_t*)_keys[index]) != _keys[index]) {
+                state.SkipWithError("Failed to find key in hashtable");
             }
         }
     }
@@ -98,49 +437,126 @@ public:
 
 BENCHMARK_DEFINE_F(HashtableSpscOpGetFixture, FindTokenInHashtableWorstCase1Benchmark)(benchmark::State& state) {
     for (auto _ : state) {
-        benchmark::DoNotOptimize(hashtable_spsc_op_get(
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_cs(
                 this->GetHashtable(),
                 "non-existing",
                 strlen("non-existing")));
     }
 }
 
-BENCHMARK_DEFINE_F(HashtableSpscOpGetFixture, FindTokenInHashtableWorstCase2Benchmark)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCaseCIBenchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[3000];
+    size_t key_length = strlen(global_keys[3000]);
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
     for (auto _ : state) {
-        benchmark::DoNotOptimize(hashtable_spsc_op_get(
-                this->GetHashtable(),
-                "non-existing",
-                strlen("non-existing")));
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_ci(
+                hashtable,
+                key,
+                key_length));
     }
 }
 
-BENCHMARK_DEFINE_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCase1Benchmark)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCaseCSBenchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[3000];
+    size_t key_length = strlen(global_keys[3000]);
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
     for (auto _ : state) {
-        benchmark::DoNotOptimize(hashtable_spsc_op_get(
-                this->GetHashtable(),
-                "set",
-                strlen("set")));
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_cs(
+                hashtable,
+                key,
+                key_length));
     }
 }
 
-BENCHMARK_DEFINE_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCase2Benchmark)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey1Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[999];
+    uint32_t key_uint32 = *(uint32_t *)key;
+
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
     for (auto _ : state) {
-        benchmark::DoNotOptimize(hashtable_spsc_op_get(
-                this->GetHashtable(),
-                "append",
-                strlen("append")));
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_by_hash_and_key_uint32(
+                hashtable,
+                key_uint32,
+                key_uint32));
+    }
+}
+
+BENCHMARK_DEFINE_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey2Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[1999];
+    uint32_t key_uint32 = *(uint32_t *)key;
+
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_by_hash_and_key_uint32(
+                hashtable,
+                key_uint32,
+                key_uint32));
+    }
+}
+
+BENCHMARK_DEFINE_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey3Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[3000];
+    uint32_t key_uint32 = *(uint32_t *)key;
+
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_by_hash_and_key_uint32(
+                hashtable,
+                key_uint32,
+                key_uint32));
+    }
+}
+
+BENCHMARK_DEFINE_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey4Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[3999];
+    uint32_t key_uint32 = *(uint32_t *)key;
+
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_by_hash_and_key_uint32(
+                hashtable,
+                key_uint32,
+                key_uint32));
+    }
+}
+
+BENCHMARK_DEFINE_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey5Benchmark)(benchmark::State& state) {
+    char *key = (char*)global_keys[4999];
+    uint32_t key_uint32 = *(uint32_t *)key;
+
+    hashtable_spsc_t *hashtable = this->GetHashtable();
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(hashtable_spsc_op_get_by_hash_and_key_uint32(
+                hashtable,
+                key_uint32,
+                key_uint32));
     }
 }
 
 static void BenchArguments(benchmark::internal::Benchmark* b) {
-    b->Iterations(100000)->UseRealTime();
+    b->Iterations(100000000);
 }
 
 BENCHMARK_REGISTER_F(HashtableSpscOpGetFixture, FindTokenInHashtableWorstCase1Benchmark)
     ->Apply(BenchArguments);
-BENCHMARK_REGISTER_F(HashtableSpscOpGetFixture, FindTokenInHashtableWorstCase2Benchmark)
+BENCHMARK_REGISTER_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCaseCIBenchmark)
     ->Apply(BenchArguments);
-BENCHMARK_REGISTER_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCase1Benchmark)
+BENCHMARK_REGISTER_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCaseCSBenchmark)
     ->Apply(BenchArguments);
-BENCHMARK_REGISTER_F(HashtableSpscOpGetFixture, FindTokenInHashtableAvgCase2Benchmark)
-    ->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey1Benchmark)
+->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey2Benchmark)
+->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey3Benchmark)
+->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey4Benchmark)
+->Apply(BenchArguments);
+BENCHMARK_REGISTER_F(HashtableSpscOpGetKeyAsIntFixture, FindTokenInHashtableBypassHashAndKey5Benchmark)
+->Apply(BenchArguments);

--- a/benches/bench-storage-db-op-get.cpp
+++ b/benches/bench-storage-db-op-get.cpp
@@ -196,22 +196,6 @@ public:
         }
 
         if (state.thread_index() == 0) {
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-            // Free up the memory allocated for the first keyset slots generated
-            test_support_free_keyset_slots((test_support_keyset_slot_t *)static_keyset_slots);
-
-            fprintf(stdout, "> Setup - second keyset slots generation\n");
-            fflush(stdout);
-
-            // Re-initialize the keyset, the random generator in use will re-generate exactly the same set as we are
-            // using the same random seed (although the generator will not generate them in the same order because
-            // threads are used but that's doesn't matter)
-            static_keyset_slots = test_support_init_keyset_slots(
-                    this->_requested_keyset_size,
-                    KEYSET_GENERATOR_METHOD,
-                    544498304);
-#endif
-
             static_storage_db_populated = true;
             MEMORY_FENCE_STORE();
         }

--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -112,6 +112,9 @@ modules:
           port: 9090
 
 database:
+  # Number of available user databases
+  max_user_databases: 64
+
   # Limits for the database to prevent it from using too much system resources, optional.
   # The hard limit will prevent any operation that would exceed the limit, the soft limit will allow the operation but
   # will run the keys eviction process to try to free up some space.

--- a/src/config.c
+++ b/src/config.c
@@ -500,6 +500,21 @@ bool config_validate_after_load_database_keys_eviction(
     return return_result;
 }
 
+bool config_validate_after_load_database(
+        config_t* config) {
+    bool return_result = true;
+
+    if (config->database->max_user_databases < 1) {
+        LOG_E(TAG, "The maximum number of user databases must be greater than <0>");
+        return_result = false;
+    } else if (config->database->max_user_databases > UINT8_MAX) {
+        LOG_E(TAG, "The maximum number of user databases must be smaller than <%d>", UINT8_MAX);
+        return_result = false;
+    }
+
+    return return_result;
+}
+
 bool config_validate_after_load_modules_network_timeout(
         config_module_t *module) {
     bool return_result = true;
@@ -657,6 +672,7 @@ bool config_validate_after_load(
         || config_validate_after_load_database_snapshots(config) == false
         || config_validate_after_load_database_limits(config) == false
         || config_validate_after_load_database_keys_eviction(config) == false
+        || config_validate_after_load_database(config) == false
         || config_validate_after_load_modules(config) == false
         || config_validate_after_load_logs(config) == false) {
         return_result = false;

--- a/src/config.h
+++ b/src/config.h
@@ -263,6 +263,7 @@ struct config_database {
     config_database_snapshots_t *snapshots;
     config_database_file_t *file;
     config_database_memory_t *memory;
+    int64_t max_user_databases;
 };
 typedef struct config_database config_database_t;
 

--- a/src/config_cyaml_schema.c
+++ b/src/config_cyaml_schema.c
@@ -354,6 +354,9 @@ const cyaml_schema_field_t config_database_schema[] = {
         CYAML_FIELD_MAPPING_PTR(
                 "memory", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
                 config_database_t, memory, config_database_backend_memory_schema),
+        CYAML_FIELD_UINT(
+                "max_user_databases", CYAML_FLAG_DEFAULT,
+                config_database_t, max_user_databases),
         CYAML_FIELD_END
 };
 

--- a/src/data_structures/hashtable/mcmp/hashtable_data.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_data.c
@@ -105,12 +105,11 @@ void hashtable_mcmp_data_keys_free(
         }
 
         if (
-                HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED) ||
-                HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
+                HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED)) {
             continue;
         }
 
-        xalloc_free((hashtable_key_data_t*)key_value->external_key.data);
+        xalloc_free((hashtable_key_data_t*)key_value->key);
     }
 }
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_delete.c
@@ -29,8 +29,9 @@
 
 bool hashtable_mcmp_op_delete(
         hashtable_t* hashtable,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t* key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_value_data_t *current_value) {
     hashtable_hash_t hash;
     hashtable_chunk_index_t chunk_index = 0;
@@ -39,9 +40,6 @@ bool hashtable_mcmp_op_delete(
     hashtable_key_value_volatile_t* key_value;
     transaction_t transaction = { 0 };
     bool deleted = false;
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-    hashtable_key_value_flags_t key_value_flags = 0;
-#endif
 
     // TODO: the deletion algorithm needs to be updated to compact the keys stored in further away slots relying on the
     //       distance.
@@ -51,9 +49,9 @@ bool hashtable_mcmp_op_delete(
     //       At the end it has to update the original over overflowed_chunks_counter to restrict the search range if
     //       there was any compaction.
 
-    hash = hashtable_mcmp_support_hash_calculate(key, key_size);
+    hash = hashtable_mcmp_support_hash_calculate(database_number, key, key_length);
 
-    LOG_DI("key (%d) = %s", key_size, key);
+    LOG_DI("key (%d) = %s", key_length, key);
     LOG_DI("hash = 0x%016x", hash);
 
     volatile hashtable_data_t* hashtable_data_list[] = {
@@ -78,8 +76,9 @@ bool hashtable_mcmp_op_delete(
 
         if (hashtable_mcmp_support_op_search_key(
                 hashtable_data,
+                database_number,
                 key,
-                key_size,
+                key_length,
                 hash,
                 &chunk_index,
                 &chunk_slot_index,
@@ -117,22 +116,14 @@ bool hashtable_mcmp_op_delete(
 
             MEMORY_FENCE_STORE();
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-            key_value_flags = key_value->flags;
-#endif
             key_value->flags = HASHTABLE_KEY_VALUE_FLAG_DELETED;
 
             MEMORY_FENCE_STORE();
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-            if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value_flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
-#endif
-            xalloc_free((hashtable_key_data_t*)key_value->external_key.data);
-            key_value->external_key.data = NULL;
-            key_value->external_key.size = 0;
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-            }
-#endif
+            xalloc_free((hashtable_key_data_t*)key_value->key);
+            key_value->database_number = 0;
+            key_value->key = NULL;
+            key_value->key_length = 0;
 
             deleted = true;
         }
@@ -153,6 +144,7 @@ bool hashtable_mcmp_op_delete(
 
 bool hashtable_mcmp_op_delete_by_index(
         hashtable_t* hashtable,
+        hashtable_database_number_t database_number,
         hashtable_bucket_index_t bucket_index,
         hashtable_value_data_t *current_value) {
     hashtable_chunk_index_t chunk_index = 0;
@@ -161,9 +153,92 @@ bool hashtable_mcmp_op_delete_by_index(
     hashtable_key_value_volatile_t* key_value;
     transaction_t transaction = { 0 };
     bool deleted = false;
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-    hashtable_key_value_flags_t key_value_flags = 0;
-#endif
+
+    volatile hashtable_data_t* hashtable_data_list[] = {
+            hashtable->ht_current,
+            hashtable->ht_old
+    };
+    uint8_t hashtable_data_list_size = 2;
+
+    for (
+            uint8_t hashtable_data_index = 0;
+            hashtable_data_index < hashtable_data_list_size;
+            hashtable_data_index++) {
+        volatile hashtable_data_t *hashtable_data = hashtable_data_list[hashtable_data_index];
+
+        LOG_DI("hashtable_data_index = %u", hashtable_data_index);
+        LOG_DI("hashtable_data = 0x%016x", hashtable_data);
+
+        if (hashtable_data_index > 0 && (!hashtable->is_resizing || hashtable_data == NULL)) {
+            LOG_DI("not resizing, skipping check on the current hashtable_data");
+            continue;
+        }
+
+        chunk_index = bucket_index / HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
+        chunk_slot_index = bucket_index % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
+
+        half_hashes_chunk = &hashtable_data->half_hashes_chunk[chunk_index];
+
+        if (half_hashes_chunk->half_hashes[chunk_slot_index].filled == 0) {
+            return false;
+        }
+
+        transaction_acquire(&transaction);
+        if (unlikely(!transaction_spinlock_lock(&half_hashes_chunk->write_lock, &transaction))) {
+            return false;
+        }
+
+        key_value = &hashtable_data->keys_values[bucket_index];
+
+        if (unlikely(key_value->database_number != database_number)) {
+            transaction_release(&transaction);
+            return false;
+        }
+
+        if (current_value != NULL) {
+            *current_value = key_value->data;
+        }
+
+        half_hashes_chunk->metadata.slots_occupied--;
+        assert(half_hashes_chunk->metadata.slots_occupied <= HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+        half_hashes_chunk->metadata.is_full = 0;
+        half_hashes_chunk->half_hashes[chunk_slot_index].slot_id = 0;
+
+        MEMORY_FENCE_STORE();
+
+        key_value->flags = HASHTABLE_KEY_VALUE_FLAG_DELETED;
+
+        MEMORY_FENCE_STORE();
+
+        xalloc_free((hashtable_key_data_t*)key_value->key);
+        key_value->database_number = 0;
+        key_value->key = NULL;
+        key_value->key_length = 0;
+
+        deleted = true;
+
+        transaction_release(&transaction);
+
+        break;
+    }
+
+    LOG_DI("deleted = %s", deleted ? "YES" : "NO");
+    LOG_DI("chunk_index = 0x%016x", chunk_index);
+    LOG_DI("chunk_slot_index = 0x%016x", chunk_slot_index);
+
+    return deleted;
+}
+
+bool hashtable_mcmp_op_delete_by_index_all_databases(
+        hashtable_t* hashtable,
+        hashtable_bucket_index_t bucket_index,
+        hashtable_value_data_t *current_value) {
+    hashtable_chunk_index_t chunk_index = 0;
+    hashtable_chunk_slot_index_t chunk_slot_index = 0;
+    hashtable_half_hashes_chunk_volatile_t* half_hashes_chunk;
+    hashtable_key_value_volatile_t* key_value;
+    transaction_t transaction = { 0 };
+    bool deleted = false;
 
     volatile hashtable_data_t* hashtable_data_list[] = {
             hashtable->ht_current,
@@ -212,23 +287,14 @@ bool hashtable_mcmp_op_delete_by_index(
 
         MEMORY_FENCE_STORE();
 
-
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-        key_value_flags = key_value->flags;
-#endif
         key_value->flags = HASHTABLE_KEY_VALUE_FLAG_DELETED;
 
         MEMORY_FENCE_STORE();
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-        if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value_flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
-#endif
-        xalloc_free((hashtable_key_data_t*)key_value->external_key.data);
-        key_value->external_key.data = NULL;
-        key_value->external_key.size = 0;
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-        }
-#endif
+        xalloc_free((hashtable_key_data_t*)key_value->key);
+        key_value->database_number = 0;
+        key_value->key = NULL;
+        key_value->key_length = 0;
 
         deleted = true;
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_delete.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_delete.h
@@ -7,11 +7,18 @@ extern "C" {
 
 bool hashtable_mcmp_op_delete(
         hashtable_t* hashtable,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t* key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_value_data_t *current_value);
 
 bool hashtable_mcmp_op_delete_by_index(
+        hashtable_t* hashtable,
+        hashtable_database_number_t database_number,
+        hashtable_bucket_index_t bucket_index,
+        hashtable_value_data_t *current_value);
+
+bool hashtable_mcmp_op_delete_by_index_all_databases(
         hashtable_t* hashtable,
         hashtable_bucket_index_t bucket_index,
         hashtable_value_data_t *current_value);

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get.c
@@ -28,8 +28,9 @@
 
 bool hashtable_mcmp_op_get(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_value_data_t *data) {
     hashtable_hash_t hash;
     hashtable_chunk_index_t chunk_index = 0;
@@ -39,9 +40,9 @@ bool hashtable_mcmp_op_get(
     bool data_found = false;
     *data = 0;
 
-    hash = hashtable_mcmp_support_hash_calculate(key, key_size);
+    hash = hashtable_mcmp_support_hash_calculate(database_number, key, key_length);
 
-    LOG_DI("key (%d) = %s", key_size, key);
+    LOG_DI("key (%d) = %s", key_length, key);
     LOG_DI("hash = 0x%016x", hash);
 
     hashtable_data_volatile_t* hashtable_data_list[] = {
@@ -68,8 +69,9 @@ bool hashtable_mcmp_op_get(
 
         if (hashtable_mcmp_support_op_search_key(
                 hashtable_data,
+                database_number,
                 key,
-                key_size,
+                key_length,
                 hash,
                 &chunk_index,
                 &chunk_slot_index,
@@ -83,14 +85,6 @@ bool hashtable_mcmp_op_get(
         MEMORY_FENCE_LOAD();
 
         *data = key_value->data;
-
-        // Note for the future
-        // ---
-        // At this point, the code can end-up returning a value of a key that has been deleted.
-        // While this is a non problem, this is something that would happen anyway in a context of a network platform
-        // that receives un-synchronized requests from the caller and that if it's necessary the caller has to implement
-        // the required sync mechanism to ensure it's not going to issue get/delete commands in the wrong order, if it
-        // will be necessary to avoid returning deleted data a check on flags can be introduced in this point
 
         data_found = true;
 

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get.h
@@ -7,8 +7,9 @@ extern "C" {
 
 bool hashtable_mcmp_op_get(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_value_data_t *data);
 
 #ifdef __cplusplus

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.c
@@ -30,11 +30,12 @@
 
 bool hashtable_mcmp_op_get_key(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         hashtable_bucket_index_t bucket_index,
         hashtable_key_data_t **key,
-        hashtable_key_size_t *key_size) {
+        hashtable_key_length_t *key_length) {
     volatile char *source_key = NULL;
-    size_t source_key_size = 0;
+    size_t source_key_length = 0;
     hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(bucket_index);
     hashtable_chunk_slot_index_t chunk_slot_index = HASHTABLE_TO_CHUNK_SLOT_INDEX(bucket_index);
 
@@ -47,29 +48,21 @@ bool hashtable_mcmp_op_get_key(
 
     if (
             unlikely(HASHTABLE_KEY_VALUE_IS_EMPTY(key_value->flags)) ||
-            unlikely(HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED))) {
+            unlikely(HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED)) ||
+            unlikely(key_value->database_number != database_number)) {
         return false;
     }
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
-    if (HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
-        source_key = key_value->inline_key.data;
-        source_key_size = key_value->inline_key.size;
-    } else {
-#endif
-        source_key = key_value->external_key.data;
-        source_key_size = key_value->external_key.size;
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE==1
-    }
-#endif
+    source_key = key_value->key;
+    source_key_length = key_value->key_length;
 
     assert(source_key != NULL);
-    assert(source_key_size > 0);
+    assert(source_key_length > 0);
 
-    *key_size = source_key_size;
-    *key = xalloc_alloc(source_key_size + 1);
-    memcpy(*key, (char*)source_key, source_key_size);
-    (*key)[source_key_size] = 0;
+    *key_length = source_key_length;
+    *key = xalloc_alloc(source_key_length + 1);
+    memcpy(*key, (char*)source_key, source_key_length);
+    (*key)[source_key_length] = 0;
 
     // Validate that the hash and the key length in the bucket haven't changed or that the bucket has been deleted in
     // the meantime
@@ -86,24 +79,82 @@ bool hashtable_mcmp_op_get_key(
         key_deleted_or_different = true;
     }
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-    if (!HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE)) {
-#endif
-    if (unlikely(!key_deleted_or_different && key_value->external_key.size != source_key_size)) {
+    if (unlikely(!key_deleted_or_different && key_value->key_length != source_key_length)) {
         key_deleted_or_different = true;
     }
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-    } else {
-        if (unlikely(!key_deleted_or_different && key_value->inline_key.size != source_key_size)) {
-            return NULL;
-        }
-    }
-#endif
 
     if (unlikely(key_deleted_or_different)) {
         xalloc_free(key);
         *key = NULL;
-        *key_size = 0;
+        *key_length = 0;
+    }
+
+    return *key != NULL;
+}
+
+bool hashtable_mcmp_op_get_key_all_databases(
+        hashtable_t *hashtable,
+        hashtable_bucket_index_t bucket_index,
+        hashtable_database_number_t *database_number,
+        hashtable_key_data_t **key,
+        hashtable_key_length_t *key_length) {
+    hashtable_database_number_t source_database_number = 0;
+    volatile char *source_key = NULL;
+    size_t source_key_length = 0;
+    hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(bucket_index);
+    hashtable_chunk_slot_index_t chunk_slot_index = HASHTABLE_TO_CHUNK_SLOT_INDEX(bucket_index);
+
+    MEMORY_FENCE_LOAD();
+
+    hashtable_data_volatile_t* hashtable_data = hashtable->ht_current;
+    hashtable_slot_id_volatile_t slot_id =
+            hashtable_data->half_hashes_chunk[chunk_index].half_hashes[chunk_slot_index].slot_id;
+    hashtable_key_value_volatile_t *key_value = &hashtable_data->keys_values[bucket_index];
+
+    if (
+            unlikely(HASHTABLE_KEY_VALUE_IS_EMPTY(key_value->flags)) ||
+            unlikely(HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED))) {
+        return false;
+    }
+
+    source_key = key_value->key;
+    source_key_length = key_value->key_length;
+    source_database_number = key_value->database_number;
+
+    assert(source_key != NULL);
+    assert(source_key_length > 0);
+    assert(source_database_number < UINT32_MAX);
+
+    *database_number = source_database_number;
+    *key_length = source_key_length;
+    *key = xalloc_alloc(source_key_length + 1);
+    memcpy(*key, (char*)source_key, source_key_length);
+    (*key)[source_key_length] = 0;
+
+    // Validate that the hash and the key length in the bucket haven't changed or that the bucket has been deleted in
+    // the meantime
+    MEMORY_FENCE_LOAD();
+
+    bool key_deleted_or_different = false;
+    if (unlikely(slot_id != hashtable->ht_current->half_hashes_chunk[chunk_index].half_hashes[chunk_slot_index].slot_id)) {
+        key_deleted_or_different = true;
+    }
+
+    if (unlikely(!key_deleted_or_different &&
+                 (HASHTABLE_KEY_VALUE_IS_EMPTY(key_value->flags) ||
+                  HASHTABLE_KEY_VALUE_HAS_FLAG(key_value->flags, HASHTABLE_KEY_VALUE_FLAG_DELETED)))) {
+        key_deleted_or_different = true;
+    }
+
+    if (unlikely(!key_deleted_or_different && key_value->key_length != source_key_length)) {
+        key_deleted_or_different = true;
+    }
+
+    if (unlikely(key_deleted_or_different)) {
+        xalloc_free(key);
+        *database_number = 0;
+        *key = NULL;
+        *key_length = 0;
     }
 
     return *key != NULL;

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_key.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_key.h
@@ -7,9 +7,17 @@ extern "C" {
 
 bool hashtable_mcmp_op_get_key(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         hashtable_bucket_index_t bucket_index,
         hashtable_key_data_t **key,
-        hashtable_key_size_t *key_size);
+        hashtable_key_length_t *key_length);
+
+bool hashtable_mcmp_op_get_key_all_databases(
+        hashtable_t *hashtable,
+        hashtable_bucket_index_t bucket_index,
+        hashtable_database_number_t *database_number,
+        hashtable_key_data_t **key,
+        hashtable_key_length_t *key_length);
 
 #ifdef __cplusplus
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.c
@@ -31,13 +31,15 @@
 
 bool hashtable_mcmp_op_get_random_key_try(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         char **key,
-        hashtable_key_size_t *key_size) {
+        hashtable_key_length_t *key_length) {
     uint64_t random_value = random_generate();
 
     return hashtable_mcmp_op_get_key(
             hashtable,
+            database_number,
             random_value % hashtable->ht_current->buckets_count_real,
             key,
-            key_size);
+            key_length);
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_get_random_key.h
@@ -7,8 +7,9 @@ extern "C" {
 
 bool hashtable_mcmp_op_get_random_key_try(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         char **key,
-        hashtable_key_size_t *key_size);
+        hashtable_key_length_t *key_length);
 
 #ifdef __cplusplus
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.c
@@ -28,6 +28,8 @@
 
 void *hashtable_mcmp_op_data_iter(
         hashtable_data_volatile_t *hashtable_data,
+        bool all_databases,
+        hashtable_database_number_t database_number,
         uint64_t *bucket_index,
         uint64_t max_distance) {
     hashtable_half_hashes_chunk_volatile_t *half_hashes_chunk;
@@ -82,6 +84,12 @@ void *hashtable_mcmp_op_data_iter(
                 continue;
             }
 
+            if (unlikely(!all_databases)) {
+                if (key_value->database_number != database_number) {
+                    continue;
+                }
+            }
+
             return (void*)data;
         }
 
@@ -94,13 +102,48 @@ void *hashtable_mcmp_op_data_iter(
 
 void *hashtable_mcmp_op_iter(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         uint64_t *bucket_index) {
-    return hashtable_mcmp_op_data_iter(hashtable->ht_current, bucket_index, UINT64_MAX);
+    return hashtable_mcmp_op_data_iter(
+            hashtable->ht_current,
+            false,
+            database_number,
+            bucket_index,
+            UINT64_MAX);
 }
 
 void *hashtable_mcmp_op_iter_max_distance(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         uint64_t *bucket_index,
         uint64_t max_distance) {
-    return hashtable_mcmp_op_data_iter(hashtable->ht_current, bucket_index, max_distance);
+    return hashtable_mcmp_op_data_iter(
+            hashtable->ht_current,
+            false,
+            database_number,
+            bucket_index,
+            max_distance);
+}
+
+void *hashtable_mcmp_op_iter_all_databases(
+        hashtable_t *hashtable,
+        uint64_t *bucket_index) {
+    return hashtable_mcmp_op_data_iter(
+            hashtable->ht_current,
+            true,
+            0,
+            bucket_index,
+            UINT64_MAX);
+}
+
+void *hashtable_mcmp_op_iter_max_distance_all_databases(
+        hashtable_t *hashtable,
+        uint64_t *bucket_index,
+        uint64_t max_distance) {
+    return hashtable_mcmp_op_data_iter(
+            hashtable->ht_current,
+            true,
+            0,
+            bucket_index,
+            max_distance);
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_iter.h
@@ -7,14 +7,27 @@ extern "C" {
 
 void *hashtable_mcmp_op_data_iter(
         hashtable_data_volatile_t *hashtable_data,
+        bool all_databases,
+        hashtable_database_number_t database_number,
         uint64_t *bucket_index,
         uint64_t max_distance);
 
 void *hashtable_mcmp_op_iter(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         uint64_t *bucket_index);
 
 void *hashtable_mcmp_op_iter_max_distance(
+        hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
+        uint64_t *bucket_index,
+        uint64_t max_distance);
+
+void *hashtable_mcmp_op_iter_all_databases(
+        hashtable_t *hashtable,
+        uint64_t *bucket_index);
+
+void *hashtable_mcmp_op_iter_max_distance_all_databases(
         hashtable_t *hashtable,
         uint64_t *bucket_index,
         uint64_t max_distance);

--- a/src/data_structures/hashtable/mcmp/hashtable_op_rmw.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_rmw.h
@@ -9,8 +9,9 @@ bool hashtable_mcmp_op_rmw_begin(
         hashtable_t *hashtable,
         transaction_t *transaction,
         hashtable_mcmp_op_rmw_status_t *rmw_status,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_value_data_t *current_value);
 
 void hashtable_mcmp_op_rmw_commit_update(

--- a/src/data_structures/hashtable/mcmp/hashtable_op_set.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_op_set.h
@@ -7,8 +7,9 @@ extern "C" {
 
 bool hashtable_mcmp_op_set(
         hashtable_t *hashtable,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_value_data_t new_value,
         hashtable_value_data_t *previous_value,
         hashtable_bucket_index_t *out_bucket_index,

--- a/src/data_structures/hashtable/mcmp/hashtable_support_hash.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_hash.h
@@ -30,15 +30,17 @@ extern "C" {
 #endif
 
 static inline __attribute__((always_inline)) hashtable_hash_t hashtable_mcmp_support_hash_calculate(
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size) {
+        hashtable_key_length_t key_length) {
+
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
-    return (hashtable_hash_t)t1ha2_atonce(key, key_size, HASHTABLE_SUPPORT_HASH_SEED);
+    return (hashtable_hash_t)t1ha2_atonce(key, key_length, database_number);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
-    return (hashtable_hash_t)XXH3_64bits_withSeed(key, key_size, HASHTABLE_SUPPORT_HASH_SEED);
+    return (hashtable_hash_t)XXH3_64bits_withSeed(key, key_length, database_number);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_CRC32C == 1
-    uint32_t crc32 = hash_crc32c(key, key_size, HASHTABLE_SUPPORT_HASH_SEED);
-    hashtable_hash_t hash = ((uint64_t)hash_crc32c(key, key_size, crc32) << 32u) | crc32;
+    uint32_t crc32 = hash_crc32c(key, key_length, database_number);
+    hashtable_hash_t hash = ((uint64_t)hash_crc32c(key, key_length, crc32) << 32u) | crc32;
 
     return hash;
 #endif

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op.c
@@ -59,8 +59,9 @@
 
 bool hashtable_mcmp_support_op_search_key(
         hashtable_data_volatile_t *hashtable_data,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_hash_t hash,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_chunk_slot_index_t *found_chunk_slot_index,
@@ -70,8 +71,9 @@ HASHTABLE_MCMP_SUPPORT_OP_FUNC_RESOLVER(hashtable_mcmp_support_op_search_key)
 
 bool hashtable_mcmp_support_op_search_key_or_create_new(
         hashtable_data_volatile_t *hashtable_data,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_hash_t hash,
         bool create_new_if_missing,
         transaction_t *transaction,
@@ -87,7 +89,7 @@ HASHTABLE_MCMP_SUPPORT_OP_FUNC_RESOLVER(hashtable_mcmp_support_op_search_key_or_
 bool hashtable_mcmp_support_op_search_key(
         hashtable_data_volatile_t *hashtable_data,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_hash_t hash,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_chunk_slot_index_t *found_chunk_slot_index,
@@ -95,7 +97,7 @@ bool hashtable_mcmp_support_op_search_key(
     return HASHTABLE_MCMP_SUPPORT_OP_FUNC_METHOD(hashtable_mcmp_support_op_search_key, loop)(
             hashtable_data,
             key,
-            key_size,
+            key_length,
             hash,
             found_chunk_index,
             found_chunk_slot_index,
@@ -106,7 +108,7 @@ bool hashtable_mcmp_support_op_search_key(
 bool hashtable_mcmp_support_op_search_key_or_create_new(
         hashtable_data_volatile_t *hashtable_data,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_hash_t hash,
         bool create_new_if_missing,
         transaction_t *transaction,
@@ -118,7 +120,7 @@ bool hashtable_mcmp_support_op_search_key_or_create_new(
     return HASHTABLE_MCMP_SUPPORT_OP_FUNC_METHOD(hashtable_mcmp_support_op_search_key_or_create_new, loop)(
         hashtable_data,
         key,
-        key_size,
+        key_length,
         hash,
         create_new_if_missing,
         transaction,

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op.h
@@ -7,8 +7,9 @@ extern "C" {
 
 extern bool hashtable_mcmp_support_op_search_key(
         hashtable_data_volatile_t *hashtable_data,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_hash_t hash,
         hashtable_chunk_index_t *found_chunk_index,
         hashtable_chunk_slot_index_t *found_chunk_slot_index,
@@ -16,8 +17,9 @@ extern bool hashtable_mcmp_support_op_search_key(
 
 extern bool hashtable_mcmp_support_op_search_key_or_create_new(
         hashtable_data_volatile_t *hashtable_data,
+        hashtable_database_number_t database_number,
         hashtable_key_data_t *key,
-        hashtable_key_size_t key_size,
+        hashtable_key_length_t key_length,
         hashtable_hash_t hash,
         bool create_new_if_missing,
         transaction_t *transaction,

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.h
@@ -11,8 +11,9 @@ extern "C" {
 #define HASHTABLE_MCMP_SUPPORT_OP_ARCH(SUFFIX) \
     bool HASHTABLE_MCMP_SUPPORT_OP_FUNC_METHOD(hashtable_mcmp_support_op_search_key, SUFFIX)( \
             hashtable_data_volatile_t *hashtable_data, \
+            hashtable_database_number_t database_number, \
             hashtable_key_data_t *key, \
-            hashtable_key_size_t key_size, \
+            hashtable_key_length_t key_length, \
             hashtable_hash_t hash, \
             hashtable_chunk_index_t *found_chunk_index, \
             hashtable_chunk_slot_index_t *found_chunk_slot_index, \
@@ -20,8 +21,9 @@ extern "C" {
      \
     bool HASHTABLE_MCMP_SUPPORT_OP_FUNC_METHOD(hashtable_mcmp_support_op_search_key_or_create_new, SUFFIX)( \
             hashtable_data_volatile_t *hashtable_data, \
+            hashtable_database_number_t database_number, \
             hashtable_key_data_t *key, \
-            hashtable_key_size_t key_size, \
+            hashtable_key_length_t key_length, \
             hashtable_hash_t hash, \
             bool create_new_if_missing, \
             transaction_t *transaction, \

--- a/src/data_structures/hashtable/spsc/hashtable_spsc.c
+++ b/src/data_structures/hashtable/spsc/hashtable_spsc.c
@@ -21,10 +21,11 @@
 
 #include "hashtable_spsc.h"
 
+#define TAG "hashtable_spsc"
+
 hashtable_spsc_t *hashtable_spsc_new(
         hashtable_spsc_bucket_count_t buckets_count,
         uint16_t max_range,
-        bool stop_on_not_set,
         bool free_keys_on_deallocation) {
     hashtable_spsc_bucket_count_t buckets_count_pow2_next, buckets_to_allocate;
 
@@ -48,7 +49,6 @@ hashtable_spsc_t *hashtable_spsc_new(
     hashtable->buckets_count_pow2 = buckets_count_pow2_next;
     hashtable->buckets_count_real = buckets_to_allocate;
     hashtable->max_range = max_range;
-    hashtable->stop_on_not_set = stop_on_not_set;
     hashtable->free_keys_on_deallocation = free_keys_on_deallocation;
 
     return hashtable;
@@ -71,6 +71,72 @@ void hashtable_spsc_free(
     }
 
     xalloc_free(hashtable);
+}
+
+hashtable_spsc_t* hashtable_spsc_uspize(
+        hashtable_spsc_t *hashtable_current) {
+    // Creates a new hashtable with the same parameters as the original one but twice the buckets
+    hashtable_spsc_t *hashtable_uspized = hashtable_spsc_new(
+            hashtable_current->buckets_count * 2,
+            hashtable_current->max_range,
+            hashtable_current->free_keys_on_deallocation);
+    hashtable_spsc_bucket_t *hashtable_uspized_buckets = hashtable_spsc_get_buckets(hashtable_uspized);
+
+    // Iterate over the original hashtable and copy the values to the new one
+    hashtable_spsc_bucket_t *hashtable_current_buckets = hashtable_spsc_get_buckets(hashtable_current);
+    for(
+            hashtable_spsc_bucket_index_t bucket_index_current = 0;
+            bucket_index_current < hashtable_current->buckets_count_real;
+            bucket_index_current++) {
+        if (!hashtable_current->hashes[bucket_index_current].set) {
+            continue;
+        }
+
+        // Get the hash and calculate the new bucket index
+        hashtable_spsc_cmp_hash_t hash = hashtable_current->hashes[bucket_index_current].cmp_hash;
+        hashtable_spsc_bucket_index_t bucket_index_uspized =
+                hashtable_spsc_bucket_index_from_hash(hashtable_uspized, hash);
+        hashtable_spsc_bucket_index_t bucket_index_max_uspized = bucket_index_uspized + hashtable_uspized->max_range;
+        bucket_index_uspized = hashtable_spsc_find_empty_bucket(
+                hashtable_uspized,
+                bucket_index_uspized,
+                bucket_index_max_uspized);
+
+        if (unlikely(bucket_index_uspized == -1)) {
+            FATAL(TAG, "Unable to find an empty bucket in the new hashtable during upsize");
+        }
+
+        hashtable_uspized->hashes[bucket_index_uspized].set = true;
+        hashtable_uspized->hashes[bucket_index_uspized].cmp_hash = hash;
+        hashtable_uspized_buckets[bucket_index_uspized].key =
+                hashtable_current_buckets[bucket_index_current].key;
+        hashtable_uspized_buckets[bucket_index_uspized].key_length =
+                hashtable_current_buckets[bucket_index_current].key_length;
+        hashtable_uspized_buckets[bucket_index_uspized].value =
+                hashtable_current_buckets[bucket_index_current].value;
+    }
+
+    // Disable the free of the keys
+    hashtable_current->free_keys_on_deallocation = false;
+
+    // Free the original hashtable
+    hashtable_spsc_free(hashtable_current);
+
+    // Return the new hashtable
+    return hashtable_uspized;
+}
+
+bool hashtable_spsc_op_delete_by_bucket_index(
+        hashtable_spsc_t *hashtable,
+        hashtable_spsc_bucket_index_t bucket_index) {
+    hashtable->hashes[bucket_index].set = false;
+
+    if (hashtable->free_keys_on_deallocation) {
+        hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
+        ffma_mem_free((void*)buckets[bucket_index].key);
+    }
+
+    return true;
 }
 
 bool hashtable_spsc_op_try_set_ci(
@@ -98,7 +164,7 @@ bool hashtable_spsc_op_try_set_ci(
         if (bucket_index > -1) {
             // If an empty bucket was found, update the hash and mark it as in use
             hashtable->hashes[bucket_index].set = true;
-            hashtable->hashes[bucket_index].cmp_hash = hash & 0x7fff;
+            hashtable->hashes[bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(hash);
         }
     }
 
@@ -130,13 +196,7 @@ bool hashtable_spsc_op_delete_ci(
         return false;
     }
 
-    hashtable->hashes[bucket_index].set = false;
-
-    if (hashtable->free_keys_on_deallocation) {
-        hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
-        ffma_mem_free((void*)buckets[bucket_index].key);
-    }
-
+    hashtable_spsc_op_delete_by_bucket_index(hashtable, bucket_index);
     return true;
 }
 
@@ -165,7 +225,7 @@ bool hashtable_spsc_op_try_set_cs(
         if (bucket_index > -1) {
             // If an empty bucket was found, update the hash and mark it as in use
             hashtable->hashes[bucket_index].set = true;
-            hashtable->hashes[bucket_index].cmp_hash = hash & 0x7fff;
+            hashtable->hashes[bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(hash);
         }
     }
 
@@ -197,12 +257,109 @@ bool hashtable_spsc_op_delete_cs(
         return false;
     }
 
-    hashtable->hashes[bucket_index].set = false;
+    hashtable_spsc_op_delete_by_bucket_index(hashtable, bucket_index);
+    return true;
+}
 
-    if (hashtable->free_keys_on_deallocation) {
-        hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
-        ffma_mem_free((void*)buckets[bucket_index].key);
+bool hashtable_spsc_op_try_set_by_hash(
+        hashtable_spsc_t *hashtable,
+        uint32_t hash,
+        const char *key,
+        hashtable_spsc_key_length_t key_length,
+        void *value) {
+    hashtable_spsc_bucket_index_t bucket_index;
+    hashtable_spsc_bucket_count_t bucket_index_max;
+
+    // Search if there is already a bucket with the same hash and key
+    bucket_index = hashtable_spsc_find_bucket_index_by_key_cs(hashtable, hash, key, key_length);
+
+    if (bucket_index == -1) {
+        // If not search for an empty bucket within the allowed range
+        bucket_index = hashtable_spsc_bucket_index_from_hash(hashtable, hash);
+        bucket_index_max = bucket_index + hashtable->max_range;
+        bucket_index = hashtable_spsc_find_empty_bucket(
+                hashtable,
+                bucket_index,
+                bucket_index_max);
+
+        if (bucket_index > -1) {
+            // If an empty bucket was found, update the hash and mark it as in use
+            hashtable->hashes[bucket_index].set = true;
+            hashtable->hashes[bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(hash);
+        }
     }
+
+    if (unlikely(bucket_index == -1)) {
+        return false;
+    }
+
+    hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
+
+    buckets[bucket_index].key = key;
+    buckets[bucket_index].key_length = key_length;
+    buckets[bucket_index].value = value;
+
+    return true;
+}
+
+bool hashtable_spsc_op_delete_by_hash(
+        hashtable_spsc_t *hashtable,
+        uint32_t hash,
+        const char* key,
+        hashtable_spsc_key_length_t key_length) {
+    hashtable_spsc_bucket_index_t bucket_index = hashtable_spsc_find_bucket_index_by_key_cs(
+            hashtable,
+            hash,
+            key,
+            key_length);
+
+    if (unlikely(bucket_index == -1)) {
+        return false;
+    }
+
+    hashtable_spsc_op_delete_by_bucket_index(hashtable, bucket_index);
+    return true;
+}
+
+
+bool hashtable_spsc_op_try_set_by_hash_and_key_uint32(
+        hashtable_spsc_t *hashtable,
+        uint32_t hash,
+        const uint32_t key_uint32,
+        void *value) {
+    hashtable_spsc_bucket_index_t bucket_index;
+    hashtable_spsc_bucket_count_t bucket_index_max;
+
+    assert(hashtable->free_keys_on_deallocation == false);
+
+    // Search if there is already a bucket with the same hash and key
+    bucket_index = hashtable_spsc_find_bucket_index_by_key_uint32(hashtable, hash, key_uint32);
+
+    if (bucket_index == -1) {
+        // If not search for an empty bucket within the allowed range
+        bucket_index = hashtable_spsc_bucket_index_from_hash(hashtable, hash);
+        bucket_index_max = bucket_index + hashtable->max_range;
+        bucket_index = hashtable_spsc_find_empty_bucket(
+                hashtable,
+                bucket_index,
+                bucket_index_max);
+
+        if (bucket_index > -1) {
+            // If an empty bucket was found, update the hash and mark it as in use
+            hashtable->hashes[bucket_index].set = true;
+            hashtable->hashes[bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(hash);
+        }
+    }
+
+    if (unlikely(bucket_index == -1)) {
+        return false;
+    }
+
+    hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
+
+    buckets[bucket_index].key_uint32 = key_uint32;
+    buckets[bucket_index].key_length = 0;
+    buckets[bucket_index].value = value;
 
     return true;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
 #include "spinlock.h"
 #include "transaction.h"
 #include "transaction_spinlock.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"

--- a/src/module/prometheus/module_prometheus.c
+++ b/src/module/prometheus/module_prometheus.c
@@ -27,6 +27,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
@@ -531,7 +532,7 @@ bool module_prometheus_process_metrics_request(
     tags_from_env = module_prometheus_fetch_extra_metrics_from_env();
 
     storage_db_counters_t storage_db_counters = { 0 };
-    storage_db_counters_sum(program_context->db, &storage_db_counters);
+    storage_db_counters_sum_global(program_context->db, &storage_db_counters);
 
     // Send out the global fields
     response_metric_field_t global_stats_fields[] = {

--- a/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
+++ b/src/module/redis/command/helpers/module_redis_command_helper_incr_decr.c
@@ -68,6 +68,7 @@ bool module_redis_command_helper_incr_decr(
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             *key,
             *key_length,
             &rmw_status,
@@ -220,6 +221,7 @@ bool module_redis_command_helper_incr_decr_float(
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             *key,
             *key_length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_append.c
+++ b/src/module/redis/command/module_redis_command_append.c
@@ -67,6 +67,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(append) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_copy.c
+++ b/src/module/redis/command/module_redis_command_copy.c
@@ -78,6 +78,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(copy) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->destination.value.key,
             context->destination.value.length,
             &rmw_status,
@@ -96,6 +97,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(copy) {
 
     entry_index_source = storage_db_get_entry_index_for_read(
             connection_context->db,
+            connection_context->database_number,
             context->source.value.key,
             context->source.value.length);
 

--- a/src/module/redis/command/module_redis_command_dbsize.c
+++ b/src/module/redis/command/module_redis_command_dbsize.c
@@ -42,6 +42,7 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(dbsize) {
     return module_redis_connection_send_number(
             connection_context,
-            storage_db_op_get_keys_count(
-                    connection_context->db));
+            storage_db_op_get_keys_count_per_db(
+                    connection_context->db,
+                    connection_context->database_number));
 }

--- a/src/module/redis/command/module_redis_command_del.c
+++ b/src/module/redis/command/module_redis_command_del.c
@@ -46,6 +46,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(del) {
     for(int index = 0; index < context->key.count; index++) {
         deleted_keys_count += storage_db_op_delete(
                 connection_context->db,
+                connection_context->database_number,
                 context->key.list[index].key,
                 context->key.list[index].length) ? 1 : 0;
     }

--- a/src/module/redis/command/module_redis_command_exists.c
+++ b/src/module/redis/command/module_redis_command_exists.c
@@ -46,6 +46,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(exists) {
     for(int index = 0; index < context->key.count; index++) {
         found_keys_count += storage_db_get_entry_index(
                 connection_context->db,
+                connection_context->database_number,
                 context->key.list[index].key,
                 context->key.list[index].length) != NULL ? 1 : 0;
     }

--- a/src/module/redis/command/module_redis_command_expire.c
+++ b/src/module/redis/command/module_redis_command_expire.c
@@ -52,6 +52,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expire) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_expireat.c
+++ b/src/module/redis/command/module_redis_command_expireat.c
@@ -52,6 +52,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expireat) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_expiretime.c
+++ b/src/module/redis/command/module_redis_command_expiretime.c
@@ -51,6 +51,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(expiretime) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_flushdb.c
+++ b/src/module/redis/command/module_redis_command_flushdb.c
@@ -45,17 +45,18 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(flushdb) {
         module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR the async flushdb is currently unsupported");
-        return true;
+        goto end;
     }
 
-    if (!storage_db_op_flush_sync(connection_context->db)) {
+    if (!storage_db_op_flush_sync(connection_context->db, connection_context->database_number)) {
         module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR Failed to flush the database");
-        return true;
+        goto end;
     }
 
     module_redis_connection_send_ok(connection_context);
 
+end:
     return true;
 }

--- a/src/module/redis/command/module_redis_command_get.c
+++ b/src/module/redis/command/module_redis_command_get.c
@@ -48,6 +48,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(get) {
 
     entry_index = storage_db_get_entry_index_for_read(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length);
 

--- a/src/module/redis/command/module_redis_command_getdel.c
+++ b/src/module/redis/command/module_redis_command_getdel.c
@@ -54,6 +54,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getdel) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_getex.c
+++ b/src/module/redis/command/module_redis_command_getex.c
@@ -56,6 +56,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getex) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_getrange.c
+++ b/src/module/redis/command/module_redis_command_getrange.c
@@ -48,6 +48,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getrange) {
 
     entry_index = storage_db_get_entry_index_for_read(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length);
 

--- a/src/module/redis/command/module_redis_command_getset.c
+++ b/src/module/redis/command/module_redis_command_getset.c
@@ -54,6 +54,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(getset) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_keys.c
+++ b/src/module/redis/command/module_redis_command_keys.c
@@ -47,6 +47,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(keys) {
 
     storage_db_key_and_key_length_t *keys = storage_db_op_get_keys(
             connection_context->db,
+            connection_context->database_number,
             0,
             0,
             context->pattern.value.pattern,

--- a/src/module/redis/command/module_redis_command_lcs.c
+++ b/src/module/redis/command/module_redis_command_lcs.c
@@ -210,6 +210,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(lcs) {
 
     if (!(entry_index_1 = storage_db_get_entry_index_for_read(
             connection_context->db,
+            connection_context->database_number,
             context->key1.value.key,
             context->key1.value.length))) {
         goto end;
@@ -217,6 +218,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(lcs) {
 
     if (!(entry_index_2 = storage_db_get_entry_index_for_read(
             connection_context->db,
+            connection_context->database_number,
             context->key2.value.key,
             context->key2.value.length))) {
         goto end;

--- a/src/module/redis/command/module_redis_command_mget.c
+++ b/src/module/redis/command/module_redis_command_mget.c
@@ -51,6 +51,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(mget) {
     for(int index = 0; index < context->key.count; index++) {
         storage_db_entry_index_t *entry_index = storage_db_get_entry_index_for_read(
                 connection_context->db,
+                connection_context->database_number,
                 context->key.list[index].key,
                 context->key.list[index].length);
 

--- a/src/module/redis/command/module_redis_command_mset.c
+++ b/src/module/redis/command/module_redis_command_mset.c
@@ -47,6 +47,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(mset) {
 
         if (!storage_db_op_set(
                 connection_context->db,
+                connection_context->database_number,
                 key_value->key.value.key,
                 key_value->key.value.length,
                 STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,

--- a/src/module/redis/command/module_redis_command_msetnx.c
+++ b/src/module/redis/command/module_redis_command_msetnx.c
@@ -65,6 +65,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(msetnx) {
         if (unlikely(!storage_db_op_rmw_begin(
                 connection_context->db,
                 &transaction,
+                connection_context->database_number,
                 key_value->key.value.key,
                 key_value->key.value.length,
                 &rmw_statuses[index],

--- a/src/module/redis/command/module_redis_command_persist.c
+++ b/src/module/redis/command/module_redis_command_persist.c
@@ -53,6 +53,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(persist) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_pexpire.c
+++ b/src/module/redis/command/module_redis_command_pexpire.c
@@ -53,6 +53,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpire) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_pexpireat.c
+++ b/src/module/redis/command/module_redis_command_pexpireat.c
@@ -53,6 +53,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpireat) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_pexpiretime.c
+++ b/src/module/redis/command/module_redis_command_pexpiretime.c
@@ -52,6 +52,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pexpiretime) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_psetex.c
+++ b/src/module/redis/command/module_redis_command_psetex.c
@@ -56,6 +56,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(psetex) {
 
     if (unlikely(!storage_db_op_set(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,

--- a/src/module/redis/command/module_redis_command_pttl.c
+++ b/src/module/redis/command/module_redis_command_pttl.c
@@ -46,6 +46,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(pttl) {
 
     entry_index = storage_db_get_entry_index(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length);
 

--- a/src/module/redis/command/module_redis_command_randomkey.c
+++ b/src/module/redis/command/module_redis_command_randomkey.c
@@ -45,8 +45,11 @@
 
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(randomkey) {
     bool return_res;
-    hashtable_key_size_t key_size = 0;
-    char *key = storage_db_op_random_key(connection_context->db, &key_size);
+    hashtable_key_length_t key_size = 0;
+    char *key = storage_db_op_random_key(
+            connection_context->db,
+            connection_context->database_number,
+            &key_size);
 
     if (likely(key)) {
         return_res = module_redis_connection_send_blob_string(connection_context, key, key_size);

--- a/src/module/redis/command/module_redis_command_rename.c
+++ b/src/module/redis/command/module_redis_command_rename.c
@@ -65,6 +65,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(rename) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status_source,
@@ -89,6 +90,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(rename) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->newkey.value.key,
             context->newkey.value.length,
             &rmw_status_destination,

--- a/src/module/redis/command/module_redis_command_renamenx.c
+++ b/src/module/redis/command/module_redis_command_renamenx.c
@@ -65,6 +65,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(renamenx) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status_source,
@@ -89,6 +90,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(renamenx) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->newkey.value.key,
             context->newkey.value.length,
             &rmw_status_destination,

--- a/src/module/redis/command/module_redis_command_scan.c
+++ b/src/module/redis/command/module_redis_command_scan.c
@@ -70,6 +70,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(scan) {
 
         keys = storage_db_op_get_keys(
                 connection_context->db,
+                connection_context->database_number,
                 context->cursor.value,
                 count,
                 pattern,

--- a/src/module/redis/command/module_redis_command_select.c
+++ b/src/module/redis/command/module_redis_command_select.c
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+#include "misc.h"
+#include "exttypes.h"
+#include "clock.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "protocol/redis/protocol_redis.h"
+#include "protocol/redis/protocol_redis_reader.h"
+#include "protocol/redis/protocol_redis_writer.h"
+#include "module/module.h"
+#include "network/io/network_io_common.h"
+#include "config.h"
+#include "network/channel/network_channel.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "module/redis/module_redis.h"
+#include "module/redis/module_redis_connection.h"
+
+#define TAG "module_redis_command_select"
+
+MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(select) {
+    module_redis_command_select_context_t *context = connection_context->command.context;
+
+    if (context->index.value > connection_context->db->config->max_user_databases) {
+        return module_redis_connection_error_message_printf_noncritical(
+                connection_context,
+                "ERR invalid DB index");
+    }
+
+    connection_context->database_number = context->index.value;
+
+    return module_redis_connection_send_ok(connection_context);
+}

--- a/src/module/redis/command/module_redis_command_set.c
+++ b/src/module/redis/command/module_redis_command_set.c
@@ -102,6 +102,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(set) {
     if (likely(!use_rmw)) {
         if (unlikely(!storage_db_op_set(
                 connection_context->db,
+                connection_context->database_number,
                 context->key.value.key,
                 context->key.value.length,
                 STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,
@@ -121,6 +122,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(set) {
         if (unlikely(!storage_db_op_rmw_begin(
                 connection_context->db,
                 &transaction,
+                connection_context->database_number,
                 context->key.value.key,
                 context->key.value.length,
                 &rmw_status,

--- a/src/module/redis/command/module_redis_command_setex.c
+++ b/src/module/redis/command/module_redis_command_setex.c
@@ -58,6 +58,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setex) {
 
     if (unlikely(!storage_db_op_set(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,

--- a/src/module/redis/command/module_redis_command_setnx.c
+++ b/src/module/redis/command/module_redis_command_setnx.c
@@ -59,6 +59,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setnx) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_setrange.c
+++ b/src/module/redis/command/module_redis_command_setrange.c
@@ -73,6 +73,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(setrange) {
     if (unlikely(!storage_db_op_rmw_begin(
             connection_context->db,
             &transaction,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length,
             &rmw_status,

--- a/src/module/redis/command/module_redis_command_strlen.c
+++ b/src/module/redis/command/module_redis_command_strlen.c
@@ -45,6 +45,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(strlen) {
 
     storage_db_entry_index_t *entry_index = storage_db_get_entry_index(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length);
 

--- a/src/module/redis/command/module_redis_command_substr.c
+++ b/src/module/redis/command/module_redis_command_substr.c
@@ -48,6 +48,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(substr) {
 
     entry_index = storage_db_get_entry_index_for_read(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length);
 

--- a/src/module/redis/command/module_redis_command_touch.c
+++ b/src/module/redis/command/module_redis_command_touch.c
@@ -53,6 +53,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(touch) {
         if (unlikely(!storage_db_op_rmw_begin(
                 connection_context->db,
                 &transaction,
+                connection_context->database_number,
                 context->key.list[index].key,
                 context->key.list[index].length,
                 &rmw_status,

--- a/src/module/redis/command/module_redis_command_ttl.c
+++ b/src/module/redis/command/module_redis_command_ttl.c
@@ -47,6 +47,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(ttl) {
 
     entry_index = storage_db_get_entry_index(
             connection_context->db,
+            connection_context->database_number,
             context->key.value.key,
             context->key.value.length);
 

--- a/src/module/redis/command/module_redis_command_unlink.c
+++ b/src/module/redis/command/module_redis_command_unlink.c
@@ -46,6 +46,7 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(unlink) {
     for(int index = 0; index < context->key.count; index++) {
         deleted_keys_count += storage_db_op_delete(
                 connection_context->db,
+                connection_context->database_number,
                 context->key.list[index].key,
                 context->key.list[index].length) ? 1 : 0;
     }

--- a/src/module/redis/module_redis.h
+++ b/src/module/redis/module_redis.h
@@ -187,6 +187,7 @@ struct module_redis_connection_context {
     network_channel_t *network_channel;
     network_channel_buffer_t read_buffer;
     storage_db_t *db;
+    uint32_t database_number;
     size_t current_argument_token_data_offset;
     bool terminate_connection;
     struct {

--- a/src/module/redis/module_redis_commands.c
+++ b/src/module/redis/module_redis_commands.c
@@ -48,7 +48,6 @@ hashtable_spsc_t *module_redis_commands_build_commands_hashtables(
     hashtable_spsc_t *commands_hashtable = hashtable_spsc_new(
             command_infos_count,
             32,
-            true,
             false);
     for(
             uint32_t command_info_index = 0;
@@ -222,7 +221,6 @@ bool module_redis_commands_build_commands_arguments_token_entries_hashtable(
         if ((tokens_hashtable = hashtable_spsc_new(
                 token_count,
                 8,
-                true,
                 false)) == NULL) {
             goto end;
         }

--- a/src/module/redis/snapshot/module_redis_snapshot_load.c
+++ b/src/module/redis/snapshot/module_redis_snapshot_load.c
@@ -28,6 +28,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "memory_allocator/ffma.h"
 #include "config.h"
 #include "module/module.h"
@@ -53,6 +54,7 @@ static uint64_t counter_strings = 0;
 static uint64_t counter_expires = 0;
 static uint64_t counter_expires_expired = 0;
 static uint64_t rdb_load_start;
+static storage_db_database_number_t current_database_number = 0;
 
 size_t module_redis_snapshot_load_read(
         storage_channel_t *channel,
@@ -258,6 +260,8 @@ void module_redis_snapshot_load_process_opcode_db_number(
         FATAL(TAG, "Unsupported DB number: %d", db_number);
     }
 
+    current_database_number = db_number;
+
     LOG_V(TAG, "RDB DB number: %d", db_number);
 }
 
@@ -347,6 +351,7 @@ bool module_redis_snapshot_load_write_key_value_string(
 
     if (unlikely(!storage_db_op_set(
             db,
+            current_database_number,
             key,
             key_length,
             STORAGE_DB_ENTRY_INDEX_VALUE_TYPE_STRING,

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -31,6 +31,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "support/simple_file_io.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"

--- a/src/program.c
+++ b/src/program.c
@@ -43,6 +43,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "epoch_gc.h"
 #include "epoch_gc_worker.h"
 #include "module/module.h"
@@ -604,6 +605,7 @@ bool program_config_setup_storage_db(
     storage_db_config_t *config = storage_db_config_new();
 
     if ((config->snapshot.enabled = program_context->config->database->snapshots != NULL)) {
+        config->max_user_databases = program_context->config->database->max_user_databases;
         config->snapshot.path = program_context->config->database->snapshots->path;
         config->snapshot.interval_ms = program_context->config->database->snapshots->interval_ms;
         config->snapshot.min_keys_changed = program_context->config->database->snapshots->min_keys_changed;

--- a/src/storage/db/storage_db_snapshot.h
+++ b/src/storage/db/storage_db_snapshot.h
@@ -14,7 +14,7 @@ extern "C" {
 struct storage_db_snapshot_entry_index_to_be_deleted {
     char *key;
     hashtable_bucket_index_t bucket_index;
-    hashtable_key_size_t key_length;
+    hashtable_key_length_t key_length;
     storage_db_entry_index_t *entry_index;
 };
 typedef struct storage_db_snapshot_entry_index_to_be_deleted storage_db_snapshot_entry_index_to_be_deleted_t;
@@ -62,6 +62,10 @@ bool storage_db_snapshot_rdb_write_value_string(
         storage_db_t *db,
         storage_db_entry_index_t *entry_index);
 
+bool storage_db_snapshot_rdb_write_database_number(
+        storage_db_t *db,
+        storage_db_database_number_t database_number);
+
 bool storage_db_snapshot_rdb_process_entry_index(
         storage_db_t *db,
         char *key,
@@ -85,6 +89,7 @@ void storage_db_snapshot_rdb_flush_entry_index_to_be_deleted_queue(
 
 bool storage_db_snapshot_rdb_process_block(
         storage_db_t *db,
+        storage_db_database_number_t *current_database_number,
         bool *last_block);
 
 static inline bool storage_db_snapshot_lock_try_acquire(

--- a/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.c
+++ b/src/worker/fiber/worker_fiber_storage_db_gc_deleted_entries.c
@@ -6,8 +6,10 @@
  * of the BSD license.  See the LICENSE file for details.
  **/
 
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <arpa/inet.h>
 #include <stddef.h>
 
@@ -22,6 +24,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
 #include "config.h"

--- a/src/worker/fiber/worker_fiber_storage_db_initialize.c
+++ b/src/worker/fiber/worker_fiber_storage_db_initialize.c
@@ -27,6 +27,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "memory_allocator/ffma.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <arpa/inet.h>
 
 #include "exttypes.h"
@@ -20,6 +21,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
 #include "config.h"

--- a/src/worker/fiber/worker_fiber_storage_db_snapshot_rdb.c
+++ b/src/worker/fiber/worker_fiber_storage_db_snapshot_rdb.c
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <arpa/inet.h>
 
 #include "exttypes.h"
@@ -20,6 +21,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
 #include "config.h"
@@ -84,7 +86,10 @@ void worker_fiber_storage_db_snapshot_rdb_fiber_entrypoint(
         }
 
         // Process a block
-        result = storage_db_snapshot_rdb_process_block(db, &last_block);
+        result = storage_db_snapshot_rdb_process_block(
+                db,
+                &db->snapshot.current_database_number,
+                &last_block);
 
         // If the block was processed successfully and was the last one, mark the snapshot as being finalized
         if (result && last_block) {

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -26,6 +26,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "memory_allocator/ffma.h"
 #include "support/io_uring/io_uring_support.h"

--- a/src/worker/storage/worker_storage_iouring_op.c
+++ b/src/worker/storage/worker_storage_iouring_op.c
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "memory_allocator/ffma.h"
 #include "support/io_uring/io_uring_support.h"
 #include "config.h"

--- a/src/worker/storage/worker_storage_posix_op.c
+++ b/src/worker/storage/worker_storage_posix_op.c
@@ -27,6 +27,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "memory_allocator/ffma.h"
 #include "config.h"
 #include "storage/io/storage_io_common.h"

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -47,6 +47,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "support/simple_file_io.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"

--- a/src/worker/worker_context.c
+++ b/src/worker/worker_context.c
@@ -7,6 +7,7 @@
  **/
 
 #include <stdlib.h>
+#include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <arpa/inet.h>
@@ -23,6 +24,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "module/module.h"
 #include "network/io/network_io_common.h"
 #include "network/channel/network_channel.h"

--- a/src/worker/worker_iouring.c
+++ b/src/worker/worker_iouring.c
@@ -34,6 +34,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "memory_allocator/ffma.h"
 #include "support/io_uring/io_uring_support.h"

--- a/src/worker/worker_iouring_op.c
+++ b/src/worker/worker_iouring_op.c
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <liburing.h>
 #include <arpa/inet.h>
 #include <dlfcn.h>
@@ -26,6 +27,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "memory_allocator/ffma.h"
 #include "support/io_uring/io_uring_support.h"

--- a/src/worker/worker_stats.c
+++ b/src/worker/worker_stats.c
@@ -27,6 +27,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
 #include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "memory_allocator/ffma.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "module/module.h"

--- a/tests/unit_tests/data_structures/hashtable/mpmc/fixtures-hashtable-mpmc.h
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/fixtures-hashtable-mpmc.h
@@ -32,42 +32,41 @@ uint64_t buckets_count_101 = 101;
 uint64_t buckets_count_307 = 307;
 
 char test_key_same_bucket_key_prefix_external[] = "same_bucket_key_not_inline_";
-char test_key_same_bucket_key_prefix_inline[] = "sb_key_inline_";
 
 char test_key_1[32] = "test key 1";
-hashtable_key_size_t test_key_1_len = strlen(test_key_1);
+hashtable_key_length_t test_key_1_len = strlen(test_key_1);
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
-    hashtable_hash_t test_key_1_hash = (hashtable_hash_t)t1ha2_atonce(test_key_1, test_key_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+    hashtable_hash_t test_key_1_hash = (hashtable_hash_t)t1ha2_atonce(test_key_1, test_key_1_len, 0);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
-    hashtable_hash_t test_key_1_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_1, test_key_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+    hashtable_hash_t test_key_1_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_1, test_key_1_len, 0);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_CRC32 == 1
-    uint32_t crc32 = hash_crc32c(test_key_1, test_key_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+    uint32_t crc32 = hash_crc32c(test_key_1, test_key_1_len, 0);
     hashtable_hash_t test_key_1_hash = ((uint64_t)hash_crc32c(test_key_1, test_key_1_len, crc32) << 32u) | crc32;
 #endif
 hashtable_hash_half_t test_key_1_hash_half = (test_key_1_hash >> 32u) | 0x80000000u;
 hashtable_hash_quarter_t test_key_1_hash_quarter = test_key_1_hash_half & 0xFFFF;
 
 char test_key_2[32] = "test key 2";
-hashtable_key_size_t test_key_2_len = strlen(test_key_2);
+hashtable_key_length_t test_key_2_len = strlen(test_key_2);
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
-    hashtable_hash_t test_key_2_hash = (hashtable_hash_t)t1ha2_atonce(test_key_2, test_key_2_len, HASHTABLE_SUPPORT_HASH_SEED);
+    hashtable_hash_t test_key_2_hash = (hashtable_hash_t)t1ha2_atonce(test_key_2, test_key_2_len, 0);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
-    hashtable_hash_t test_key_2_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_2, test_key_2_len, HASHTABLE_SUPPORT_HASH_SEED);
+    hashtable_hash_t test_key_2_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_2, test_key_2_len, 0);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_CRC32 == 1
-    uint32_t crc32 = hash_crc32c(test_key_2, test_key_2_len, HASHTABLE_SUPPORT_HASH_SEED);
+    uint32_t crc32 = hash_crc32c(test_key_2, test_key_2_len, 0);
     hashtable_hash_t test_key_2_hash = ((uint64_t)hash_crc32c(test_key_2, test_key_2_len, crc32) << 32u) | crc32;
 #endif
 hashtable_hash_half_t test_key_2_hash_half = (test_key_2_hash >> 32u) | 0x80000000u;
 hashtable_hash_quarter_t test_key_2_hash_quarter = test_key_2_hash_half & 0xFFFF;
 
 char test_key_long_1[] = "a very long test key that can't be inlined 1";
-hashtable_key_size_t test_key_long_1_len = strlen(test_key_long_1);
+hashtable_key_length_t test_key_long_1_len = strlen(test_key_long_1);
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
-hashtable_hash_t test_key_long_1_hash = (hashtable_hash_t)t1ha2_atonce(test_key_long_1, test_key_long_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+hashtable_hash_t test_key_long_1_hash = (hashtable_hash_t)t1ha2_atonce(test_key_long_1, test_key_long_1_len, 0);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
-hashtable_hash_t test_key_long_1_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_long_1, test_key_long_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+hashtable_hash_t test_key_long_1_hash = (hashtable_hash_t)XXH3_64bits_withSeed(test_key_long_1, test_key_long_1_len, 0);
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_CRC32 == 1
-uint32_t crc32 = hash_crc32c(test_key_long_1, test_key_long_1_len, HASHTABLE_SUPPORT_HASH_SEED);
+uint32_t crc32 = hash_crc32c(test_key_long_1, test_key_long_1_len, 0);
 hashtable_hash_t test_key_long_1_hash = ((uint64_t)hash_crc32c(test_key_long_1, test_key_long_1_len, crc32) << 32u) | crc32;
 #endif
 hashtable_hash_half_t test_key_long_1_hash_half = (test_key_long_1_hash >> 32u) | 0x80000000u;
@@ -132,23 +131,15 @@ hashtable_hash_quarter_t test_key_long_1_hash_quarter = test_key_long_1_hash_hal
     HASHTABLE_HALF_HASHES_CHUNK(chunk_index).half_hashes[chunk_slot_index].filled = true; \
     HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).data = value;
 
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-#define HASHTABLE_SET_KEY_INLINE_BY_INDEX(chunk_index, chunk_slot_index, hash, key, key_size, value) \
+#define HASHTABLE_SET_KEY_BY_INDEX(chunk_index, chunk_slot_index, hash, database_number_, key_, key_size_, value) \
     HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value); \
-    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).flags = \
-        HASHTABLE_KEY_VALUE_FLAG_FILLED | HASHTABLE_KEY_VALUE_FLAG_KEY_INLINE; \
-    strncpy((char*)&HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).inline_key.data, key, HASHTABLE_KEY_INLINE_MAX_LENGTH); \
-    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).inline_key.size = key_size;
-#endif
+    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).flags = HASHTABLE_KEY_VALUE_FLAG_FILLED; \
+    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).database_number = database_number_; \
+    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).key = key_; \
+    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).key_length = key_size_;
 
-#define HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(chunk_index, chunk_slot_index, hash, key, key_size, value) \
-    HASHTABLE_SET_INDEX_SHARED(chunk_index, chunk_slot_index, hash, value); \
-    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).flags = \
-        HASHTABLE_KEY_VALUE_FLAG_FILLED; \
-    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).external_key.data = \
-        key; \
-    HASHTABLE_KEYS_VALUES(chunk_index, chunk_slot_index).external_key.size = \
-        key_size;
+#define HASHTABLE_SET_KEY_DB_0_BY_INDEX(chunk_index, chunk_slot_index, hash, key_, key_size_, value) \
+    HASHTABLE_SET_KEY_BY_INDEX(chunk_index, chunk_slot_index, hash, 0, key_, key_size_, value)
 
 #ifdef __cplusplus
 }

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-delete.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-delete.cpp
@@ -47,6 +47,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
             HASHTABLE(0x7FFF, false, {
                 REQUIRE(!hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         nullptr));
@@ -73,6 +74,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
+                        0,
                         test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
@@ -88,6 +90,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         nullptr));
@@ -118,6 +121,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
+                        0,
                         test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
@@ -132,6 +136,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         &prev_value));
@@ -162,6 +167,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
+                        0,
                         test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
@@ -175,6 +181,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         nullptr));
@@ -188,6 +195,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
+                        0,
                         test_key_1_alloc,
                         test_key_1_len,
                         test_value_1,
@@ -204,6 +212,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         nullptr));
@@ -220,6 +229,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 bool out_should_free_key = false;
                 hashtable_chunk_slot_index_t slots_to_fill = 8;
                 test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        0,
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
@@ -230,6 +240,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
+                            0,
                             test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
@@ -242,6 +253,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_same_bucket[random_slot_index].key,
                         test_key_same_bucket[random_slot_index].key_len,
                         nullptr));
@@ -270,6 +282,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
                 bool out_should_free_key = false;
                 hashtable_chunk_slot_index_t slots_to_fill = 8;
                 test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        0,
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
@@ -280,6 +293,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                     REQUIRE(hashtable_mcmp_op_set(
                             hashtable,
+                            0,
                             test_key_same_bucket_alloc,
                             test_key_same_bucket[i].key_len,
                             test_value_1 + i,
@@ -292,6 +306,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_delete(
                         hashtable,
+                        0,
                         test_key_same_bucket[random_slot_index].key,
                         test_key_same_bucket[random_slot_index].key_len,
                         nullptr));
@@ -314,6 +329,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_delete.c", "[hashtable][hashtable_op][has
 
                 REQUIRE(hashtable_mcmp_op_set(
                         hashtable,
+                        0,
                         test_key_same_bucket_alloc,
                         test_key_same_bucket[slots_to_fill - 1].key_len,
                         test_value_1 + slots_to_fill - 1,

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-get.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-get.cpp
@@ -51,37 +51,12 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
             HASHTABLE(0x7FFF, false, {
                 REQUIRE(!hashtable_mcmp_op_get(
                         hashtable,
-                        test_key_1,
-                        test_key_1_len,
-                        &value));
-            })
-        }
-
-#if HASHTABLE_FLAG_ALLOW_KEY_INLINE == 1
-        SECTION("found - key inline") {
-            HASHTABLE(0x7FFF, false, {
-                hashtable_chunk_index_t chunk_index = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
-                        hashtable->ht_current->buckets_count,
-                        test_key_1_hash));
-
-                HASHTABLE_SET_KEY_INLINE_BY_INDEX(
-                        chunk_index,
                         0,
-                        test_key_1_hash,
-                        test_key_1,
-                        test_key_1_len,
-                        test_value_1);
-
-                REQUIRE(hashtable_mcmp_op_get(
-                        hashtable,
                         test_key_1,
                         test_key_1_len,
                         &value));
-
-                REQUIRE(value == test_value_1);
             })
         }
-#endif
 
         SECTION("found - key external") {
             HASHTABLE(0x7FFF, false, {
@@ -93,7 +68,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index,
                         0,
                         test_key_1_hash,
@@ -103,6 +78,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_1_copy,
                         test_key_1_len,
                         &value));
@@ -126,7 +102,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         hashtable->ht_current->buckets_count,
                         test_key_2_hash));
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index1,
                         0,
                         test_key_1_hash,
@@ -134,7 +110,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         test_key_1_len,
                         test_value_1);
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index2,
                         0,
                         test_key_2_hash,
@@ -144,6 +120,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_1_copy,
                         test_key_1_len,
                         &value));
@@ -152,6 +129,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_2_copy,
                         test_key_2_len,
                         &value));
@@ -170,7 +148,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index,
                         1,
                         test_key_1_hash,
@@ -180,6 +158,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_1_copy,
                         test_key_1_len,
                         &value));
@@ -191,6 +170,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
         SECTION("found - single chunk multiple slots - key prefix/external") {
             HASHTABLE(0x7FFF, false, {
                 test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        0,
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
@@ -206,7 +186,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                             test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len + 1);
 
-                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                    HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                             HASHTABLE_TO_CHUNK_INDEX(bucket_index_base),
                             i,
                             test_key_same_bucket[i].key_hash,
@@ -218,6 +198,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                 for(hashtable_chunk_slot_index_t i = 0; i < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; i++) {
                     REQUIRE(hashtable_mcmp_op_get(
                             hashtable,
+                            0,
                             (char *) test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len,
                             &value));
@@ -234,6 +215,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                 hashtable_chunk_slot_index_t slots_to_fill =
                         (HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT * chunks_to_set) + 3;
                 test_key_same_bucket_t* test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        0,
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         slots_to_fill);
@@ -258,7 +240,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                     hashtable_chunk_slot_index_t chunk_slot_index =
                             i % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT;
 
-                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                    HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                             chunk_index,
                             chunk_slot_index,
                             test_key_same_bucket[i].key_hash,
@@ -277,6 +259,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                     REQUIRE(hashtable_mcmp_op_get(
                             hashtable,
+                            0,
                             (char *) test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len,
                             &value));
@@ -293,7 +276,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                 char *test_key_1_copy = (char*)xalloc_alloc(test_key_1_len + 1);
                 strcpy(test_key_1_copy, test_key_1);
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         HASHTABLE_TO_CHUNK_INDEX(test_key_1_hash & (0x8000 - 1)),
                         0,
                         test_key_1_hash,
@@ -306,6 +289,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(!hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         &value));
@@ -322,7 +306,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index,
                         0,
                         test_key_1_hash,
@@ -337,6 +321,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(!hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         &value));
@@ -355,7 +340,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index,
                         0,
                         test_key_1_hash,
@@ -366,7 +351,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
                 HASHTABLE_KEYS_VALUES(chunk_index, 0).flags =
                         HASHTABLE_KEY_VALUE_FLAG_DELETED;
 
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index,
                         2,
                         test_key_1_hash,
@@ -376,6 +361,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_get.c", "[hashtable][hashtable_op][hashta
 
                 REQUIRE(hashtable_mcmp_op_get(
                         hashtable,
+                        0,
                         test_key_1,
                         test_key_1_len,
                         &value));

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-iter.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-op-iter.cpp
@@ -48,7 +48,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
             hashtable_bucket_index_t bucket_index = 0;
 
             HASHTABLE(0x7FFF, false, {
-                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, 0, &bucket_index));
                 REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
             })
         }
@@ -64,7 +64,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                 hashtable_chunk_index_t chunk_index1 = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index1,
                         0,
                         test_key_1_hash,
@@ -72,11 +72,11 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                         test_key_1_len,
                         test_value_1);
 
-                REQUIRE((uintptr_t)hashtable_mcmp_op_iter(hashtable,&bucket_index) == test_value_1);
+                REQUIRE((uintptr_t)hashtable_mcmp_op_iter(hashtable, 0, &bucket_index) == test_value_1);
                 REQUIRE(bucket_index == HASHTABLE_TO_BUCKET_INDEX(chunk_index1, 0));
 
                 bucket_index++;
-                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, 0, &bucket_index));
                 REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
             })
         }
@@ -86,6 +86,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
 
             HASHTABLE(0x7FFF, false, {
                 test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        0,
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
@@ -101,7 +102,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                             test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len + 1);
 
-                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                    HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                             HASHTABLE_TO_CHUNK_INDEX(bucket_index_base),
                             i,
                             test_key_same_bucket[i].key_hash,
@@ -111,13 +112,13 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                 }
 
                 for (hashtable_chunk_slot_index_t i = 0; i < HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT; i++) {
-                    REQUIRE((uintptr_t)hashtable_mcmp_op_iter(hashtable, &bucket_index) == test_value_1 + i);
+                    REQUIRE((uintptr_t)hashtable_mcmp_op_iter(hashtable, 0, &bucket_index) == test_value_1 + i);
                     REQUIRE(bucket_index == HASHTABLE_TO_BUCKET_INDEX(HASHTABLE_TO_CHUNK_INDEX(bucket_index_base), i));
 
                     bucket_index++;
                 }
 
-                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, 0, &bucket_index));
                 REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
             })
         }
@@ -127,6 +128,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
 
             HASHTABLE(0x7FFF, false, {
                 test_key_same_bucket_t *test_key_same_bucket = test_support_same_hash_mod_fixtures_generate(
+                        0,
                         hashtable->ht_current->buckets_count,
                         test_key_same_bucket_key_prefix_external,
                         HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
@@ -142,7 +144,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                             test_key_same_bucket[i].key,
                             test_key_same_bucket[i].key_len + 1);
 
-                    HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                    HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                             HASHTABLE_TO_CHUNK_INDEX(bucket_index_base),
                             i,
                             test_key_same_bucket[i].key_hash,
@@ -154,7 +156,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                             HASHTABLE_KEY_VALUE_FLAG_DELETED;
                 }
 
-                REQUIRE(!hashtable_mcmp_op_iter(hashtable, &bucket_index));
+                REQUIRE(!hashtable_mcmp_op_iter(hashtable, 0, &bucket_index));
                 REQUIRE(bucket_index + 1 == hashtable->ht_current->buckets_count_real);
             })
         }
@@ -165,8 +167,8 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
             hashtable_bucket_index_t bucket_index = 0;
 
             HASHTABLE(0x7FFF, false, {
-                REQUIRE(!hashtable_mcmp_op_iter_max_distance(hashtable, &bucket_index, 100));
-                REQUIRE(bucket_index + 1== 100 - (100 % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) + HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
+                REQUIRE(!hashtable_mcmp_op_iter_max_distance(hashtable, 0, &bucket_index, 100));
+                REQUIRE(bucket_index + 1 == 100 - (100 % HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT) + HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT);
             })
         }
 
@@ -181,7 +183,7 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                 hashtable_chunk_index_t chunk_index1 = HASHTABLE_TO_CHUNK_INDEX(hashtable_mcmp_support_index_from_hash(
                         hashtable->ht_current->buckets_count,
                         test_key_1_hash));
-                HASHTABLE_SET_KEY_EXTERNAL_BY_INDEX(
+                HASHTABLE_SET_KEY_DB_0_BY_INDEX(
                         chunk_index1,
                         0,
                         test_key_1_hash,
@@ -189,11 +191,11 @@ TEST_CASE("hashtable/hashtable_mcmp_op_iter.c", "[hashtable][hashtable_op][hasht
                         test_key_1_len,
                         test_value_1);
 
-                hashtable_mcmp_op_iter_max_distance(hashtable,&bucket_index, HASHTABLE_TO_BUCKET_INDEX(chunk_index1, 0) + 1);
+                hashtable_mcmp_op_iter_max_distance(hashtable, 0, &bucket_index, HASHTABLE_TO_BUCKET_INDEX(chunk_index1, 0) + 1);
                 REQUIRE(bucket_index == HASHTABLE_TO_BUCKET_INDEX(chunk_index1, 0));
 
                 bucket_index++;
-                REQUIRE(!hashtable_mcmp_op_iter_max_distance(hashtable, &bucket_index, 2000));
+                REQUIRE(!hashtable_mcmp_op_iter_max_distance(hashtable, 0, &bucket_index, 2000));
 
                 hashtable_bucket_index_t expected_bucket_index =
                         HASHTABLE_TO_BUCKET_INDEX(chunk_index1, 0) +

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash.cpp
@@ -35,10 +35,24 @@ TEST_CASE("hashtable/hashtable_support_hash.c", "[hashtable][hashtable_support][
     transaction_set_worker_index(worker_context.worker_index);
 
     SECTION("hashtable_mcmp_support_hash_calculate") {
-        SECTION("hash calculation") {
+        SECTION("one key, db 0") {
             REQUIRE(hashtable_mcmp_support_hash_calculate(
+                    0,
                     test_key_1,
                     test_key_1_len) == test_key_1_hash);
+        }
+
+        SECTION("same key, different dbs = different hashes") {
+            hashtable_hash_t hash_db0 = hashtable_mcmp_support_hash_calculate(
+                    0,
+                    test_key_1,
+                    test_key_1_len);
+            hashtable_hash_t hash_db1 = hashtable_mcmp_support_hash_calculate(
+                    1,
+                    test_key_1,
+                    test_key_1_len);
+
+            REQUIRE(hash_db0 != hash_db1);
         }
     }
 

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-index.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-index.cpp
@@ -29,9 +29,9 @@
 #include "fixtures-hashtable-mpmc.h"
 
 #if CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_T1HA2 == 1
-hashtable_bucket_index_t test_key_1_hash_buckets_0x80 = 76;
-hashtable_bucket_index_t test_key_1_hash_buckets_0x8000 = 24908;
-hashtable_bucket_index_t test_key_1_hash_buckets_0x80000000 = 4940108;
+hashtable_bucket_index_t test_key_1_hash_buckets_0x80 = 100;
+hashtable_bucket_index_t test_key_1_hash_buckets_0x8000 = 1508;
+hashtable_bucket_index_t test_key_1_hash_buckets_0x80000000 = 6751716;
 #elif CACHEGRAND_CMAKE_CONFIG_USE_HASH_ALGORITHM_XXH3 == 1
 hashtable_bucket_index_t test_key_1_hash_buckets_0x80 = 106;
 hashtable_bucket_index_t test_key_1_hash_buckets_0x8000 = 28010;

--- a/tests/unit_tests/data_structures/test-hashtable-spsc.cpp
+++ b/tests/unit_tests/data_structures/test-hashtable-spsc.cpp
@@ -29,31 +29,17 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
     uint32_t key2_ci_hash = fnv_32_hash_ci(key2, key2_length);
 
     SECTION("hashtable_spsc_new") {
-        SECTION("valid buckets_count, default max range, stop_on_not_set true, free_keys_on_deallocation false") {
+        SECTION("valid buckets_count, default max range, free_keys_on_deallocation false") {
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     10,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    true,
                     false);
 
             REQUIRE(hashtable->buckets_count == 10);
             REQUIRE(hashtable->buckets_count_pow2 == 16);
             REQUIRE(hashtable->buckets_count_real == 16 + HASHTABLE_SPSC_DEFAULT_MAX_RANGE);
-            REQUIRE(hashtable->stop_on_not_set == true);
             REQUIRE(hashtable->free_keys_on_deallocation == false);
             REQUIRE(hashtable->max_range == HASHTABLE_SPSC_DEFAULT_MAX_RANGE);
-
-            hashtable_spsc_free(hashtable);
-        }
-
-        SECTION("valid buckets_count, stop_on_not_set false") {
-            hashtable_spsc_t *hashtable = hashtable_spsc_new(
-                    10,
-                    HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
-                    false);
-
-            REQUIRE(hashtable->stop_on_not_set == false);
 
             hashtable_spsc_free(hashtable);
         }
@@ -62,7 +48,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     10,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     true);
 
             REQUIRE(hashtable->free_keys_on_deallocation == true);
@@ -74,7 +59,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     10,
                     1,
-                    true,
                     false);
 
             REQUIRE(hashtable->buckets_count_real == 16 + 1);
@@ -88,7 +72,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         hashtable_spsc_t *hashtable = hashtable_spsc_new(
                 10,
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                true,
                 false);
 
         hashtable_spsc_bucket_t *buckets = hashtable_spsc_get_buckets(hashtable);
@@ -102,7 +85,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         hashtable_spsc_t *hashtable = hashtable_spsc_new(
                 16,
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
                 false);
         hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_ci_hash & (hashtable->buckets_count_pow2 - 1);
         hashtable_spsc_bucket_count_t hashtable_key_bucket_index_max =
@@ -140,7 +122,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         hashtable_spsc_t *hashtable = hashtable_spsc_new(
                 16,
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
                 false);
         hashtable_spsc_bucket_count_t hashtable_key_bucket_index = key_ci_hash & (hashtable->buckets_count_pow2 - 1);
         hashtable_spsc_bucket_count_t hashtable_key_bucket_index_max =
@@ -182,7 +163,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         hashtable_spsc_t *hashtable = hashtable_spsc_new(
                 16,
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
                 false);
 
         REQUIRE((key_hash & (hashtable->buckets_count_pow2 - 1)) == 15);
@@ -195,7 +175,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -205,7 +184,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable2 = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    true,
                     false);
             hashtable_spsc_bucket_t *hashtable2_buckets = hashtable_spsc_get_buckets(hashtable2);
             hashtable_spsc_bucket_count_t hashtable2_key_bucket_index =
@@ -213,7 +191,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket found - key exists") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -223,7 +201,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket found - same hash but different key_length and key") {
                 hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
                 hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
 
@@ -239,7 +217,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket found - same hash and same key_length but different key") {
                 hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
                 hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
 
@@ -259,11 +237,11 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
                 for (int index = 0; index < extra_slots; index++) {
                     hashtable->hashes[hashtable_key_bucket_index + index].set = true;
-                    hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = (key_ci_hash & 0x7FFF) + 1 + index;
+                    hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash) + 1 + index;
                 }
 
                 hashtable->hashes[hashtable_key_bucket_index + extra_slots].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index + extra_slots].key = key;
                 hashtable_buckets[hashtable_key_bucket_index + extra_slots].key_length = key_length;
 
@@ -274,7 +252,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             SECTION("bucket found - key exists, last bucket within max range") {
                 hashtable_key_bucket_index += hashtable->max_range - 1;
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -284,7 +262,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket found - key with different case") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -294,7 +272,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket not found - key not-existent") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -305,7 +283,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             SECTION("bucket not found - key outside max range") {
                 hashtable_key_bucket_index += hashtable->max_range;
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -315,7 +293,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             SECTION("bucket not found - key exists but not set buckets on the way") {
                 hashtable2_key_bucket_index += hashtable2->max_range;
                 hashtable2->hashes[hashtable2_key_bucket_index].set = true;
-                hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable2_buckets[hashtable2_key_bucket_index].key = key;
                 hashtable2_buckets[hashtable2_key_bucket_index].key_length = key_length;
 
@@ -333,7 +311,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -344,7 +321,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key, key_length, value1));
 
                 REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_ci_hash & 0x7FFF));
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == HASHTABLE_SPSC_HASH(key_ci_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
@@ -355,7 +332,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key, key_length, value2));
 
                 REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_ci_hash & 0x7FFF));
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == HASHTABLE_SPSC_HASH(key_ci_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
@@ -366,7 +343,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 REQUIRE(hashtable_spsc_op_try_set_ci(hashtable, key_different_case, key_length, value2));
 
                 REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_ci_hash & 0x7FFF));
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == HASHTABLE_SPSC_HASH(key_ci_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key_different_case);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
@@ -398,7 +375,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -406,7 +382,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value found - existing key") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
                 hashtable_buckets[hashtable_key_bucket_index].value = value1;
@@ -416,7 +392,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value found - existing key with different case") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
                 hashtable_buckets[hashtable_key_bucket_index].value = value1;
@@ -435,7 +411,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -443,7 +418,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value deleted - existing key") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -454,7 +429,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value deleted - existing key with different case") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_ci_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_ci_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -476,7 +451,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -485,14 +459,13 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable2 = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    true,
                     false);
             hashtable_spsc_bucket_t *hashtable2_buckets = hashtable_spsc_get_buckets(hashtable2);
             hashtable_spsc_bucket_count_t hashtable2_key_bucket_index = key_hash & (hashtable2->buckets_count_pow2 - 1);
 
             SECTION("bucket found - key exists") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -502,7 +475,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket found - same hash but different key_length and key") {
                 hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
                 hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
 
@@ -518,7 +491,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket found - same hash and same key_length but different key") {
                 hashtable->hashes[hashtable_key_bucket_index + 1].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index + 1].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index + 1].key = key;
                 hashtable_buckets[hashtable_key_bucket_index + 1].key_length = key_length;
 
@@ -538,11 +511,11 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
                 for (int index = 0; index < extra_slots; index++) {
                     hashtable->hashes[hashtable_key_bucket_index + index].set = true;
-                    hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = (key_hash & 0x7FFF) + 1 + index;
+                    hashtable->hashes[hashtable_key_bucket_index + index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash) + 1 + index;
                 }
 
                 hashtable->hashes[hashtable_key_bucket_index + extra_slots].set = true;
-                hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index + extra_slots].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index + extra_slots].key = key;
                 hashtable_buckets[hashtable_key_bucket_index + extra_slots].key_length = key_length;
 
@@ -553,7 +526,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             SECTION("bucket found - key exists, last bucket within max range") {
                 hashtable_key_bucket_index += hashtable->max_range - 1;
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -563,7 +536,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket not found - key with different case") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -573,7 +546,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("bucket not found - key not-existent") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -584,7 +557,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             SECTION("bucket not found - key outside max range") {
                 hashtable_key_bucket_index += hashtable->max_range;
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -594,7 +567,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             SECTION("bucket not found - key exists but not set buckets on the way") {
                 hashtable2_key_bucket_index += hashtable2->max_range;
                 hashtable2->hashes[hashtable2_key_bucket_index].set = true;
-                hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable2->hashes[hashtable2_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable2_buckets[hashtable2_key_bucket_index].key = key;
                 hashtable2_buckets[hashtable2_key_bucket_index].key_length = key_length;
 
@@ -611,7 +584,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -629,7 +601,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key, key_length, value1));
 
                 REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == HASHTABLE_SPSC_HASH(key_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
@@ -640,7 +612,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key, key_length, value2));
 
                 REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == HASHTABLE_SPSC_HASH(key_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value2);
@@ -651,14 +623,14 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
                 REQUIRE(hashtable_spsc_op_try_set_cs(hashtable, key_different_case, key_length, value2));
 
                 REQUIRE(hashtable->hashes[hashtable_key_bucket_index].set);
-                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == (key_hash & 0x7FFF));
+                REQUIRE(hashtable->hashes[hashtable_key_bucket_index].cmp_hash == HASHTABLE_SPSC_HASH(key_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key == key);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_bucket_index].value == value1);
 
                 REQUIRE(hashtable->hashes[hashtable_key_different_case_bucket_index].set);
                 REQUIRE(hashtable->hashes[hashtable_key_different_case_bucket_index].cmp_hash ==
-                        (key_different_case_hash & 0x7FFF));
+                        HASHTABLE_SPSC_HASH(key_different_case_hash));
                 REQUIRE(hashtable_buckets[hashtable_key_different_case_bucket_index].key == key_different_case);
                 REQUIRE(hashtable_buckets[hashtable_key_different_case_bucket_index].key_length == key_length);
                 REQUIRE(hashtable_buckets[hashtable_key_different_case_bucket_index].value == value2);
@@ -688,7 +660,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -696,7 +667,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value found - existing key ") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
                 hashtable_buckets[hashtable_key_bucket_index].value = value1;
@@ -706,7 +677,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value not found - existing key with different case") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
                 hashtable_buckets[hashtable_key_bucket_index].value = value1;
@@ -725,7 +696,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
             hashtable_spsc_t *hashtable = hashtable_spsc_new(
                     16,
                     HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                    false,
                     false);
             hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
 
@@ -733,7 +703,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value deleted - existing key") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -744,7 +714,7 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
 
             SECTION("value not deleted - existing key with different case") {
                 hashtable->hashes[hashtable_key_bucket_index].set = true;
-                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = key_hash & 0x7FFF;
+                hashtable->hashes[hashtable_key_bucket_index].cmp_hash = HASHTABLE_SPSC_HASH(key_hash);
                 hashtable_buckets[hashtable_key_bucket_index].key = key;
                 hashtable_buckets[hashtable_key_bucket_index].key_length = key_length;
 
@@ -767,7 +737,6 @@ TEST_CASE("data_structures/hashtable/spsc/hashtable_spsc.c", "[data_structures][
         hashtable_spsc_t *hashtable = hashtable_spsc_new(
                 16,
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                false,
                 false);
         hashtable_spsc_bucket_t *hashtable_buckets = hashtable_spsc_get_buckets(hashtable);
         hashtable_spsc_bucket_index_t hashtable_key_bucket_index = 0;

--- a/tests/unit_tests/modules/prometheus/test-program-prometheus.cpp
+++ b/tests/unit_tests/modules/prometheus/test-program-prometheus.cpp
@@ -34,6 +34,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/hashtable/mcmp/hashtable_config.h"
 #include "protocol/redis/protocol_redis.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-append.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-bgsave.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-bgsave.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-copy.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-copy.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-dbsize.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-dbsize.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-decr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-decr.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-decrby.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-decrby.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-del.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-del.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-echo.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-echo.cpp
@@ -41,30 +41,10 @@
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
-TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - TOUCH", "[redis][command][TOUCH]") {
-    SECTION("Existing key") {
+TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - ECHO", "[redis][command][ECHO]") {
+    SECTION("With value") {
         REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"SET", "a_key", "b_value"},
-                "+OK\r\n"));
-
-        REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"TOUCH", "a_key"},
-                ":1\r\n"));
-    }
-
-    SECTION("Multiple key") {
-        REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"MSET", "a_key", "b_value", "b_key", "value_z", "c_key", "d_value"},
-                "+OK\r\n"));
-
-        REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"TOUCH", "a_key", "b_key", "c_key"},
-                ":3\r\n"));
-    }
-
-    SECTION("Non-existing key") {
-        REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"TOUCH", "a_key"},
-                ":0\r\n"));
+                std::vector<std::string>{"ECHO", "a test"},
+                "$6\r\na test\r\n"));
     }
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-exists.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-exists.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expire.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expire.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expireat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expireat.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-expiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-expiretime.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
@@ -40,6 +40,7 @@
 #include "module/module.h"
 #include "network/io/network_io_common.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "network/channel/network_channel.h"
@@ -137,6 +138,7 @@ TestModulesRedisCommandFixture::TestModulesRedisCommandFixture() {
             .backend = CONFIG_DATABASE_BACKEND_MEMORY,
             .snapshots = &config_database_snapshots,
             .memory = &config_database_memory,
+            .max_user_databases = 16,
     };
 
     config = {

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-generic.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-generic.cpp
@@ -27,6 +27,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-get.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-get.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getdel.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getdel.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getex.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"
@@ -72,7 +73,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[re
                     std::vector<std::string>{"GET", "a_key"},
                     "$-1\r\n"));
 
-            storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, "a_key", strlen("a_key"));
+            storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, "a_key", strlen("a_key"));
             REQUIRE(entry_index == NULL);
         }
 
@@ -94,7 +95,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - GETEX", "[re
                     std::vector<std::string>{"GET", "a_key"},
                     "$-1\r\n"));
 
-            storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, "a_key", strlen("a_key"));
+            storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, "a_key", strlen("a_key"));
             REQUIRE(entry_index == NULL);
         }
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getrange.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getrange.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-getset.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-getset.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-hello.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-hello.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incr.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrby.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrby.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrbyfloat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-incrbyfloat.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-keys.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-keys.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"
@@ -127,7 +128,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - KEYS", "[red
         SECTION("Match - star - multiple results") {
             REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "*key"},
-                    "*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                    "*4\r\n$5\r\nc_key\r\n$5\r\nd_key\r\n$5\r\nb_key\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - question mark") {
@@ -145,13 +146,13 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - KEYS", "[red
         SECTION("Match - brackets") {
             REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "[a-z]_key"},
-                    "*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                    "*4\r\n$5\r\nc_key\r\n$5\r\nd_key\r\n$5\r\nb_key\r\n$5\r\na_key\r\n"));
         }
 
         SECTION("Match - everything") {
             REQUIRE(send_recv_resp_command_text_and_validate_recv(
                     std::vector<std::string>{"KEYS", "*"},
-                    "*5\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                    "*5\r\n$5\r\nc_key\r\n$5\r\nd_key\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n"));
         }
     }
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-lcs.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-lcs.cpp
@@ -22,6 +22,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "config.h"
 #include "fiber/fiber.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-mget.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-mget.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-mset.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-mset.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-msetnx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-msetnx.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-persist.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-persist.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpire.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpire.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpireat.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpireat.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pexpiretime.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-ping.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-ping.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-psetex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-psetex.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"
@@ -88,7 +89,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index == NULL);
     }
 
@@ -112,7 +113,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - PSETEX", "[r
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index == NULL);
     }
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-pttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-pttl.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-quit.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-quit.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-randomkey.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-randomkey.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-rename.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-rename.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-save.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-save.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-scan.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-scan.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"
@@ -76,30 +77,30 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
             SECTION("No match") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "100"},
-                        "*2\r\n:687\r\n*0\r\n"));
+                        "*2\r\n:981\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "687", "MATCH", "nomatch", "COUNT", "100"},
+                        std::vector<std::string>{"SCAN", "981", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key", "COUNT", "100"},
-                        "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
+                        "*2\r\n:981\r\n*1\r\n$5\r\na_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "687", "MATCH", "a_key", "COUNT", "100"},
+                        std::vector<std::string>{"SCAN", "981", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Only count") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "COUNT", "100"},
-                        "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
+                        "*2\r\n:981\r\n*1\r\n$5\r\na_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "687", "COUNT", "100"},
+                        std::vector<std::string>{"SCAN", "981", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
         }
@@ -164,54 +165,66 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
             SECTION("No match") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "nomatch", "COUNT", "100"},
-                        "*2\r\n:281\r\n*0\r\n"));
+                        "*2\r\n:421\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "281", "MATCH", "nomatch", "COUNT", "100"},
-                        "*2\r\n:687\r\n*0\r\n"));
+                        std::vector<std::string>{"SCAN", "421", "MATCH", "nomatch", "COUNT", "100"},
+                        "*2\r\n:659\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "687", "MATCH", "nomatch", "COUNT", "100"},
-                        "*2\r\n:841\r\n*0\r\n"));
+                        std::vector<std::string>{"SCAN", "659", "MATCH", "nomatch", "COUNT", "100"},
+                        "*2\r\n:869\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "841", "MATCH", "nomatch", "COUNT", "100"},
+                        std::vector<std::string>{"SCAN", "869", "MATCH", "nomatch", "COUNT", "100"},
+                        "*2\r\n:981\r\n*0\r\n"));
+
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                        std::vector<std::string>{"SCAN", "981", "MATCH", "nomatch", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Match - simple") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "a_key", "COUNT", "100"},
-                        "*2\r\n:281\r\n*0\r\n"));
+                        "*2\r\n:421\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "281", "MATCH", "a_key", "COUNT", "100"},
-                        "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
+                        std::vector<std::string>{"SCAN", "421", "MATCH", "a_key", "COUNT", "100"},
+                        "*2\r\n:659\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "687", "MATCH", "a_key", "COUNT", "100"},
-                        "*2\r\n:841\r\n*0\r\n"));
+                        std::vector<std::string>{"SCAN", "659", "MATCH", "a_key", "COUNT", "100"},
+                        "*2\r\n:869\r\n*0\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "841", "MATCH", "nomatch", "COUNT", "100"},
+                        std::vector<std::string>{"SCAN", "869", "MATCH", "a_key", "COUNT", "100"},
+                        "*2\r\n:981\r\n*1\r\n$5\r\na_key\r\n"));
+
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                        std::vector<std::string>{"SCAN", "981", "MATCH", "a_key", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
 
             SECTION("Only count") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "COUNT", "100"},
-                        "*2\r\n:281\r\n*2\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n"));
+                        "*2\r\n:421\r\n*1\r\n$5\r\nc_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "281", "COUNT", "100"},
-                        "*2\r\n:687\r\n*1\r\n$5\r\na_key\r\n"));
+                        std::vector<std::string>{"SCAN", "421", "COUNT", "100"},
+                        "*2\r\n:659\r\n*1\r\n$5\r\nd_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "687", "COUNT", "100"},
-                        "*2\r\n:841\r\n*2\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                        std::vector<std::string>{"SCAN", "659", "COUNT", "100"},
+                        "*2\r\n:869\r\n*2\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n"));
 
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                        std::vector<std::string>{"SCAN", "841", "COUNT", "100"},
+                        std::vector<std::string>{"SCAN", "869", "COUNT", "100"},
+                        "*2\r\n:981\r\n*1\r\n$5\r\na_key\r\n"));
+
+                REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                        std::vector<std::string>{"SCAN", "981", "COUNT", "100"},
                         "*2\r\n:0\r\n*0\r\n"));
             }
         }
@@ -238,7 +251,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
             SECTION("Match - star - multiple results") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*key"},
-                        "*2\r\n:0\r\n*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                        "*2\r\n:0\r\n*4\r\n$5\r\nc_key\r\n$5\r\nd_key\r\n$5\r\nb_key\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - question mark") {
@@ -256,13 +269,13 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SCAN", "[red
             SECTION("Match - brackets") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "[a-z]_key"},
-                        "*2\r\n:0\r\n*4\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                        "*2\r\n:0\r\n*4\r\n$5\r\nc_key\r\n$5\r\nd_key\r\n$5\r\nb_key\r\n$5\r\na_key\r\n"));
             }
 
             SECTION("Match - everything") {
                 REQUIRE(send_recv_resp_command_text_and_validate_recv(
                         std::vector<std::string>{"SCAN", "0", "MATCH", "*"},
-                        "*2\r\n:0\r\n*5\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n$5\r\nd_key\r\n$5\r\nc_key\r\n"));
+                        "*2\r\n:0\r\n*5\r\n$5\r\nc_key\r\n$5\r\nd_key\r\n$7\r\nkey_zzz\r\n$5\r\nb_key\r\n$5\r\na_key\r\n"));
             }
         }
     }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-set.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"
@@ -51,7 +52,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"SET", key, value},
                 "+OK\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index->value.sequence[0].chunk_length == strlen(value));
         REQUIRE(strncmp((char *) entry_index->value.sequence[0].memory.chunk_data, value, strlen(value)) == 0);
     }
@@ -64,7 +65,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"SET", key, value},
                 "+OK\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index->value.sequence[0].chunk_length == strlen(value));
         REQUIRE(strncmp((char *) entry_index->value.sequence[0].memory.chunk_data, value, strlen(value)) == 0);
     }
@@ -82,7 +83,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"SET", key, value2},
                 "+OK\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index->value.sequence[0].chunk_length == strlen(value2));
         REQUIRE(strncmp((char *) entry_index->value.sequence[0].memory.chunk_data, value2, strlen(value2)) == 0);
     }
@@ -125,7 +126,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index == NULL);
     }
 
@@ -149,7 +150,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index == NULL);
     }
 
@@ -167,7 +168,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"GET", key},
                 "$7\r\nb_value\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index->value.sequence[0].chunk_length == strlen(value1));
         REQUIRE(strncmp((char *) entry_index->value.sequence[0].memory.chunk_data, value1, strlen(value1)) == 0);
 
@@ -183,7 +184,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"SET", key, value2, "KEEPTTL"},
                 "+OK\r\n"));
 
-        entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index->value.sequence[0].chunk_length == strlen(value2));
         REQUIRE(strncmp((char *) entry_index->value.sequence[0].memory.chunk_data, value2, strlen(value2)) == 0);
 
@@ -198,7 +199,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SET", "[redi
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
-        entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index == NULL);
     }
 

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-setex.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-setex.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"
@@ -88,7 +89,7 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SETEX", "[re
                 std::vector<std::string>{"GET", key},
                 "$-1\r\n"));
 
-        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, key, strlen(key));
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(db, 0, key, strlen(key));
         REQUIRE(entry_index == NULL);
     }
 }

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-setnx.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-setnx.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-setrange.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-setrange.cpp
@@ -26,6 +26,7 @@
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-shutdown.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-shutdown.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-strlen.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-strlen.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-substr.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-substr.cpp
@@ -25,6 +25,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-ttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-ttl.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-unlink.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-unlink.cpp
@@ -23,6 +23,7 @@
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "worker/worker_stats.h"

--- a/tests/unit_tests/modules/redis/test-module-redis-commands.cpp
+++ b/tests/unit_tests/modules/redis/test-module-redis-commands.cpp
@@ -169,7 +169,6 @@ TEST_CASE("module/redis/module_redis_commands.c", "[module][redis][module_redis_
         hashtable_spsc_t *hashtable = hashtable_spsc_new(
                 32,
                 HASHTABLE_SPSC_DEFAULT_MAX_RANGE,
-                true,
                 false);
 
         SECTION("command with tokens") {
@@ -265,7 +264,6 @@ TEST_CASE("module/redis/module_redis_commands.c", "[module][redis][module_redis_
         command_infos_map[0].tokens_hashtable = hashtable_spsc_new(
                 8,
                 8,
-                true,
                 false);
 
         module_redis_commands_free_command_arguments_token_entries_hashtable(&command_infos_map[0]);

--- a/tests/unit_tests/support.c
+++ b/tests/unit_tests/support.c
@@ -197,6 +197,7 @@ void test_support_hashtable_print_heatmap(
 }
 
 test_key_same_bucket_t* test_support_same_hash_mod_fixtures_generate(
+        hashtable_database_number_t database_number,
         hashtable_bucket_count_t bucket_count,
         const char* key_prefix,
         uint32_t count) {
@@ -227,7 +228,10 @@ test_key_same_bucket_t* test_support_same_hash_mod_fixtures_generate(
         bool add_fixture = false;
 
         snprintf(key_test, key_test_size, key_model, i);
-        hashtable_hash_t hash_test = hashtable_mcmp_support_hash_calculate(key_test, strlen(key_test));
+        hashtable_hash_t hash_test = hashtable_mcmp_support_hash_calculate(
+                database_number,
+                key_test,
+                strlen(key_test));
 
         if (!reference_hash_set) {
             reference_bucket_index = hash_test & (bucket_count - 1);
@@ -241,6 +245,7 @@ test_key_same_bucket_t* test_support_same_hash_mod_fixtures_generate(
             memset(key_test_copy, 0, key_test_size);
             strncpy(key_test_copy, key_test, key_test_size);
 
+            test_key_same_bucket_fixtures[matches_counter].database_number = database_number;
             test_key_same_bucket_fixtures[matches_counter].key = key_test_copy;
             test_key_same_bucket_fixtures[matches_counter].key_len = strlen(key_test);
             test_key_same_bucket_fixtures[matches_counter].key_hash = hash_test;
@@ -486,6 +491,7 @@ hashtable_t* test_support_init_hashtable(
 
 bool test_support_hashtable_prefill(
         hashtable_t* hashtable,
+        hashtable_database_number_t database_number,
         char* keyset,
         uint64_t value,
         uint64_t insert_count) {
@@ -497,6 +503,7 @@ bool test_support_hashtable_prefill(
 
         bool result = hashtable_mcmp_op_set(
                 hashtable,
+                database_number,
                 key,
                 strlen(key),
                 value + i,

--- a/tests/unit_tests/support.h
+++ b/tests/unit_tests/support.h
@@ -53,14 +53,16 @@ typedef uint16_t hashtable_hash_quarter_t;
 typedef uint8_t hashtable_chunk_slot_index_t;
 typedef hashtable_bucket_index_t hashtable_bucket_count_t;
 typedef hashtable_chunk_index_t hashtable_chunk_count_t;
-typedef uint32_t hashtable_key_size_t;
+typedef uint32_t hashtable_database_number_t;
+typedef uint32_t hashtable_key_length_t;
 typedef char hashtable_key_data_t;
 typedef uintptr_t hashtable_value_data_t;
 
 typedef struct test_key_same_bucket test_key_same_bucket_t;
 struct test_key_same_bucket {
+    hashtable_database_number_t database_number;
     char* key;
-    hashtable_key_size_t key_len;
+    hashtable_key_length_t key_len;
     hashtable_hash_t key_hash;
     hashtable_hash_half_t key_hash_half;
     hashtable_hash_quarter_t key_hash_quarter;
@@ -86,6 +88,7 @@ void test_support_hashtable_print_heatmap(
         uint8_t columns);
 
 test_key_same_bucket_t* test_support_same_hash_mod_fixtures_generate(
+        hashtable_database_number_t database_number,
         hashtable_bucket_count_t bucket_count,
         const char* key_prefix,
         uint32_t count);
@@ -109,6 +112,7 @@ hashtable_t* test_support_init_hashtable(
 
 bool test_support_hashtable_prefill(
         hashtable_t* hashtable,
+        hashtable_database_number_t database_number,
         char* keyset,
         uint64_t value,
         uint64_t insert_count);

--- a/tests/unit_tests/test-config.cpp
+++ b/tests/unit_tests/test-config.cpp
@@ -153,6 +153,7 @@ modules:
           port: 6379
           tls: true
 database:
+  max_user_databases: 16
   limits:
     hard:
       max_keys: 1000000
@@ -234,6 +235,7 @@ modules:
         - host: "::"
           port: 6379
 database:
+  max_user_databases: 16
   limits:
     hard:
       max_keys: 1000000

--- a/tests/unit_tests/test-program.cpp
+++ b/tests/unit_tests/test-program.cpp
@@ -35,6 +35,7 @@
 #include "module/module.h"
 #include "network/io/network_io_common.h"
 #include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "config.h"
 #include "fiber/fiber.h"
 #include "network/channel/network_channel.h"

--- a/tests/unit_tests/worker/test-worker.cpp
+++ b/tests/unit_tests/worker/test-worker.cpp
@@ -28,6 +28,7 @@
 #include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
 #include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
 #include "storage/io/storage_io_common.h"
 #include "storage/channel/storage_channel.h"
 #include "module/module.h"

--- a/tools/redis-commands-scaffolding-generator/commands.json
+++ b/tools/redis-commands-scaffolding-generator/commands.json
@@ -2199,6 +2199,31 @@
         ]
     },
     {
+        "command_string": "SELECT",
+        "command_callback_name": "select",
+        "since": "1.0.0",
+        "required_arguments_count": 1,
+        "has_variable_arguments": true,
+        "key_specs": [
+        ],
+        "arguments": [
+            {
+                "name": "index",
+                "type": "integer",
+                "since": "1.0.0",
+                "key_spec_index": null,
+                "token": null,
+                "sub_arguments": [],
+                "is_positional": true,
+                "is_optional": false,
+                "is_sub_argument": false,
+                "has_sub_arguments": false,
+                "has_multiple_occurrences": false,
+                "has_multiple_token": false
+            }
+        ]
+    },
+    {
         "command_string": "SCAN",
         "command_callback_name": "scan",
         "since": "2.8.0",


### PR DESCRIPTION
This PR implements the multi database support in cachegrand, allowing cachegrand to have separated namespaces where to store data meanwhile sharing the database index.

Although this approach is different from what Redis does, it opens the doors to different scenarios, e.g. transactional operations across different namespaces will be possible because the indexes are shared.

This approach also will open the door to mapping specific database numbers to specific module configurations in the config file (currently not implemented), allowing to have more endpoint exposed with access to different databases (e.g. an endpoint with access to the db numbers from 0 to 15, and another, maybe in the future shared with memcache, from 16 to 64).
Although internally the database number is an uint32, the configuration allows only up to UINT8_MAX (255) namespaces.

One of the biggest downsides of having to support multiple databases is having separated counters, one global and one per database. To avoid a performance loss, a number of optimizations have been implemented in the hashtable_spsc and it's now capable of getting the value associated with a key in ~1.09ns in average with the worst case being around ~1.30ns.

Here a bench run of hashtable-spsc-op-get
```
2023-04-28T23:00:29+02:00
Running /home/daalbano/dev/cachegrand/cmake-build-release/benches/bench-hashtable-spsc-op-get
Run on (32 X 4200 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 16384 KiB (x4)
Load Average: 3.27, 2.28, 2.98
------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                      Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------------------------------------
HashtableSpscOpGetFixture/FindTokenInHashtableWorstCase1Benchmark/iterations:100000000                      14.3 ns         14.3 ns    100000000
HashtableSpscOpGetFixture/FindTokenInHashtableAvgCaseCIBenchmark/iterations:100000000                       8.78 ns         8.78 ns    100000000
HashtableSpscOpGetFixture/FindTokenInHashtableAvgCaseCSBenchmark/iterations:100000000                       6.98 ns         6.98 ns    100000000
HashtableSpscOpGetKeyAsIntFixture/FindTokenInHashtableBypassHashAndKey1Benchmark/iterations:100000000       1.09 ns         1.09 ns    100000000
HashtableSpscOpGetKeyAsIntFixture/FindTokenInHashtableBypassHashAndKey2Benchmark/iterations:100000000       1.36 ns         1.36 ns    100000000
HashtableSpscOpGetKeyAsIntFixture/FindTokenInHashtableBypassHashAndKey3Benchmark/iterations:100000000       1.09 ns         1.09 ns    100000000
HashtableSpscOpGetKeyAsIntFixture/FindTokenInHashtableBypassHashAndKey4Benchmark/iterations:100000000       1.20 ns         1.20 ns    100000000
HashtableSpscOpGetKeyAsIntFixture/FindTokenInHashtableBypassHashAndKey5Benchmark/iterations:100000000       1.60 ns         1.60 ns    100000000
```

These amazing performances render almost null the impact of the extra counters.

The PR also introduces the SELECT command.

Although some tests have been implemented for the SELECT command to test, end-to-end, the process, it's necessary to implement further tests.

Closes #368
Closes #369