### PR TITLE
Fix scaffolding support for commands with dots

### DIFF
--- a/tools/redis-commands-scaffolding-generator/generate-commands-scaffolding.py
+++ b/tools/redis-commands-scaffolding-generator/generate-commands-scaffolding.py
@@ -378,7 +378,7 @@ class Program:
             for command_info in commands_info:
                 fp.writelines([
                     "    MODULE_REDIS_COMMAND_{command_string},\n".format(
-                        command_string=command_info["command_string"]),
+                        command_string=command_info["command_string"].replace(".", "_")),
                 ])
 
             fp.writelines([


### PR DESCRIPTION
This PR fixes the scaffolding generation for the Redis commands that contain dots.