### PR TITLE
When validating the configuration, ensure that the keepalive is valid

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -586,6 +586,7 @@ bool config_validate_after_load_modules_network_tls(
                 module->network->tls->private_key_path);
         return_result = false;
     }
+}
 
 bool config_validate_after_load_modules_network_keepalive(
         config_module_t *module) {

--- a/src/config.c
+++ b/src/config.c
@@ -586,6 +586,8 @@ bool config_validate_after_load_modules_network_tls(
                 module->network->tls->private_key_path);
         return_result = false;
     }
+
+    return return_result;
 }
 
 bool config_validate_after_load_modules_network_keepalive(

--- a/src/config.c
+++ b/src/config.c
@@ -587,6 +587,38 @@ bool config_validate_after_load_modules_network_tls(
         return_result = false;
     }
 
+bool config_validate_after_load_modules_network_keepalive(
+        config_module_t *module) {
+    bool return_result = true;
+
+    if (module->network->keepalive == NULL) {
+        return true;
+    }
+
+    if (module->network->keepalive->time == 0) {
+        LOG_E(
+                TAG,
+                "In module <%s>, the keepalive time has to be greater than zero",
+                config_module_type_schema_strings[module->type].str);
+        return_result = false;
+    }
+
+    if (module->network->keepalive->interval == 0) {
+        LOG_E(
+                TAG,
+                "In module <%s>, the keepalive interval has to be greater than zero",
+                config_module_type_schema_strings[module->type].str);
+        return_result = false;
+    }
+
+    if (module->network->keepalive->probes == 0) {
+        LOG_E(
+                TAG,
+                "In module <%s>, the keepalive probes has to be greater than zero",
+                config_module_type_schema_strings[module->type].str);
+        return_result = false;
+    }
+
     return return_result;
 }
 
@@ -618,6 +650,7 @@ bool config_validate_after_load_modules(
         config_module_t *module = &config->modules[module_index];
 
         if (config_validate_after_load_modules_network_timeout(module) == false
+            || config_validate_after_load_modules_network_keepalive(module) == false
             || config_validate_after_load_modules_network_tls(module) == false
             || config_validate_after_load_modules_network_bindings(module) == false
             || config_validate_after_load_modules_redis(module) == false) {

--- a/tests/unit_tests/test-config.cpp
+++ b/tests/unit_tests/test-config.cpp
@@ -136,9 +136,9 @@ modules:
         read_ms: 2000
         write_ms: 2000
       keepalive:
-        time: 0
-        interval: 0
-        probes: 0
+        time: 10
+        interval: 20
+        probes: 30
       tls:
         certificate_path: "/path/to/certificate.pem"
         private_key_path: "/path/to/certificate.key"
@@ -223,9 +223,9 @@ modules:
         read_ms: 2000
         write_ms: 2000
       keepalive:
-        time: 0
-        interval: 0
-        probes: 0
+        time: 10
+        interval: 20
+        probes: 30
       tls:
         certificate_path: "/path/to/non-existent/certificate"
         private_key_path: "/path/to/non-existent/private_key"


### PR DESCRIPTION
This PR add validation for the keepalive settings, if present but set to zero are currently accepted and this will cause a number of errors printed out on the console on every new connection.