### PR TITLE
Fix multiple snapshots at shutdown

### DIFF
--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -505,7 +505,7 @@ void* worker_thread_func(
 
                 if (counter == 0) {
                     // All the fds have been closed
-                    if (worker_context->db->config->snapshot.snapshot_at_shutdown) {
+                    if (worker_context->worker_index == 0 && worker_context->db->config->snapshot.snapshot_at_shutdown) {
                         can_start_snapshot_at_shutdown = true;
                     } else {
                         can_terminate_loop = true;


### PR DESCRIPTION
When the workers start to shutdown they try to generate a snapshot if instructed to do so via the configuration but, because of a sync bug, they try, in parallel, to start a snapshot ending up having some workers triggering a second snapshot if plenty of them are running and the snapshot is generated quickly enough.

To avoid this issue, as the only snapshot format currently implemented doesn't support parallelism, allow only the first worker to wait for it meanwhile all the other ones can be terminated.