### PR TITLE
Fix ktls detection

### DIFF
--- a/src/fiber/fiber_scheduler.c
+++ b/src/fiber/fiber_scheduler.c
@@ -175,7 +175,7 @@ void fiber_scheduler_switch_to(
     fiber_scheduler_stack.index--;
 
     if (fiber->terminate) {
-        LOG_DI(TAG, "Fiber marked for termination, cleaning up");
+        LOG_DI("Fiber marked for termination, cleaning up");
         fiber_free(fiber);
     }
 }

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -329,22 +329,16 @@ bool network_channel_tls_setup_ktls_tx_rx(
 
 bool network_channel_tls_setup_ktls(
         network_channel_t *network_channel) {
-    if (!network_io_common_tls_socket_set_ulp(
-            network_channel->fd,
-            "tls")) {
+    if (!network_io_common_tls_socket_set_ulp_tls(network_channel->fd)) {
         return false;
     }
 
-    if (!network_channel_tls_setup_ktls_tx_rx(
-            network_channel,
-            0)) {
+    if (!network_channel_tls_setup_ktls_tx_rx(network_channel, 0)) {
         LOG_V(TAG, "Failed to setup kTLS, unable to setup the tx offloading");
         return false;
     }
 
-    if (!network_channel_tls_setup_ktls_tx_rx(
-            network_channel,
-            1)) {
+    if (!network_channel_tls_setup_ktls_tx_rx(network_channel, 1)) {
         LOG_V(TAG, "Failed to setup kTLS, unable to setup the rx offloading");
         return false;
     }

--- a/src/network/io/network_io_common_tls.c
+++ b/src/network/io/network_io_common_tls.c
@@ -26,6 +26,11 @@
 
 #define TAG "network_io_common_tls"
 
+bool network_io_common_tls_socket_set_ulp_tls(
+        network_io_common_fd_t fd) {
+    return network_io_common_tls_socket_set_ulp(fd, "tls");
+}
+
 bool network_io_common_tls_socket_set_ulp(
         network_io_common_fd_t fd,
         char *ulp) {

--- a/src/network/io/network_io_common_tls.h
+++ b/src/network/io/network_io_common_tls.h
@@ -22,6 +22,9 @@ union network_io_common_tls_crypto_info {
 #endif
 };
 
+bool network_io_common_tls_socket_set_ulp_tls(
+        network_io_common_fd_t fd);
+
 bool network_io_common_tls_socket_set_ulp(
         network_io_common_fd_t fd,
         char *ulp);

--- a/src/network/network_tls.c
+++ b/src/network/network_tls.c
@@ -26,6 +26,7 @@
 
 #include "misc.h"
 #include "exttypes.h"
+#include "random.h"
 #include "xalloc.h"
 #include "log/log.h"
 #include "spinlock.h"
@@ -47,17 +48,60 @@
 #define TAG "network_tls"
 
 bool network_tls_is_ulp_tls_supported_internal() {
-    char buffer[256] = { 0 };
-    if (simple_file_io_read(
-            NETWORK_TLS_PROC_SYS_NET_IPV4_TCP_AVAILABLE_ULP,
-            buffer,
-            sizeof(buffer))) {
-        if (strstr(buffer, "tls") != NULL) {
-            return true;
+    bool result = true;
+    struct sockaddr_in server_addr = {
+            .sin_family = AF_INET,
+            .sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+    };
+    struct sockaddr_in client_addr = {
+            .sin_family = AF_INET,
+            .sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+    };
+
+    // Create the sockets
+    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    int client_fd = socket(AF_INET, SOCK_STREAM, 0);
+
+    // Try to find a free port for the server to bind to and listen temporarily
+    int attempts = 0;
+    int max_attempts = 100;
+    do {
+        // Generate a random port between 10000 and UINT16_MAX
+        server_addr.sin_port = htons((random_generate() % (UINT16_MAX - 10000)) + 10000);
+    } while(bind(server_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) != 0 &&
+            attempts++ < max_attempts);
+
+    // If we have reached the max attempts, we have failed
+    if (attempts >= max_attempts) {
+        result = false;
+    }
+
+    // Listen on the socket but do not start any accept, rely on backlog set to 1 to let the connection go through
+    // unaccepted
+    if (result) {
+        if (listen(server_fd, 1) != 0) {
+            result = false;
         }
     }
 
-    return false;
+    // Connect to the server
+    client_addr.sin_port = server_addr.sin_port;
+    if (result) {
+        if (connect(client_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)) != 0) {
+            result = false;
+        }
+    }
+
+    // Try to enable the ULP TLS on the client fd
+    if (result) {
+        result = network_io_common_tls_socket_set_ulp(client_fd, "tls");
+    }
+
+    // Close the sockets
+    close(server_fd);
+    close(client_fd);
+
+    return result;
 }
 
 bool network_tls_does_ulp_tls_support_mbedtls_cipher_suite(

--- a/src/network/network_tls.c
+++ b/src/network/network_tls.c
@@ -94,7 +94,7 @@ bool network_tls_is_ulp_tls_supported_internal() {
 
     // Try to enable the ULP TLS on the client fd
     if (result) {
-        result = network_io_common_tls_socket_set_ulp(client_fd, "tls");
+        result = network_io_common_tls_socket_set_ulp_tls(client_fd);
     }
 
     // Close the sockets

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -107,11 +107,11 @@ void storage_db_snapshot_completed(
 
     // Report the snapshot status
     if (status == STORAGE_DB_SNAPSHOT_STATUS_FAILED_DURING_PREPARATION) {
-        LOG_E(TAG, "Snapshot failed, next run in <%s>", next_shapshot_run_buffer);
+        LOG_E(TAG, "Snapshot failed during preparation");
     } else if (status == STORAGE_DB_SNAPSHOT_STATUS_FAILED) {
-        LOG_E(TAG, "Snapshot failed after <%s>, next run in <%s>", snapshot_duration_buffer, next_shapshot_run_buffer);
+        LOG_E(TAG, "Snapshot failed after <%s>", snapshot_duration_buffer);
     } else if (status == STORAGE_DB_SNAPSHOT_STATUS_COMPLETED) {
-        LOG_I(TAG, "Snapshot completed in <%s>, next run in <%s>", snapshot_duration_buffer, next_shapshot_run_buffer);
+        LOG_I(TAG, "Snapshot completed in <%s>", snapshot_duration_buffer);
     }
 }
 

--- a/tests/unit_tests/network/io/test-network-io-common-tls.cpp
+++ b/tests/unit_tests/network/io/test-network-io-common-tls.cpp
@@ -76,6 +76,16 @@ TEST_CASE("network/io/network_io_common_tls.c", "[network][network_io][network_i
         }
     }
 
+    SECTION("network_io_common_tls_socket_set_ulp_tls") {
+        if (network_tls_is_ulp_tls_supported()) {
+            SECTION("valid option") {
+                REQUIRE(network_io_common_tls_socket_set_ulp_tls(server_fd));
+            }
+        } else {
+            WARN("Can't test kTLS, tls ulp not available, try to load the tls kernel module");
+        }
+    }
+
     SECTION("network_io_common_tls_socket_set_tls_rx") {
         if (network_tls_is_ulp_tls_supported()) {
             REQUIRE(network_io_common_tls_socket_set_ulp(server_fd, "tls"));

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -4,13 +4,6 @@
 # This software may be modified and distributed under the terms
 # of the BSD license. See the LICENSE file for details.
 
-# Build commands
-#docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-#docker buildx create --name cachegrand-builder --platform linux/amd64 --use
-#docker buildx create --name cachegrand-builder --append --platform linux/arm64,linux/arm/v8 ssh://cg-server-arm64-01
-#docker buildx build --pull --push --platform linux/amd64,linux/arm64/v8 --tag cachegrand/cachegrand-server:latest --tag cachegrand/cachegrand-server:v0.2.0 .
-#docker buildx rm --name cachegrand-builder
-
 FROM ubuntu:22.04 AS builder
 
 # General dpkg and packages settings

--- a/tools/docker/release/Dockerfile
+++ b/tools/docker/release/Dockerfile
@@ -90,6 +90,7 @@ RUN \
         | sed -e 's/\#\(\s\+tls\:\)/\1/' \
         | sed -e 's/\#\(\s\+certificate_path\:\)/\1/' \
         | sed -e 's/\#\(\s\+private_key_path\:\)/\1/' \
+        | sed -e 's/\#\(\s\+ca_certificate_chain_path\:\)/\1/' \
         | sed -e "/^\s\- type\: file$/ s|^|//|; /^\s*\- type\: file/, /);$/ s|^|#|" \
         | sed -e 's/^           tls: true/          tls: true/' \
         | sed -e 's/^           tls: false/          tls: false/' \

--- a/tools/docker/release/build.sh
+++ b/tools/docker/release/build.sh
@@ -2,7 +2,8 @@
 
 # Requires docker buildx plugin to run
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-docker buildx rm cachegrand-server
-docker buildx create --use --name cachegrand-server --bootstrap
-docker buildx build --pull --push --platform linux/amd64,linux/arm64/v8 --tag cachegrand/cachegrand-server:latest --tag cachegrand/cachegrand-server:v0.1.5 .
-docker buildx rm cachegrand-server
+docker buildx create --name cachegrand-builder --platform linux/amd64 --use
+docker buildx create --name cachegrand-builder --append --platform linux/arm64,linux/arm/v8 ssh://cg-server-arm64-01
+docker buildx build --no-cache --pull --platform linux/amd64,linux/arm64/v8 --tag cachegrand/cachegrand-server:latest --tag cachegrand/cachegrand-server:v0.2.1 .
+docker buildx build --push --platform linux/amd64,linux/arm64/v8 --tag cachegrand/cachegrand-server:latest --tag cachegrand/cachegrand-server:v0.2.1 .
+docker buildx rm --name cachegrand-builder


### PR DESCRIPTION
Currently cachegrand relies on reading the /proc file to check if the ULP TLS is available for kTLS but inside a docker container (or a container in general) this is not possible as often the /proc filesystem is not exposed at all.

To avoid this issue this PR changes the mechanism to check out if kTLS is available and tries to setup and establish a connection on a random port (trying multiple times to find one free).

Now kTLS is correctly detected inside a docker container (or a container in general) correctly if kTLS is enabled in the host machine.

Although unrelated, the PR also changes how the docker image is built to uncomment ca_certificate_chain_path to load the ca certificate as well.