### PR TITLE
Refactor the module_redis_command_helper_hello_send_response to do not build the response internally

### DIFF
--- a/src/module/redis/command/helpers/module_redis_command_helper_hello.h
+++ b/src/module/redis/command/helpers/module_redis_command_helper_hello.h
@@ -43,7 +43,9 @@ bool module_redis_command_helper_hello_send_error_invalid_proto_version(
         module_redis_connection_context_t *connection_context);
 
 bool module_redis_command_helper_hello_send_response(
-        module_redis_connection_context_t *connection_context);
+        module_redis_connection_context_t *connection_context,
+        module_redis_command_helper_hello_response_item_t *hello_items,
+        size_t hello_items_count);
 
 #ifdef __cplusplus
 }

--- a/src/module/redis/command/module_redis_command_hello.c
+++ b/src/module/redis/command/module_redis_command_hello.c
@@ -85,5 +85,54 @@ MODULE_REDIS_COMMAND_FUNCPTR_COMMAND_END(hello) {
     module_redis_command_helper_hello_try_fetch_proto_version(connection_context, context);
     module_redis_command_helper_hello_try_fetch_client_name(connection_context, context);
 
-    return module_redis_command_helper_hello_send_response(connection_context);
+    module_redis_command_helper_hello_response_item_t hello_items[] = {
+            {
+                    .key = "server",
+                    .value_type = PROTOCOL_REDIS_TYPE_SIMPLE_STRING,
+                    .value.string = MODULE_REDIS_COMPATIBILITY_SERVER_NAME
+            },
+            {
+                    .key = "version",
+                    .value_type = PROTOCOL_REDIS_TYPE_SIMPLE_STRING,
+                    .value.string = MODULE_REDIS_COMPATIBILITY_SERVER_VERSION
+            },
+            {
+                    .key = "cachegrand_version",
+                    .value_type = PROTOCOL_REDIS_TYPE_SIMPLE_STRING,
+                    .value.string = CACHEGRAND_CMAKE_CONFIG_VERSION_GIT
+            },
+            {
+                    .key = "proto",
+                    .value_type = PROTOCOL_REDIS_TYPE_NUMBER,
+                    .value.number = connection_context->resp_version == PROTOCOL_REDIS_RESP_VERSION_2
+                                    ? 2
+                                    : 3
+            },
+            {
+                    .key = "id",
+                    .value_type = PROTOCOL_REDIS_TYPE_NUMBER,
+                    .value.number = 0
+            },
+            {
+                    .key = "mode",
+                    .value_type = PROTOCOL_REDIS_TYPE_SIMPLE_STRING,
+                    .value.string = "standalone"
+            },
+            {
+                    .key = "role",
+                    .value_type = PROTOCOL_REDIS_TYPE_SIMPLE_STRING,
+                    .value.string = "master"
+            },
+            {
+                    .key = "modules",
+                    .value_type = PROTOCOL_REDIS_TYPE_ARRAY,
+                    .value.array.list = NULL,
+                    .value.array.count = 0
+            },
+    };
+
+    return module_redis_command_helper_hello_send_response(
+            connection_context,
+            hello_items,
+            ARRAY_SIZE(hello_items));
 }


### PR DESCRIPTION
This PR refactors how the module_redis_command_helper_hello_send_response sends the list of items for the HELLO command by abstracting away the list itself and accepting it as parameter.

It will be responsability of the caller to pass the list as needed.