### PR TITLE
Bug intrinsic max freq wrong registry

### DIFF
--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -109,7 +109,7 @@ uint64_t intrinsics_frequency_max_calculate() {
     return return_value;
 }
 
-bool intrinsics_frequency_max_estimated() {
+bool intrinsics_frequency_max_is_estimated() {
 #if defined(__x86_64__)
     return intrinsics_frequency_calculate_max_x64_cpuid_level_16h() > 0 ? false : true;
 #elif defined(__aarch64__)

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -38,19 +38,20 @@ uint64_t intrinsics_frequency_max_calculate_aarch64_cntfrq_el0() {
 
 #if defined(__x86_64__)
 uint64_t intrinsics_frequency_calculate_max_x64_cpuid_level_16h() {
-    uint32_t eax, ebx, ecx, edx;
+    uint32_t base_mhz, max_mhz, bus_mhz, edx;
+
     if (__get_cpuid_max(0, NULL) < 0x16) {
         return 0;
     }
 
-    __cpuid_count(0x16, 0, eax, ebx, ecx, edx);
+    __cpuid_count(0x16, 0, base_mhz, max_mhz, bus_mhz, edx);
 
-    if (eax == 0) {
+    if (base_mhz == 0) {
         return 0;
     }
 
-    uint64_t cycles = ebx;
-    cycles *= 1000;
+    uint64_t cycles = base_mhz;
+    cycles *= 1000000;
 
     return cycles;
 }

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -19,7 +19,7 @@ uint64_t intrinsics_frequency_max_calculate_simple();
 
 uint64_t intrinsics_frequency_max_calculate();
 
-bool intrinsics_frequency_max_estimated();
+bool intrinsics_frequency_max_is_estimated();
 
 static inline uint64_t intrinsics_frequency_max() {
     if (unlikely(intrinsics_frequency_max_internal == 0)) {

--- a/src/program_startup_report.c
+++ b/src/program_startup_report.c
@@ -104,7 +104,7 @@ void program_startup_report_machine_clock() {
     LOG_I(
             TAG,
             "> Monotonic clock source <Hardware (TSC)> (%scpu cycles per second <%0.02lf GHz>), resolution <%ld ms>",
-            intrinsics_frequency_max_estimated() ? "estimated " : "",
+            intrinsics_frequency_max_is_estimated() ? "estimated " : "",
             (double)intrinsics_frequency_max() / 1000000000.0f,
             clock_monotonic_coarse_get_resolution_ms());
 }


### PR DESCRIPTION
This PR fixes the intrinsics max frequency calculation, on modern Intel CPUs cachegrand tries to utilize the CPUID level 0x16 to read the base frequency, expressed in MHz, instead of trying to calculate it.

This issue wasn't affecting AMD CPUs as they don't expose that CPUID level.

This bug was EXTREMELY serious as was messing up the internal clock handling of cachegrand on, basically, all the recent Intel CPUs causing random crashes and malfuctions, although there are tests for this as they run on the Github runners which emulate the TSC and the CPUIDs the issue was never caught.