### PR TITLE
Reduce global db counters sums

### DIFF
--- a/src/log/log_debug.h
+++ b/src/log/log_debug.h
@@ -29,6 +29,7 @@ extern "C" {
         "hashtable_mcmp_op_set", \
         "hashtable_mcmp_op_delete", \
         "hashtable_mcmp_op_delete_by_index", \
+        "hashtable_mcmp_op_delete_by_index_all_databases", \
         "hashtable_mcmp_support_op_search_key_avx512f", \
         "hashtable_mcmp_support_op_search_key_or_create_new_avx512f", \
         "hashtable_mcmp_support_op_search_key_avx2", \

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1990,11 +1990,12 @@ uint8_t storage_db_keys_eviction_run_worker(
 
 #pragma unroll(STORAGE_DB_KEYS_EVICTION_EVICT_FIRST_N_KEYS)
     for (
-            uint8_t entry_index = 0;
-            entry_index < evict_first_n_keys &&
-                entry_index < STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH;
-            entry_index++) {
-        storage_db_keys_eviction_kv_list_entry_t *key_eviction_list_entry = &keys_evitction_candidates_list[entry_index];
+            uint8_t key_eviction_list_entry_index = 0;
+            key_eviction_list_entry_index < evict_first_n_keys &&
+                    key_eviction_list_entry_index < STORAGE_DB_KEYS_EVICTION_BITONIC_SORT_16_ELEMENTS_ARRAY_LENGTH;
+            key_eviction_list_entry_index++) {
+        storage_db_keys_eviction_kv_list_entry_t *key_eviction_list_entry =
+                &keys_evitction_candidates_list[key_eviction_list_entry_index];
 
         // Check if the key is set to UINT64_MAX and the value is set to UINT64_MAX, in which case there are no more
         // keys to evict in the list

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -519,7 +519,8 @@ bool storage_db_op_delete_by_index(
 
 bool storage_db_op_delete_by_index_all_databases(
         storage_db_t *db,
-        hashtable_bucket_index_t bucket_index);
+        hashtable_bucket_index_t bucket_index,
+        storage_db_entry_index_t **out_current_entry_index);
 
 char *storage_db_op_random_key(
         storage_db_t *db,

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -564,6 +564,7 @@ void storage_db_keys_eviction_bitonic_sort_16_elements(
 
 uint8_t storage_db_keys_eviction_run_worker(
         storage_db_t *db,
+        storage_db_counters_t *counters,
         bool only_ttl,
         config_database_keys_eviction_policy_t policy);
 

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -569,19 +569,18 @@ uint8_t storage_db_keys_eviction_run_worker(
         config_database_keys_eviction_policy_t policy);
 
 static inline bool storage_db_keys_eviction_should_run(
-        storage_db_t *db) {
-    uint64_t keys_count = storage_db_op_get_keys_count_global(db);
-    uint64_t data_size = storage_db_op_get_data_size_global(db);
+        storage_db_t *db,
+        storage_db_counters_t *counters) {
 
-    if (keys_count == 0) {
+    if (counters->keys_count == 0) {
         return false;
     }
 
-    if (db->limits.keys_count.soft_limit > 0 && keys_count > db->limits.keys_count.soft_limit) {
+    if (db->limits.keys_count.soft_limit > 0 && counters->keys_count > db->limits.keys_count.soft_limit) {
         return true;
     }
 
-    if (db->limits.data_size.soft_limit > 0 && data_size > db->limits.data_size.soft_limit) {
+    if (db->limits.data_size.soft_limit > 0 && counters->data_size > db->limits.data_size.soft_limit) {
         return true;
     }
 
@@ -589,25 +588,24 @@ static inline bool storage_db_keys_eviction_should_run(
 }
 
 static inline double storage_db_keys_eviction_calculate_close_to_hard_limit_percentage(
-        storage_db_t *db) {
+        storage_db_t *db,
+        storage_db_counters_t *counters) {
     double keys_count_close_to_hard_limit_percentage = 0;
     double data_size_close_to_hard_limit_percentage = 0;
-    uint64_t keys_count = storage_db_op_get_keys_count_global(db);
-    uint64_t data_size = storage_db_op_get_data_size_global(db);
 
     if (db->limits.keys_count.soft_limit == 0 && db->limits.data_size.soft_limit == 0) {
         return 0;
     }
 
-    if (db->limits.keys_count.soft_limit > 0 && keys_count > db->limits.keys_count.soft_limit) {
+    if (db->limits.keys_count.soft_limit > 0 && counters->keys_count > db->limits.keys_count.soft_limit) {
         keys_count_close_to_hard_limit_percentage =
-                (double)(keys_count - db->limits.keys_count.soft_limit) /
+                (double)(counters->keys_count - db->limits.keys_count.soft_limit) /
                 (double)(db->limits.keys_count.hard_limit - db->limits.keys_count.soft_limit);
     }
 
-    if (db->limits.data_size.soft_limit > 0 && data_size > db->limits.data_size.soft_limit) {
+    if (db->limits.data_size.soft_limit > 0 && counters->data_size > db->limits.data_size.soft_limit) {
         data_size_close_to_hard_limit_percentage =
-                (double)(data_size - db->limits.data_size.soft_limit) /
+                (double)(counters->data_size - db->limits.data_size.soft_limit) /
                 (double)(db->limits.data_size.hard_limit - db->limits.data_size.soft_limit);
     }
 

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -52,6 +52,7 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
             continue;
         }
 
+        storage_db_counters_t counters = { 0 };
         // Check if limits have been passed
         if (likely(!storage_db_keys_eviction_should_run(worker_context->db))) {
             continue;
@@ -89,6 +90,7 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
             // Run the eviction
             storage_db_keys_eviction_run_worker(
                     worker_context->db,
+                    &counters,
                     worker_context->config->database->keys_eviction->only_ttl,
                     worker_context->config->database->keys_eviction->policy);
 

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 1l
+#define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_WAIT_LOOP_MS 2l
 #define WORKER_FIBER_STORAGE_DB_KEYS_EVICTION_CLOSE_TO_HARD_LIMIT_PERCENTAGE_THRESHOLD 0.99
 
 void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(


### PR DESCRIPTION
The Keys Eviction fiber tries to free up resources if the amount of keys or data stored in cachegrand gets over the soft limits using an algorithm to pace the speed of the purge, depending how close it's to hit the hard limit.

To achieve that, the algorithm has to check constantly the amount of data stored in cachegrand and as consequence it uses a lot of CPU getting to almost 100%.

Although this happens **only** if there are no incoming connections there is still no reason for cachegrand to abuse the CPU usage in this way so optimize the code path to fetch the storage db counters only once instead of 6 times, on a machine with an elevated number of cores it's a very expensive operation so less is better.

To further reduce the CPU consumption, increase the sleep time of the fiber from 1ms to 2ms.

The PR includes some minor fixes and optimization to avoid an insane amount of logging in debug mode when the keys eviction kicks in and a mini optimization to accelerate the hot path when deleting a key when it exists as it's expected to be existing.

The PR is marked as a bug fix and not an enhancement as it's a bad practice to perform expensive operations so many times.