### PR TITLE
Fix prometheus module crash improve stats

### DIFF
--- a/src/module/prometheus/module_prometheus.h
+++ b/src/module/prometheus/module_prometheus.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#define MODULE_PROMETHEUS_HTTP_HEADERS_SIZE_INCREASE 5
+#define MODULE_PROMETHEUS_HTTP_HEADERS_SIZE_INCREASE 2
 #define MODULE_PROMETHEUS_HTTP_MAX_URL_LENGTH 256
 #define MODULE_PROMETHEUS_HTTP_MAX_HEADER_NAME_LENGTH 256
 #define MODULE_PROMETHEUS_HTTP_MAX_HEADER_VALUE_LENGTH (8 * 1024)
@@ -47,7 +47,7 @@ struct module_prometheus_client {
 };
 
 void module_prometheus_connection_accept(
-        network_channel_t *channel);
+        network_channel_t *network_channel);
 
 #ifdef __cplusplus
 }

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -128,10 +128,8 @@ network_op_result_t network_receive(
 
         // Update stats
         worker_stats_t *stats = worker_stats_get_internal_current();
-        stats->network.per_minute.received_packets++;
-        stats->network.total.received_packets++;
-        stats->network.per_minute.received_data += received_length;
-        stats->network.total.received_data += received_length;
+        stats->network.received_packets++;
+        stats->network.received_data += received_length;
 
         LOG_DI(
                 "[FD:%5d][RECV] Received <%lu> bytes from client <%s>",
@@ -287,10 +285,8 @@ network_op_result_t network_send_direct_wrapper(
 
     if (likely(res == NETWORK_OP_RESULT_OK)) {
         worker_stats_t *stats = worker_stats_get_internal_current();
-        stats->network.per_minute.sent_packets++;
-        stats->network.total.sent_packets++;
-        stats->network.per_minute.sent_data += sent_length;
-        stats->network.total.sent_data += sent_length;
+        stats->network.sent_packets++;
+        stats->network.sent_data += sent_length;
 
         LOG_DI(
                 "[FD:%5d][SEND] Sent <%lu> bytes to client <%s>",

--- a/src/storage/storage.c
+++ b/src/storage/storage.c
@@ -35,7 +35,7 @@ storage_channel_t* storage_open(
 
     if (likely(res)) {
         worker_stats_t *stats = worker_stats_get_internal_current();
-        stats->storage.total.open_files++;
+        stats->storage.open_files++;
     } else {
         int error_number = fiber_scheduler_get_error();
         LOG_E(
@@ -57,7 +57,7 @@ storage_channel_t* storage_open_fd(
 
     if (likely(res)) {
         worker_stats_t *stats = worker_stats_get_internal_current();
-        stats->storage.total.open_files++;
+        stats->storage.open_files++;
     } else {
         int error_number = fiber_scheduler_get_error();
         LOG_E(
@@ -113,10 +113,8 @@ bool storage_readv(
             channel->path);
 
     worker_stats_t *stats = worker_stats_get_internal_current();
-    stats->storage.per_minute.read_data += read_len;
-    stats->storage.total.read_data += read_len;
-    stats->storage.per_minute.read_iops++;
-    stats->storage.total.read_iops++;
+    stats->storage.read_data += read_len;
+    stats->storage.read_iops++;
 
     return true;
 }
@@ -178,10 +176,8 @@ bool storage_writev(
             channel->path);
 
     worker_stats_t *stats = worker_stats_get_internal_current();
-    stats->storage.per_minute.written_data += write_len;
-    stats->storage.total.written_data += write_len;
-    stats->storage.per_minute.write_iops++;
-    stats->storage.total.write_iops++;
+    stats->storage.written_data += write_len;
+    stats->storage.write_iops++;
 
     return true;
 }
@@ -248,7 +244,7 @@ bool storage_close(
 
     if (likely(res)) {
         worker_stats_t *stats = worker_stats_get_internal_current();
-        stats->storage.total.open_files--;
+        stats->storage.open_files--;
     } else {
         int error_number = fiber_scheduler_get_error();
         LOG_E(

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -85,7 +85,7 @@ network_channel_t* worker_network_iouring_op_network_accept_setup_new_channel(
             new_channel->wrapped_channel.address.str,
             sizeof(new_channel->wrapped_channel.address.str));
 
-    if (unlikely(stats->network.total.active_connections >= worker_context->config->network->max_clients)) {
+    if (unlikely(stats->network.active_connections >= worker_context->config->network->max_clients)) {
         LOG_V(
                 TAG,
                 "[FD:%5d][ACCEPT] Maximum active connections established, can't accept any new connection",

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -286,17 +286,15 @@ void worker_network_new_client_fiber_entrypoint(
     network_channel_t *new_channel = user_data;
     bool tls_enabled = new_channel->tls.enabled;
 
-    stats->network.total.active_connections++;
+    stats->network.active_connections++;
     if (tls_enabled) {
-        stats->network.total.active_tls_connections++;
+        stats->network.active_tls_connections++;
     }
 
-    stats->network.total.accepted_connections++;
-    stats->network.per_minute.accepted_connections++;
+    stats->network.accepted_connections++;
 
     if (tls_enabled) {
-        stats->network.total.accepted_tls_connections++;
-        stats->network.per_minute.accepted_tls_connections++;
+        stats->network.accepted_tls_connections++;
     }
 
     // Handover the new connection to the module
@@ -309,9 +307,9 @@ void worker_network_new_client_fiber_entrypoint(
     }
 
     // Updates the amount of active connections
-    stats->network.total.active_connections--;
+    stats->network.active_connections--;
     if (tls_enabled) {
-        stats->network.total.active_tls_connections--;
+        stats->network.active_tls_connections--;
     }
 
     fiber_scheduler_terminate_current_fiber();

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -541,13 +541,9 @@ void* worker_thread_func(
 
         // Checks if the stats should be published with an interval of 1 second
         if (worker_stats_should_publish_totals_after_interval(&worker_context->stats.shared)) {
-            // Check if the per_minute stats should be published too
-            bool only_total = !worker_stats_should_publish_per_minute_after_interval(
-                    &worker_context->stats.shared);
             worker_stats_publish(
                     &worker_context->stats.internal,
-                    &worker_context->stats.shared,
-                    only_total);
+                    &worker_context->stats.shared);
         }
     } while(!can_terminate_loop);
 

--- a/src/worker/worker_stats.h
+++ b/src/worker/worker_stats.h
@@ -5,60 +5,37 @@
 extern "C" {
 #endif
 
-#define WORKER_PUBLISH_FULL_STATS_INTERVAL_SEC 60
+#define WORKER_PUBLISH_FULL_STATS_INTERVAL_SEC 1
 
 typedef struct worker_stats worker_stats_t;
 struct worker_stats {
     struct {
-        struct {
-            uint64_t received_packets;
-            uint64_t received_data;
-            uint64_t sent_packets;
-            uint64_t sent_data;
-            uint64_t accepted_connections;
-            uint16_t active_connections;
-            uint64_t accepted_tls_connections;
-            uint16_t active_tls_connections;
-        } total;
-        struct {
-            uint64_t received_packets;
-            uint64_t received_data;
-            uint64_t sent_packets;
-            uint64_t sent_data;
-            uint64_t accepted_connections;
-            uint64_t accepted_tls_connections;
-        } per_minute;
+        uint64_t received_packets;
+        uint64_t received_data;
+        uint64_t sent_packets;
+        uint64_t sent_data;
+        uint64_t accepted_connections;
+        uint16_t active_connections;
+        uint64_t accepted_tls_connections;
+        uint16_t active_tls_connections;
     } network;
     struct {
-        struct {
-            uint64_t written_data;
-            uint64_t write_iops;
-            uint64_t read_data;
-            uint64_t read_iops;
-            uint16_t open_files;
-        } total;
-        struct {
-            uint64_t written_data;
-            uint64_t write_iops;
-            uint64_t read_data;
-            uint64_t read_iops;
-        } per_minute;
+        uint64_t written_data;
+        uint64_t write_iops;
+        uint64_t read_data;
+        uint64_t read_iops;
+        uint16_t open_files;
     } storage;
     struct timespec started_on_timestamp;
-    struct timespec total_last_update_timestamp;
-    struct timespec per_minute_last_update_timestamp;
+    struct timespec last_update_timestamp;
 };
 typedef _Volatile(worker_stats_t) worker_stats_volatile_t;
 
 void worker_stats_publish(
         worker_stats_t* worker_stats_new,
-        worker_stats_volatile_t* worker_stats_public,
-        bool only_total);
-
-bool worker_stats_should_publish_totals_after_interval(
         worker_stats_volatile_t* worker_stats_public);
 
-bool worker_stats_should_publish_per_minute_after_interval(
+bool worker_stats_should_publish_totals_after_interval(
         worker_stats_volatile_t* worker_stats_public);
 
 worker_stats_t *worker_stats_get_internal_current();

--- a/tests/unit_tests/storage/test-storage.cpp
+++ b/tests/unit_tests/storage/test-storage.cpp
@@ -9,7 +9,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstring>
 #include <unistd.h>
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
@@ -19,18 +18,13 @@
 #include "misc.h"
 #include "exttypes.h"
 #include "xalloc.h"
-#include "spinlock.h"
-#include "transaction.h"
-#include "transaction_spinlock.h"
 #include "fiber/fiber.h"
 #include "fiber/fiber_scheduler.h"
-#include "clock.h"
 #include "config.h"
-#include "data_structures/hashtable/mcmp/hashtable.h"
 #include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/queue_mpmc/queue_mpmc.h"
 #include "worker/worker_stats.h"
 #include "worker/worker_context.h"
-#include "worker/worker.h"
 #include "worker/storage/worker_storage_posix_op.h"
 #include "memory_allocator/ffma.h"
 
@@ -39,7 +33,7 @@
 extern thread_local fiber_scheduler_stack_t fiber_scheduler_stack;
 
 TEST_CASE("storage/storage.c", "[storage]") {
-    char *fixture_temp_path_copy = nullptr;
+    char *fixture_temp_path_copy;
     storage_channel_t *storage_channel = nullptr;
 
     char fiber_name[] = "test-fiber";
@@ -81,7 +75,7 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(strncmp(storage_channel->path, fixture_temp_path, strlen(fixture_temp_path)) == 0);
             REQUIRE(strlen(fixture_temp_path) == storage_channel->path_len);
 
-            REQUIRE(worker_context.stats.internal.storage.total.open_files == 1);
+            REQUIRE(worker_context.stats.internal.storage.open_files == 1);
         }
 
         SECTION("open a non-existing file creating it") {
@@ -99,7 +93,7 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(strncmp(storage_channel->path, fixture_temp_path, strlen(fixture_temp_path)) == 0);
             REQUIRE(strlen(fixture_temp_path) == storage_channel->path_len);
 
-            REQUIRE(worker_context.stats.internal.storage.total.open_files == 1);
+            REQUIRE(worker_context.stats.internal.storage.open_files == 1);
         }
 
         SECTION("fail to open an non-existing file without create option") {
@@ -115,7 +109,7 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(fiber.error_number == ENOENT);
             REQUIRE(storage_channel == nullptr);
 
-            REQUIRE(worker_context.stats.internal.storage.total.open_files == 0);
+            REQUIRE(worker_context.stats.internal.storage.open_files == 0);
         }
     }
 
@@ -135,10 +129,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(storage_readv(storage_channel, iovec, 1, iovec[0].iov_len, 0));
             REQUIRE(fiber.error_number == 0);
             REQUIRE(strncmp(buffer_write, buffer_read1, strlen(buffer_write)) == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_data == iovec[0].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.total.read_data == iovec[0].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_iops == 1);
-            REQUIRE(worker_context.stats.internal.storage.total.read_iops == 1);
+            REQUIRE(worker_context.stats.internal.storage.read_data == iovec[0].iov_len);
+            REQUIRE(worker_context.stats.internal.storage.read_iops == 1);
         }
 
         SECTION("read n. 2 iovec") {
@@ -160,10 +152,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(fiber.error_number == 0);
             REQUIRE(strncmp(buffer_write, buffer_read1, strlen(buffer_write)) == 0);
             REQUIRE(strncmp(buffer_write, buffer_read2, strlen(buffer_write)) == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_data == iovec[0].iov_len + iovec[1].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.total.read_data == iovec[0].iov_len + iovec[1].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_iops == 1);
-            REQUIRE(worker_context.stats.internal.storage.total.read_iops == 1);
+            REQUIRE(worker_context.stats.internal.storage.read_data == iovec[0].iov_len + iovec[1].iov_len);
+            REQUIRE(worker_context.stats.internal.storage.read_iops == 1);
         }
 
         SECTION("invalid fd") {
@@ -177,10 +167,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
 
             REQUIRE(storage_readv(storage_channel, iovec, 1, iovec[0].iov_len, 0) == false);
             REQUIRE(fiber.error_number == EBADF);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.read_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_iops == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.read_iops == 0);
+            REQUIRE(worker_context.stats.internal.storage.read_data == 0);
+            REQUIRE(worker_context.stats.internal.storage.read_iops == 0);
 
             storage_channel = nullptr;
         }
@@ -199,10 +187,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(storage_read(storage_channel, buffer_read1, strlen(buffer_write), 0));
             REQUIRE(fiber.error_number == 0);
             REQUIRE(strncmp(buffer_write, buffer_read1, strlen(buffer_write)) == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_data == strlen(buffer_write));
-            REQUIRE(worker_context.stats.internal.storage.total.read_data == strlen(buffer_write));
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_iops == 1);
-            REQUIRE(worker_context.stats.internal.storage.total.read_iops == 1);
+            REQUIRE(worker_context.stats.internal.storage.read_data == strlen(buffer_write));
+            REQUIRE(worker_context.stats.internal.storage.read_iops == 1);
         }
 
         SECTION("invalid fd") {
@@ -213,10 +199,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
 
             REQUIRE(storage_read(storage_channel, buffer_read1, strlen(buffer_write), 0) == false);
             REQUIRE(fiber.error_number == EBADF);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.read_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.read_iops == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.read_iops == 0);
+            REQUIRE(worker_context.stats.internal.storage.read_data == 0);
+            REQUIRE(worker_context.stats.internal.storage.read_iops == 0);
 
             storage_channel = nullptr;
         }
@@ -238,10 +222,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(pread(fd, buffer_read1, strlen(buffer_write), 0) == strlen(buffer_write));
             REQUIRE(strncmp(buffer_write, buffer_read1, strlen(buffer_write)) == 0);
             REQUIRE(close(fd) == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.written_data == iovec[0].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.total.written_data == iovec[0].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.write_iops == 1);
-            REQUIRE(worker_context.stats.internal.storage.total.write_iops == 1);
+            REQUIRE(worker_context.stats.internal.storage.written_data == iovec[0].iov_len);
+            REQUIRE(worker_context.stats.internal.storage.write_iops == 1);
         }
 
         SECTION("write n. 2 iovec") {
@@ -263,10 +245,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(strncmp(buffer_write, buffer_read1, strlen(buffer_write)) == 0);
             REQUIRE(strncmp(buffer_write, buffer_read2, strlen(buffer_write)) == 0);
             REQUIRE(close(fd) == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.written_data == iovec[0].iov_len + iovec[1].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.total.written_data == iovec[0].iov_len + iovec[1].iov_len);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.write_iops == 1);
-            REQUIRE(worker_context.stats.internal.storage.total.write_iops == 1);
+            REQUIRE(worker_context.stats.internal.storage.written_data == iovec[0].iov_len + iovec[1].iov_len);
+            REQUIRE(worker_context.stats.internal.storage.write_iops == 1);
         }
 
         SECTION("invalid fd") {
@@ -280,10 +260,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
 
             REQUIRE(storage_writev(storage_channel, iovec, 1, iovec[0].iov_len, 0) == false);
             REQUIRE(fiber.error_number == EBADF);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.written_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.written_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.write_iops == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.write_iops == 0);
+            REQUIRE(worker_context.stats.internal.storage.written_data == 0);
+            REQUIRE(worker_context.stats.internal.storage.write_iops == 0);
 
             storage_channel = nullptr;
         }
@@ -302,10 +280,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(pread(fd, buffer_read1, strlen(buffer_write), 0) == strlen(buffer_write));
             REQUIRE(strncmp(buffer_write, buffer_read1, strlen(buffer_write)) == 0);
             REQUIRE(close(fd) == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.written_data == strlen(buffer_write));
-            REQUIRE(worker_context.stats.internal.storage.total.written_data == strlen(buffer_write));
-            REQUIRE(worker_context.stats.internal.storage.per_minute.write_iops == 1);
-            REQUIRE(worker_context.stats.internal.storage.total.write_iops == 1);
+            REQUIRE(worker_context.stats.internal.storage.written_data == strlen(buffer_write));
+            REQUIRE(worker_context.stats.internal.storage.write_iops == 1);
         }
 
         SECTION("invalid fd") {
@@ -316,10 +292,8 @@ TEST_CASE("storage/storage.c", "[storage]") {
 
             REQUIRE(storage_write(storage_channel, buffer_write, strlen(buffer_write), 0) == false);
             REQUIRE(fiber.error_number == EBADF);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.written_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.written_data == 0);
-            REQUIRE(worker_context.stats.internal.storage.per_minute.write_iops == 0);
-            REQUIRE(worker_context.stats.internal.storage.total.write_iops == 0);
+            REQUIRE(worker_context.stats.internal.storage.written_data == 0);
+            REQUIRE(worker_context.stats.internal.storage.write_iops == 0);
 
             storage_channel = nullptr;
         }
@@ -397,7 +371,7 @@ TEST_CASE("storage/storage.c", "[storage]") {
             REQUIRE(storage_close(storage_channel));
             REQUIRE(fiber.error_number == 0);
 
-            REQUIRE(worker_context.stats.internal.storage.total.open_files == 0);
+            REQUIRE(worker_context.stats.internal.storage.open_files == 0);
         }
 
         SECTION("invalid fd") {


### PR DESCRIPTION
This PR fixes a crash in the prometheus module triggered by having to send out too many stats (requiring a buffer bigger than 64kb) using transfer encoding chunked.

Also, drops the per-minute stats as these were not really useful, they can be generated by the system that ingests and processes the metrics.