### PR TITLE
Allow loading RDBs with multiple databases

### DIFF
--- a/src/module/redis/snapshot/module_redis_snapshot_load.c
+++ b/src/module/redis/snapshot/module_redis_snapshot_load.c
@@ -256,10 +256,6 @@ void module_redis_snapshot_load_process_opcode_aux(
 void module_redis_snapshot_load_process_opcode_db_number(
         storage_channel_t *channel) {
     uint32_t db_number = module_redis_snapshot_load_read_length_encoded_int(channel);
-    if (db_number != 0) {
-        FATAL(TAG, "Unsupported DB number: %d", db_number);
-    }
-
     current_database_number = db_number;
 
     LOG_V(TAG, "RDB DB number: %d", db_number);


### PR DESCRIPTION
This PR fixes a bug in the RDB loader to allow the loading of RDBs with multiple databases (db number greater than 0).