### PR TITLE
Feat avoid secondary lzf buffer

### DIFF
--- a/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.c
+++ b/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.c
@@ -431,7 +431,8 @@ module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_seriali
     }
 
     // Calculate the maximum required buffer space
-    size_t max_required_buffer_space = 1 + 5 + 5 + LZF_MAX_COMPRESSED_SIZE(string_length);
+    size_t header_length = 1 + 5 + 5;
+    size_t max_required_buffer_space = header_length + LZF_MAX_COMPRESSED_SIZE(string_length);
 
     // Check if the buffer is big enough
     if (*buffer_offset_out + max_required_buffer_space > buffer_size) {
@@ -439,12 +440,13 @@ module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_seriali
         goto end;
     }
 
+
     // Try to compress the data
     size_t compressed_string_length = lzf_compress(
             string,
             string_length,
-            buffer + *buffer_offset_out,
-            buffer_size - *buffer_offset_out);
+            buffer + *buffer_offset_out + header_length,
+            buffer_size - *buffer_offset_out - header_length);
 
     // Check if the compression was successful, if not, return an error
     if (compressed_string_length == 0) {

--- a/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.c
+++ b/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.c
@@ -31,9 +31,9 @@ size_t module_redis_snapshot_serialize_primitive_encode_length_required_buffer_s
     } else if (length <= 16383) {
         required_buffer_space = 2;
     } else if (length <= UINT32_MAX) {
-        required_buffer_space = 4;
+        required_buffer_space = 5;
     } else {
-        required_buffer_space = 8;
+        required_buffer_space = 9;
     }
 
     return required_buffer_space;

--- a/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.c
+++ b/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.c
@@ -196,8 +196,8 @@ module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_seriali
     // Numbers up to UINT32_MAX included are encoded in five bytes, the first two bits of the first byte are set to
     // 10 and the remaining 6 bits of the first byte are discarded. The number is encoded using big endian encoding
     // (most significant byte first) in the remaining four bytes
-        buffer[*buffer_offset_out] = 0x80;
-        (*buffer_offset_out)++;
+    buffer[*buffer_offset_out] = 0x80;
+    (*buffer_offset_out)++;
     uint32_t length_32 = int32_hton(length);
     memcpy(buffer + *buffer_offset_out, &length_32, sizeof(length_32));
     *buffer_offset_out += sizeof(length_32);
@@ -222,8 +222,8 @@ module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_seriali
     // Numbers greater than UINT32_MAX are encoded in nine bytes, the first two bits of the first byte are set to
     // 11 and the remaining 6 bits of the first byte are discarded. The number is encoded using big endian encoding
     // (most significant byte first) in the remaining eight bytes
-        buffer[*buffer_offset_out] = 0x81;
-        (*buffer_offset_out)++;
+    buffer[*buffer_offset_out] = 0x81;
+    (*buffer_offset_out)++;
     uint64_t length_64 = int64_hton(length);
     memcpy(buffer + *buffer_offset_out, &length_64, sizeof(length_64));
     *buffer_offset_out += sizeof(length_64);
@@ -463,7 +463,7 @@ module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_seriali
     (*buffer_offset_out)++;
 
     // Encode the length of the string
