### PR TITLE
Fix ca load

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -587,6 +587,16 @@ bool config_validate_after_load_modules_network_tls(
         return_result = false;
     }
 
+    if (module->network->tls->ca_certificate_chain_path &&
+            !simple_file_io_exists(module->network->tls->ca_certificate_chain_path)) {
+        LOG_E(
+                TAG,
+                "In module <%s>, the ca certificate chain <%s> doesn't exist",
+                config_module_type_schema_strings[module->type].str,
+                module->network->tls->ca_certificate_chain_path);
+        return_result = false;
+    }
+
     return return_result;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -91,6 +91,7 @@ typedef struct config_module_network_tls config_module_network_tls_t;
 struct config_module_network_tls {
     char *certificate_path;
     char *private_key_path;
+    char *ca_certificate_chain_path;
     char **cipher_suites;
     unsigned cipher_suites_count;
     config_module_network_tls_min_version_t min_version;

--- a/src/config_cyaml_schema.c
+++ b/src/config_cyaml_schema.c
@@ -69,6 +69,9 @@ const cyaml_schema_field_t config_module_network_tls_schema[] = {
         CYAML_FIELD_STRING_PTR(
                 "private_key_path", CYAML_FLAG_DEFAULT,
                 config_module_network_tls_t, private_key_path, 0, CYAML_UNLIMITED),
+        CYAML_FIELD_STRING_PTR(
+                "ca_certificate_chain_path", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                config_module_network_tls_t, ca_certificate_chain_path, 0, CYAML_UNLIMITED),
         CYAML_FIELD_SEQUENCE(
                 "cipher_suites", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
                 config_module_network_tls_t, cipher_suites,

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <pthread.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/network/network_tls.h
+++ b/src/network/network_tls.h
@@ -29,6 +29,7 @@ int *network_tls_build_cipher_suites_from_names(
 network_tls_config_t *network_tls_config_init(
         char *certificate_path,
         char *private_key_path,
+        char *ca_certificate_path,
         config_module_network_tls_min_version_t tls_min_version,
         config_module_network_tls_max_version_t tls_max_version,
         int *cipher_suites,

--- a/src/network/network_tls_mbedtls.h
+++ b/src/network/network_tls_mbedtls.h
@@ -26,6 +26,7 @@ struct network_tls_config {
     mbedtls_ssl_config config;
     mbedtls_x509_crt server_cert;
     mbedtls_pk_context server_key;
+    mbedtls_x509_crt server_ca_cert_chain;
     int cipher_suites[];
 };
 

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -166,7 +166,7 @@ network_channel_t* worker_network_iouring_op_network_accept_setup_new_channel(
                     listener_channel->wrapped_channel.address.str);
 
             worker_network_iouring_op_network_close(
-                    (network_channel_t *) new_channel,
+                    &new_channel->wrapped_channel,
                     true);
 
             return NULL;

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -20,7 +20,6 @@
 #include <mbedtls/gcm.h>
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/ssl.h>
-#include <mbedtls/ssl_internal.h>
 
 #include "misc.h"
 #include "exttypes.h"

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -105,6 +105,7 @@ worker_module_context_t *worker_module_contexts_initialize(
         network_tls_config_t *network_tls_config = network_tls_config_init(
                 config_module->network->tls->certificate_path,
                 config_module->network->tls->private_key_path,
+                config_module->network->tls->ca_certificate_chain_path,
                 config_module->network->tls->min_version,
                 config_module->network->tls->max_version,
                 cipher_suites,

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -18,15 +18,6 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include <mbedtls/aes.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/error.h>
-#include <mbedtls/gcm.h>
-#include <mbedtls/net_sockets.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/ssl_internal.h>
-
 #include "exttypes.h"
 #include "misc.h"
 #include "xalloc.h"

--- a/tests/unit_tests/network/test-network-tls.cpp
+++ b/tests/unit_tests/network/test-network-tls.cpp
@@ -402,6 +402,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                         network_tls_config = network_tls_config_init(
                                                 certificate_path,
                                                 private_key_path,
+                                                nullptr,
                                                 CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_ANY,
                                                 CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_ANY,
                                                 NULL,
@@ -426,6 +427,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                         network_tls_config = network_tls_config_init(
                                                 certificate_path,
                                                 private_key_path,
+                                                nullptr,
                                                 CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_TLS_1_2,
                                                 CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_TLS_1_2,
                                                 NULL,
@@ -450,6 +452,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                         network_tls_config = network_tls_config_init(
                                                 certificate_path,
                                                 private_key_path,
+                                                nullptr,
                                                 CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_ANY,
                                                 CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_TLS_1_2,
                                                 NULL,
@@ -490,6 +493,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                         network_tls_config = network_tls_config_init(
                                                 certificate_path,
                                                 private_key_path,
+                                                nullptr,
                                                 CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_ANY,
                                                 CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_TLS_1_2,
                                                 cipher_suites_ids,
@@ -516,6 +520,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                         network_tls_config = network_tls_config_init(
                                                 certificate_path,
                                                 private_key_path,
+                                                nullptr,
                                                 CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_ANY,
                                                 CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_ANY,
                                                 NULL,
@@ -540,6 +545,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                         network_tls_config = network_tls_config_init(
                                                 certificate_path,
                                                 private_key_path,
+                                                nullptr,
                                                 CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_ANY,
                                                 CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_ANY,
                                                 NULL,
@@ -578,6 +584,7 @@ TEST_CASE("network_tls.c", "[network][network_tls]") {
                                     network_tls_config = network_tls_config_init(
                                             certificate_path,
                                             private_key_path,
+                                            nullptr,
                                             CONFIG_MODULE_NETWORK_TLS_MIN_VERSION_ANY,
                                             CONFIG_MODULE_NETWORK_TLS_MAX_VERSION_ANY,
                                             NULL,


### PR DESCRIPTION
This PR changes on the CA certificate is loaded, instead of expecting it to be the second in the server certificate it adds a new field to the configuration file called `ca_certificate_chain_path` which can be used to load a chain of ca certificates.

This change is also required for another functionality which will be introduced afterward to enable or disable the client certificate verification.