### PR TITLE
Improve kTLS fail management

### DIFF
--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -325,7 +325,6 @@ bool network_channel_tls_setup_ktls(
     if (!network_io_common_tls_socket_set_ulp(
             network_channel->fd,
             "tls")) {
-        LOG_V(TAG, "Failed to setup kTLS, unable to set the ULP for the socket");
         return false;
     }
 

--- a/src/network/io/network_io_common.c
+++ b/src/network/io/network_io_common.c
@@ -24,13 +24,22 @@
 
 #define TAG "network_io_common"
 
+bool network_io_common_socket_try_set_option(
+        network_io_common_fd_t fd,
+        int level,
+        int option,
+        void* value,
+        socklen_t value_size) {
+    return unlikely(setsockopt(fd, level, option, value, value_size) < 0) ? false : true;
+}
+
 bool network_io_common_socket_set_option(
         network_io_common_fd_t fd,
         int level,
         int option,
         void* value,
         socklen_t value_size) {
-    if (setsockopt(fd, level, option, value, value_size) < 0) {
+    if (unlikely(!network_io_common_socket_try_set_option(fd, level, option, value, value_size))) {
         LOG_E(TAG, "Unable to set an option on the socket with fd <%d>", fd);
         LOG_E_OS_ERROR(TAG);
 

--- a/src/network/io/network_io_common.h
+++ b/src/network/io/network_io_common.h
@@ -33,53 +33,69 @@ bool network_io_common_socket_set_option(
         int option,
         void* value,
         socklen_t value_size);
+
 bool network_io_common_socket_set_reuse_address(
         network_io_common_fd_t fd,
         bool enable);
+
 bool network_io_common_socket_set_reuse_port(
         network_io_common_fd_t fd,
         bool enable);
+
 bool network_io_common_socket_attach_reuseport_cbpf(
         network_io_common_fd_t fd);
+
 bool network_io_common_socket_set_nodelay(
         network_io_common_fd_t fd,
         bool enable);
+
 bool network_io_common_socket_set_quickack(
         network_io_common_fd_t fd,
         bool enable);
+
 bool network_io_common_socket_set_linger(
         network_io_common_fd_t fd,
         bool enable,
         int seconds);
+
 bool network_io_common_socket_enable_keepalive(
         network_io_common_fd_t fd,
         bool enable);
+
 bool network_io_common_socket_set_keepalive_count(
         network_io_common_fd_t fd,
         uint32_t keepalive_count);
+
 bool network_io_common_socket_set_keepalive_idle(
         network_io_common_fd_t fd,
         uint32_t keepalive_idle);
+
 bool network_io_common_socket_set_keepalive_interval(
         network_io_common_fd_t fd,
         uint32_t keepalive_interval);
+
 bool network_io_common_socket_set_incoming_cpu(
         network_io_common_fd_t fd,
         int cpu);
+
 bool network_io_common_socket_set_receive_buffer(
         network_io_common_fd_t fd,
         int size);
+
 bool network_io_common_socket_set_send_buffer(
         network_io_common_fd_t fd,
         int size);
+
 bool network_io_common_socket_set_receive_timeout(
         network_io_common_fd_t fd,
         long seconds,
         long useconds);
+
 bool network_io_common_socket_set_send_timeout(
         network_io_common_fd_t fd,
         long seconds,
         long useconds);
+
 bool network_io_common_socket_set_ipv6_only(
         network_io_common_fd_t fd,
         bool enable);
@@ -88,9 +104,11 @@ bool network_io_common_socket_bind(
         network_io_common_fd_t fd,
         struct sockaddr *address,
         socklen_t address_size);
+
 bool network_io_common_socket_listen(
         network_io_common_fd_t fd,
         uint16_t backlog);
+
 bool network_io_common_socket_close(
         network_io_common_fd_t fd,
         bool shutdown_may_fail);
@@ -105,6 +123,7 @@ bool network_io_common_socket_setup_server(
 
 int network_io_common_socket_tcp4_new(
         int flags);
+
 int network_io_common_socket_tcp4_new_server(
         int flags,
         struct sockaddr_in *address,
@@ -114,6 +133,7 @@ int network_io_common_socket_tcp4_new_server(
 
 int network_io_common_socket_tcp6_new(
         int flags);
+
 int network_io_common_socket_tcp6_new_server(
         int flags,
         struct sockaddr_in6 *address,

--- a/src/network/io/network_io_common.h
+++ b/src/network/io/network_io_common.h
@@ -20,6 +20,13 @@ typedef bool (*network_io_common_parse_addresses_foreach_callback_t)(
         module_types_t protocol,
         void* user_data);
 
+bool network_io_common_socket_try_set_option(
+        network_io_common_fd_t fd,
+        int level,
+        int option,
+        void* value,
+        socklen_t value_size);
+
 bool network_io_common_socket_set_option(
         network_io_common_fd_t fd,
         int level,

--- a/src/network/io/network_io_common_tls.c
+++ b/src/network/io/network_io_common_tls.c
@@ -29,7 +29,7 @@
 bool network_io_common_tls_socket_set_ulp(
         network_io_common_fd_t fd,
         char *ulp) {
-    return network_io_common_socket_set_option(fd, SOL_TCP, TCP_ULP, ulp, strlen(ulp));
+    return network_io_common_socket_try_set_option(fd, SOL_TCP, TCP_ULP, ulp, strlen(ulp));
 }
 
 bool network_io_common_tls_socket_set_tls_rx(

--- a/src/network/network_tls.c
+++ b/src/network/network_tls.c
@@ -364,9 +364,8 @@ void network_tls_config_free(
     ffma_mem_free(network_tls_config);
 }
 
-network_op_result_t network_tls_close_internal(
-        network_channel_t *channel,
-        bool shutdown_may_fail) {
+void network_tls_close_internal(
+        network_channel_t *channel) {
     int32_t res;
     while((res = mbedtls_ssl_close_notify(channel->tls.context)) < 0) {
         if (res != MBEDTLS_ERR_SSL_WANT_READ && res != MBEDTLS_ERR_SSL_WANT_WRITE) {
@@ -382,8 +381,6 @@ network_op_result_t network_tls_close_internal(
                     channel->address.str);
         }
     }
-
-    return network_close_internal(channel, shutdown_may_fail);
 }
 
 network_op_result_t network_tls_receive_internal(

--- a/src/network/network_tls_mbedtls.h
+++ b/src/network/network_tls_mbedtls.h
@@ -59,9 +59,8 @@ network_op_result_t network_tls_send_direct_internal(
         size_t buffer_length,
         size_t *sent_length);
 
-network_op_result_t network_tls_close_internal(
-        network_channel_t *channel,
-        bool shutdown_may_fail);
+void network_tls_close_internal(
+        network_channel_t *channel);
 
 #ifdef __cplusplus
 }

--- a/src/program_startup_report.c
+++ b/src/program_startup_report.c
@@ -91,7 +91,7 @@ void program_startup_report_machine_tls() {
     if (!network_tls_is_ulp_tls_supported()) {
         LOG_I(
                 TAG,
-                "       Try to load the tls kernel module with \"modprobe tls\" and restart %s",
+                "       Try to load the tls kernel module with \"modprobe tls\", no need to restart %s",
                 CACHEGRAND_CMAKE_CONFIG_NAME);
     }
 }


### PR DESCRIPTION
This PR changes how failures in enabling kTLS are managed, now instead of refusing the connection it falls back to use the standard mbedtls.

As a kTLS error is not an hard error, switch to try set the socket options instead of expecting that the operation has to succeed. If it fails, it simply go ahead with the fallback to mbedtls.

As part of the changes, now the mbedtls session context is freed only when the connection is closed, this to have access to the peer certificate if sent by the client at any time during the life of the connection.