### PR TITLE
Implement a sink for syslog

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,7 @@ typedef uint32_t module_id_t;
 enum config_log_type {
     CONFIG_LOG_TYPE_CONSOLE,
     CONFIG_LOG_TYPE_FILE,
+    CONFIG_LOG_TYPE_SYSLOG,
     CONFIG_LOG_TYPE_MAX,
 };
 typedef enum config_log_type config_log_type_t;

--- a/src/config_cyaml_schema.h
+++ b/src/config_cyaml_schema.h
@@ -41,6 +41,7 @@ static cyaml_strval_t config_database_backend_schema_strings[] = {
 static cyaml_strval_t config_log_type_schema_strings[] = {
         { "console", CONFIG_LOG_TYPE_CONSOLE },
         { "file",    CONFIG_LOG_TYPE_FILE },
+        { "syslog",    CONFIG_LOG_TYPE_SYSLOG },
 };
 
 // Allowed strings for config -> logs -> log -> level (config_log_level_t)

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -199,7 +199,7 @@ char* log_buffer_static_or_alloc_new(
 
     // If the message is small enough, avoid allocating & freeing memory, uses < to keep 1 byte free for NULL
     // termination
-    if (data_size < static_buffer_size) {
+    if (data_size < static_buffer_size - 1) {
         buffer = static_buffer;
         *static_buffer_selected = true;
     } else {

--- a/src/log/sink/log_sink.c
+++ b/src/log/sink/log_sink.c
@@ -19,6 +19,7 @@
 
 #include "log/sink/log_sink_console.h"
 #include "log/sink/log_sink_file.h"
+#include "log/sink/log_sink_syslog.h"
 
 log_sink_t** log_sink_registered = NULL;
 uint8_t log_sink_registered_count = 0;
@@ -86,6 +87,9 @@ log_sink_t* log_sink_factory(
 
         case LOG_SINK_TYPE_FILE:
             return log_sink_file_init(levels, settings);
+
+        case LOG_SINK_TYPE_SYSLOG:
+            return log_sink_syslog_init(levels, settings);
 
         default:
             return NULL;

--- a/src/log/sink/log_sink.h
+++ b/src/log/sink/log_sink.h
@@ -13,6 +13,7 @@ extern uint8_t log_sink_registered_count;
 enum log_sink_type {
     LOG_SINK_TYPE_CONSOLE = 0,
     LOG_SINK_TYPE_FILE,
+    LOG_SINK_TYPE_SYSLOG,
     LOG_SINK_TYPE_MAX
 };
 typedef enum log_sink_type log_sink_type_t;
@@ -28,6 +29,11 @@ union log_sink_settings {
             int fd;
         } internal;
     } file;
+    struct {
+        struct {
+            bool opened;
+        } internal;
+    } syslog;
 };
 
 typedef void (log_sink_printer_fn_t)(

--- a/src/log/sink/log_sink_console.c
+++ b/src/log/sink/log_sink_console.c
@@ -65,7 +65,7 @@ void log_sink_console_printer(
         size_t message_len) {
     char* log_message;
     char* log_message_beginning;
-    char log_message_static_buffer[200] = { 0 };
+    char log_message_static_buffer[256] = { 0 };
     bool log_message_static_buffer_selected = false;
     size_t color_fg_desired_len = 0;
     size_t color_fg_reset_len = 0;

--- a/src/log/sink/log_sink_file.c
+++ b/src/log/sink/log_sink_file.c
@@ -65,7 +65,7 @@ void log_sink_file_printer(
         const char* message,
         size_t message_len) {
     char* log_message;
-    char log_message_static_buffer[200] = { 0 };
+    char log_message_static_buffer[256] = { 0 };
     bool log_message_static_buffer_selected = false;
 
     size_t log_message_size = log_sink_support_printer_str_len(

--- a/src/log/sink/log_sink_file.h
+++ b/src/log/sink/log_sink_file.h
@@ -25,4 +25,4 @@ void log_sink_file_printer(
 }
 #endif
 
-#endif //CACHEGRAND_LOG_SINK_CONSOLE_H
+#endif //CACHEGRAND_LOG_SINK_FILE_H

--- a/src/log/sink/log_sink_support.c
+++ b/src/log/sink/log_sink_support.c
@@ -69,8 +69,8 @@ size_t log_sink_support_printer_str(
         const char* early_prefix_thread,
         const char* message,
         size_t message_len) {
-    size_t message_out_len_res = 0;
-    char timestamp_str[LOG_MESSAGE_TIMESTAMP_MAX_LENGTH + 1] = {0};
+    size_t message_out_len_res;
+    char timestamp_str[LOG_MESSAGE_TIMESTAMP_MAX_LENGTH + 1] = { 0 };
 
     message_out_len_res = snprintf(
             message_out,

--- a/src/log/sink/log_sink_support.c
+++ b/src/log/sink/log_sink_support.c
@@ -35,6 +35,31 @@ size_t log_sink_support_printer_str_len(
     return log_message_len;
 }
 
+size_t log_sink_support_printer_simple_str(
+        char* message_out,
+        size_t message_out_len,
+        const char* tag,
+        const char* early_prefix_thread,
+        const char* message,
+        size_t message_len) {
+    size_t message_out_len_res;
+
+    message_out_len_res = snprintf(
+            message_out,
+            message_out_len,
+            "%s[%s] ",
+            early_prefix_thread != NULL ? early_prefix_thread : "",
+            tag);
+
+    strcpy(message_out + message_out_len_res, message);
+    message_out_len_res += message_len;
+
+    message_out[message_out_len_res] = '\n';
+    message_out_len_res++;
+
+    return message_out_len_res;
+}
+
 size_t log_sink_support_printer_str(
         char* message_out,
         size_t message_out_len,

--- a/src/log/sink/log_sink_support.h
+++ b/src/log/sink/log_sink_support.h
@@ -10,6 +10,14 @@ size_t log_sink_support_printer_str_len(
         const char* early_prefix_thread,
         size_t message_len);
 
+size_t log_sink_support_printer_simple_str(
+        char* message_out,
+        size_t message_out_len,
+        const char* tag,
+        const char* early_prefix_thread,
+        const char* message,
+        size_t message_len);
+
 size_t log_sink_support_printer_str(
         char* message_out,
         size_t message_out_len,

--- a/src/log/sink/log_sink_syslog.c
+++ b/src/log/sink/log_sink_syslog.c
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/syslog.h>
+
+#include "misc.h"
+#include "clock.h"
+#include "log/log.h"
+#include "log/sink/log_sink.h"
+#include "log/sink/log_sink_support.h"
+#include "xalloc.h"
+
+#include "log_sink_syslog.h"
+
+#define TAG "log_sink_syslog"
+
+static bool log_sink_syslog_log_level_map_initialized = false;
+static int log_sink_syslog_log_level_map[LOG_LEVEL_MAX] = { 0 };
+void log_sink_syslog_log_level_map_init() {
+    log_sink_syslog_log_level_map[LOG_LEVEL_ERROR] = LOG_ERR;
+    log_sink_syslog_log_level_map[LOG_LEVEL_WARNING] = LOG_WARNING;
+    log_sink_syslog_log_level_map[LOG_LEVEL_INFO] = LOG_NOTICE;
+    log_sink_syslog_log_level_map[LOG_LEVEL_VERBOSE] = LOG_INFO;
+    log_sink_syslog_log_level_map[LOG_LEVEL_DEBUG] = LOG_DEBUG;
+
+    log_sink_syslog_log_level_map_initialized = true;
+}
+
+log_sink_t *log_sink_syslog_init(
+        log_level_t levels,
+        log_sink_settings_t* settings) {
+    // Initialize the log level map if not already initialized
+    if (!log_sink_syslog_log_level_map_initialized) {
+        log_sink_syslog_log_level_map_init();
+        log_sink_syslog_log_level_map_initialized = true;
+    }
+
+    // Open syslog
+    openlog(CACHEGRAND_CMAKE_CONFIG_NAME, LOG_CONS | LOG_NDELAY | LOG_PID, LOG_USER);
+
+    // Mark the syslog as opened
+    settings->syslog.internal.opened = true;
+
+    return log_sink_init(
+            LOG_SINK_TYPE_SYSLOG,
+            levels,
+            settings,
+            log_sink_syslog_printer,
+            log_sink_syslog_free);
+}
+
+void log_sink_syslog_free(
+        log_sink_settings_t* settings) {
+    if (settings->syslog.internal.opened == true) {
+        closelog();
+    }
+}
+
+void log_sink_syslog_printer(
+        log_sink_settings_t* settings,
+        const char* tag,
+        time_t timestamp,
+        log_level_t level,
+        char* early_prefix_thread,
+        const char* message,
+        size_t message_len) {
+    char* log_message;
+    char log_message_static_buffer[256] = { 0 };
+    bool log_message_static_buffer_selected = false;
+
+    size_t log_message_size = log_sink_support_printer_str_len(
+            tag,
+            early_prefix_thread,
+            message_len);
+
+    log_message = log_buffer_static_or_alloc_new(
+            log_message_static_buffer,
+            sizeof(log_message_static_buffer),
+            log_message_size,
+            &log_message_static_buffer_selected);
+
+    // Write the log message
+    log_sink_support_printer_simple_str(
+            log_message,
+            log_message_size,
+            tag,
+            early_prefix_thread,
+            message,
+            message_len);
+
+    // Write the log message to syslog
+    syslog(LOG_USER | log_sink_syslog_log_level_map[level], "%s", log_message);
+
+    if (!log_message_static_buffer_selected) {
+        xalloc_free(log_message);
+    }
+}

--- a/src/log/sink/log_sink_syslog.h
+++ b/src/log/sink/log_sink_syslog.h
@@ -1,0 +1,28 @@
+#ifndef CACHEGRAND_LOG_SINK_SYSLOG_H
+#define CACHEGRAND_LOG_SINK_SYSLOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+log_sink_t *log_sink_syslog_init(
+        log_level_t levels,
+        log_sink_settings_t* settings);
+
+void log_sink_syslog_free(
+        log_sink_settings_t* settings);
+
+void log_sink_syslog_printer(
+        log_sink_settings_t* settings,
+        const char* tag,
+        time_t timestamp,
+        log_level_t level,
+        char* early_prefix_thread,
+        const char* message,
+        size_t message_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CACHEGRAND_LOG_SINK_SYSLOG_H

--- a/src/program.c
+++ b/src/program.c
@@ -573,6 +573,10 @@ void program_config_setup_log_sinks(
                 log_sink_settings.file.path = config_log->file->path;
                 break;
 
+            case LOG_SINK_TYPE_SYSLOG:
+                // nothing to do
+                break;
+
             default:
                 // To catch mismatches
                 assert(false);

--- a/tests/unit_tests/test-config.cpp
+++ b/tests/unit_tests/test-config.cpp
@@ -1969,6 +1969,7 @@ TEST_CASE("config.c", "[config]") {
     SECTION("config_log_type_t == log_sink_type_t") {
         REQUIRE((int)CONFIG_LOG_TYPE_CONSOLE == LOG_SINK_TYPE_CONSOLE);
         REQUIRE((int)CONFIG_LOG_TYPE_FILE == LOG_SINK_TYPE_FILE);
+        REQUIRE((int)CONFIG_LOG_TYPE_SYSLOG == LOG_SINK_TYPE_SYSLOG);
         REQUIRE((int)CONFIG_LOG_TYPE_MAX == LOG_SINK_TYPE_MAX);
     }
 


### PR DESCRIPTION
This PR implements a sink for syslog to be able to use structured logs with containers or telemetry collectors.