### PR TITLE
Bug fix connection close

### DIFF
--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -397,12 +397,8 @@ bool network_channel_tls_shutdown(
 
 void network_channel_tls_free(
         network_channel_t *network_channel) {
-    if (network_channel->tls.context == NULL) {
-        return;
-    }
-
+    assert(network_channel->tls.context != NULL);
     mbedtls_ssl_free(network_channel->tls.context);
     ffma_mem_free(network_channel->tls.context);
-
     network_channel->tls.context = NULL;
 }

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -303,7 +303,7 @@ void worker_network_new_client_fiber_entrypoint(
     // TODO: when ti gets here new_channel might have been already freed, the flow should always close the connection
     //       the connection here and not from within the module
     if (new_channel->status != NETWORK_CHANNEL_STATUS_CLOSED) {
-        worker_op_network_close(new_channel, true);
+        network_close(new_channel, true);
     }
 
     // Updates the amount of active connections


### PR DESCRIPTION
When a connection is closed, the `network_close` function has to be invoked as it performs a number of tasks, from setting certain flags to freein up some buffers.

Currently the worker, when a connection is terminated, invokes directly the operation provided by the registered worker backend and this is causing memory leaks with TLS, among other things.

In addition, the `network_channel_tls_free` should never check if the context is set to NULL, if it is and the function is invoked there is a bug somewhere so better to catch, if it happens, with an assert.