-    if ((result = module_redis_snapshot_serialize_primitive_encode_length(
+    if ((result = module_redis_snapshot_serialize_primitive_encode_length_up_to_uint32b(
             compressed_string_length,
             buffer,
             buffer_size,
@@ -473,7 +473,7 @@ module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_seriali
     }
 
     // Encode the length of the string
-    if ((result = module_redis_snapshot_serialize_primitive_encode_length(
+    if ((result = module_redis_snapshot_serialize_primitive_encode_length_up_to_uint32b(
             string_length,
             buffer,
             buffer_size,

--- a/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.h
+++ b/src/module/redis/snapshot/module_redis_snapshot_serialize_primitive.h
@@ -13,6 +13,7 @@ enum module_redis_snapshot_serialize_primitive_result {
     MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_COMPRESSION_RATIO_TOO_LOW,
     MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_INVALID_VALUE_TYPE,
     MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_BUFFER_TOO_LARGE,
+    MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_NUMBER_TOO_BIG,
 };
 typedef enum module_redis_snapshot_serialize_primitive_result module_redis_snapshot_serialize_primitive_result_t;
 
@@ -75,6 +76,34 @@ bool module_redis_snapshot_serialize_primitive_can_encode_string_int(
 
 module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_serialize_primitive_encode_header(
         module_redis_snapshot_header_t *header,
+        uint8_t *buffer,
+        size_t buffer_size,
+        size_t buffer_offset,
+        size_t *buffer_offset_out);
+
+module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_serialize_primitive_encode_length_up_to_uint63(
+        uint64_t length,
+        uint8_t *buffer,
+        size_t buffer_size,
+        size_t buffer_offset,
+        size_t *buffer_offset_out);
+
+module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_serialize_primitive_encode_length_up_to_uint16383(
+        uint64_t length,
+        uint8_t *buffer,
+        size_t buffer_size,
+        size_t buffer_offset,
+        size_t *buffer_offset_out);
+
+module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_serialize_primitive_encode_length_up_to_uint32b(
+        uint64_t length,
+        uint8_t *buffer,
+        size_t buffer_size,
+        size_t buffer_offset,
+        size_t *buffer_offset_out);
+
+module_redis_snapshot_serialize_primitive_result_t module_redis_snapshot_serialize_primitive_encode_length_up_to_uint64b(
+        uint64_t length,
         uint8_t *buffer,
         size_t buffer_size,
         size_t buffer_offset,

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -534,35 +534,35 @@ bool storage_db_snapshot_rdb_write_value_string(
             }
         }
 
-        // Try to compress the string using LZF
-        if (likely(!string_serialized && (entry_index->value.size > 32 && entry_index->value.size < 40 * 1024))) {
-            module_redis_snapshot_serialize_primitive_result_t serialize_result;
-            buffer_size = 128 + (size_t)(LZF_MAX_COMPRESSED_SIZE(entry_index->value.size) * 1.2);
-            if ((buffer = storage_buffered_write_buffer_acquire_slice(
-                    db->snapshot.storage_buffered_channel,
-                    buffer_size)) == NULL) {
-                LOG_E(TAG, "Failed to acquire a slice for the string value");
-                result = false;
-                goto end;
-            }
-
-            serialize_result = module_redis_snapshot_serialize_primitive_encode_small_string_lzf(
-                    string,
-                    entry_index->value.size,
-                    (uint8_t*)buffer,
-                    buffer_size,
-                    0,
-                    &buffer_offset);
-
-            // If the compression fails or the ration is too low ignore the error, cachegrand will try to
-            // save the string as a regular string
-            if (likely(serialize_result == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK)) {
-                storage_db_snapshot_rdb_release_slice(db, buffer_offset);
-                string_serialized = true;
-            } else {
-                storage_buffered_write_buffer_discard_slice(db->snapshot.storage_buffered_channel);
-            }
-        }
+//        // Try to compress the string using LZF
+//        if (likely(!string_serialized && (entry_index->value.size > 32 && entry_index->value.size < 40 * 1024))) {
+//            module_redis_snapshot_serialize_primitive_result_t serialize_result;
+//            buffer_size = 128 + (size_t)(LZF_MAX_COMPRESSED_SIZE(entry_index->value.size) * 1.2);
+//            if ((buffer = storage_buffered_write_buffer_acquire_slice(
+//                    db->snapshot.storage_buffered_channel,
+//                    buffer_size)) == NULL) {
+//                LOG_E(TAG, "Failed to acquire a slice for the string value");
+//                result = false;
+//                goto end;
+//            }
+//
+//            serialize_result = module_redis_snapshot_serialize_primitive_encode_small_string_lzf(
+//                    string,
+//                    entry_index->value.size,
+//                    (uint8_t*)buffer,
+//                    buffer_size,
+//                    0,
+//                    &buffer_offset);
+//
+//            // If the compression fails or the ration is too low ignore the error, cachegrand will try to
+//            // save the string as a regular string
+//            if (likely(serialize_result == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK)) {
+//                storage_db_snapshot_rdb_release_slice(db, buffer_offset);
+//                string_serialized = true;
+//            } else {
+//                storage_buffered_write_buffer_discard_slice(db->snapshot.storage_buffered_channel);
+//            }
+//        }
     }
 
     // If the string hasn't been serialized via the fast path or is too long, serialize it as a regular

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -1013,7 +1013,7 @@ void storage_db_snapshot_report_progress(
     // Report the progress
     LOG_I(
             TAG,
-            "Snapshot progress <%0.02f%%>, keys processed <%lu>, data processed <%0.02lf MB>, eta: <%s>",
+            "Snapshot progress <%0.02f%%>, keys processed <%lu>, data written <%0.02lf MB>, eta: <%s>",
             progress,
             db->snapshot.stats.keys_written,
             (double)db->snapshot.stats.data_written / 1024.0 / 1024.0,

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -534,37 +534,35 @@ bool storage_db_snapshot_rdb_write_value_string(
             }
         }
 
-        // The LZF compression is disabled for now, it causes a segfault
-//        if (false && likely(!string_serialized || (entry_index->value.size > 32 && entry_index->value.size < 52 * 1024))) {
-//           module_redis_snapshot_serialize_primitive_result_t serialize_result;
-//            size_t allocated_buffer_size = LZF_MAX_COMPRESSED_SIZE(entry_index->value.size) * 1.2;
-//            uint8_t *allocated_buffer = ffma_mem_alloc(allocated_buffer_size);
-//
-//            serialize_result = module_redis_snapshot_serialize_primitive_encode_small_string_lzf(
-//                    string,
-//                    entry_index->value.size,
-//                    allocated_buffer,
-//                    allocated_buffer_size,
-//                    0,
-//                    &buffer_offset);
-//
-//            // If the compression fails or the ration is too low ignore the error, cachegrand will try to
-//            // save the string as a regular string
-//            if (likely(serialize_result == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK)) {
-//                if (unlikely(!storage_db_snapshot_rdb_write_buffer(
-//                        db,
-//                        allocated_buffer,
-//                        allocated_buffer_size))) {
-//                    ffma_mem_free(allocated_buffer);
-//                    result = false;
-//                    goto end;
-//                }
-//
-//                string_serialized = true;
-//            }
-//
-//            ffma_mem_free(allocated_buffer);
-//        }
+        // Try to compress the string using LZF
+        if (likely(!string_serialized && (entry_index->value.size > 32 && entry_index->value.size < 40 * 1024))) {
+            module_redis_snapshot_serialize_primitive_result_t serialize_result;
+            buffer_size = 128 + (size_t)(LZF_MAX_COMPRESSED_SIZE(entry_index->value.size) * 1.2);
+            if ((buffer = storage_buffered_write_buffer_acquire_slice(
+                    db->snapshot.storage_buffered_channel,
+                    buffer_size)) == NULL) {
+                LOG_E(TAG, "Failed to acquire a slice for the string value");
+                result = false;
+                goto end;
+            }
+
+            serialize_result = module_redis_snapshot_serialize_primitive_encode_small_string_lzf(
+                    string,
+                    entry_index->value.size,
+                    (uint8_t*)buffer,
+                    buffer_size,
+                    0,
+                    &buffer_offset);
+
+            // If the compression fails or the ration is too low ignore the error, cachegrand will try to
+            // save the string as a regular string
+            if (likely(serialize_result == MODULE_REDIS_SNAPSHOT_SERIALIZE_PRIMITIVE_RESULT_OK)) {
+                storage_db_snapshot_rdb_release_slice(db, buffer_offset);
+                string_serialized = true;
+            } else {
+                storage_buffered_write_buffer_discard_slice(db->snapshot.storage_buffered_channel);
+            }
+        }
     }
 
     // If the string hasn't been serialized via the fast path or is too long, serialize it as a regular

--- a/src/storage/storage_buffered.h
+++ b/src/storage/storage_buffered.h
@@ -109,6 +109,17 @@ static inline __attribute__((always_inline))void storage_buffered_write_buffer_r
 #endif
 }
 
+static inline __attribute__((always_inline))void storage_buffered_write_buffer_discard_slice(
+        storage_buffered_channel_t *storage_buffered_channel) {
+    // Ensure that when the slice is released, the amount of data used is always the same or smaller than the length
+    // acquired. Also ensure that there was a slice acquired.
+    assert(storage_buffered_channel->buffers.write.slice_acquired_length > 0);
+
+#if DEBUG == 1
+    storage_buffered_channel->buffers.write.slice_acquired_length = 0;
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR changes the lzf compression support when dumping the RDB snapshot to avoid using a secondary buffer on the stack.

It also update the code (although it's kept disabled) that compresses data with LZF to use the new storage buffered channels.

The library in use requires way too much stack space (1MB) to compress 256 bytes of data, it's an absolute waste of memory. Once we will switch to a different library this functionality will be re-enabled.