### PR TITLE
Fix Redis SELECT command max db check

### DIFF
--- a/src/module/redis/command/module_redis_command_select.c
+++ b/src/module/redis/command/module_redis_command_select.c
@@ -42,7 +42,7 @@
 MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(select) {
     module_redis_command_select_context_t *context = connection_context->command.context;
 
-    if (context->index.value > connection_context->db->config->max_user_databases) {
+    if (context->index.value >= connection_context->db->config->max_user_databases) {
         return module_redis_connection_error_message_printf_noncritical(
                 connection_context,
                 "ERR invalid DB index");

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-select.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-select.cpp
@@ -48,9 +48,15 @@ TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - SELECT", "[r
                 "+OK\r\n"));
     }
 
-    SECTION("Select DB 17 - not allowed") {
+    SECTION("Select DB 15 - allowed") {
         REQUIRE(send_recv_resp_command_text_and_validate_recv(
-                std::vector<std::string>{"SELECT", "17"},
+                std::vector<std::string>{"SELECT", "15"},
+                "+OK\r\n"));
+    }
+
+    SECTION("Select DB 16 - not allowed") {
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                std::vector<std::string>{"SELECT", "16"},
                 "-ERR invalid DB index\r\n"));
     }
 


### PR DESCRIPTION
This PR fixes the maximum user database number allowed in the Redis SELECT command.