### PR TITLE
Bug fix hashtable spsc upsize fn name

### DIFF
--- a/benches/bench-hashtable-spsc-op-get.cpp
+++ b/benches/bench-hashtable-spsc-op-get.cpp
@@ -360,13 +360,24 @@ public:
             strcpy(key_dup, _keys[index]);
             key_dup[strlen(_keys[index])] = '\0';
 
-            if (!hashtable_spsc_op_try_set_cs(this->_hashtable, key_dup, strlen(_keys[index]), _keys[index])) {
+            if (!hashtable_spsc_op_try_set_cs(
+                    this->_hashtable,
+                    key_dup,
+                    strlen(_keys[index]),
+                    _keys[index])) {
                 // Move back the pointer of the keys array
                 index--;
 
                 // Resize the hashtable
                 uint32_t current_size = this->_hashtable->buckets_count_real;
                 this->_hashtable = hashtable_spsc_upsize(this->_hashtable);
+                if (!hashtable_spsc_op_try_set_cs(
+                        this->_hashtable,
+                        key_dup,
+                        strlen(_keys[index]),
+                        _keys[index])) {
+                    state.SkipWithError("Failed to set key in hashtable");
+                }
             }
         }
 
@@ -416,6 +427,13 @@ public:
                 // Resize the hashtable
                 uint32_t current_size = this->_hashtable->buckets_count_real;
                 this->_hashtable = hashtable_spsc_upsize(this->_hashtable);
+                if (!hashtable_spsc_op_try_set_by_hash_and_key_uint32(
+                        this->_hashtable,
+                        *(uint32_t*)_keys[index],
+                        *(uint32_t*)_keys[index],
+                        _keys[index])) {
+                    state.SkipWithError("Failed to set key in hashtable");
+                }
             }
         }
 

--- a/benches/bench-hashtable-spsc-op-get.cpp
+++ b/benches/bench-hashtable-spsc-op-get.cpp
@@ -366,7 +366,7 @@ public:
 
                 // Resize the hashtable
                 uint32_t current_size = this->_hashtable->buckets_count_real;
-                this->_hashtable = hashtable_spsc_uspize(this->_hashtable);
+                this->_hashtable = hashtable_spsc_upsize(this->_hashtable);
             }
         }
 
@@ -415,7 +415,7 @@ public:
 
                 // Resize the hashtable
                 uint32_t current_size = this->_hashtable->buckets_count_real;
-                this->_hashtable = hashtable_spsc_uspize(this->_hashtable);
+                this->_hashtable = hashtable_spsc_upsize(this->_hashtable);
             }
         }
 

--- a/src/data_structures/hashtable/spsc/hashtable_spsc.c
+++ b/src/data_structures/hashtable/spsc/hashtable_spsc.c
@@ -73,7 +73,7 @@ void hashtable_spsc_free(
     xalloc_free(hashtable);
 }
 
-hashtable_spsc_t* hashtable_spsc_uspize(
+hashtable_spsc_t* hashtable_spsc_upsize(
         hashtable_spsc_t *hashtable_current) {
     // Creates a new hashtable with the same parameters as the original one but twice the buckets
     hashtable_spsc_t *hashtable_uspized = hashtable_spsc_new(

--- a/src/data_structures/hashtable/spsc/hashtable_spsc.h
+++ b/src/data_structures/hashtable/spsc/hashtable_spsc.h
@@ -279,7 +279,7 @@ hashtable_spsc_t *hashtable_spsc_new(
 void hashtable_spsc_free(
         hashtable_spsc_t *hashtable);
 
-hashtable_spsc_t* hashtable_spsc_uspize(
+hashtable_spsc_t* hashtable_spsc_upsize(
         hashtable_spsc_t *hashtable_current);
 
 bool hashtable_spsc_op_try_set_ci(


### PR DESCRIPTION
This PR fixes a typo in the name of the function hashtable_spsc_upsize and a bug in the benchmark were some entries might be skipped because of the upsize