### PR TITLE
Rely on a bool flag to indicate the in preparation status of the snapshots

### DIFF
--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -318,6 +318,7 @@ storage_db_t* storage_db_new(
     db->counters_slots_bitmap = slots_bitmap_mpmc_init(STORAGE_DB_WORKERS_MAX);
     db->snapshot.next_run_time_ms = 0;
     db->snapshot.status = STORAGE_DB_SNAPSHOT_STATUS_NONE;
+    db->snapshot.in_preparation = false;
     db->snapshot.block_index = 0;
     db->snapshot.storage_channel_opened = false;
     db->snapshot.storage_buffered_channel = NULL;

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -197,6 +197,9 @@ struct storage_db {
         queue_mpmc_t *entry_index_to_be_deleted_queue;
         uint64_t keys_changed_at_start;
         uint64_t data_changed_at_start;
+#if DEBUG == 1
+        uint64_volatile_t parallel_runs;
+#endif
         char *path;
         struct {
             uint64_t data_written;

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -161,7 +161,6 @@ struct storage_db_counters_global_and_per_db {
 
 enum storage_db_snapshot_status {
     STORAGE_DB_SNAPSHOT_STATUS_NONE = 0,
-    STORAGE_DB_SNAPSHOT_STATUS_IN_PREPARATION,
     STORAGE_DB_SNAPSHOT_STATUS_IN_PROGRESS,
     STORAGE_DB_SNAPSHOT_STATUS_BEING_FINALIZED,
     STORAGE_DB_SNAPSHOT_STATUS_COMPLETED,
@@ -189,6 +188,7 @@ struct storage_db {
         uint64_volatile_t start_time_ms;
         uint64_volatile_t end_time_ms;
         uint64_volatile_t progress_reported_at_ms;
+        bool_volatile_t in_preparation;
         storage_db_snapshot_status_volatile_t status;
         uint64_volatile_t block_index;
         bool_volatile_t running;

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -396,7 +396,7 @@ bool storage_db_snapshot_rdb_ensure_prepared(
     }
 
 #if DEBUG == 1
-    assert(__sync_fetch_and_add(&db->snapshot.parallel_runs, -1) == 0);
+    assert(__sync_fetch_and_add(&db->snapshot.parallel_runs, 1) == 0);
 #endif
 
     // Prepare the snapshot

--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -99,6 +99,10 @@ void storage_db_snapshot_completed(
             false,
             false);
 
+#if DEBUG == 1
+    assert(__sync_fetch_and_add(&db->snapshot.parallel_runs, -1) == 1);
+#endif
+
     // Report the snapshot status
     if (status == STORAGE_DB_SNAPSHOT_STATUS_FAILED_DURING_PREPARATION) {
         LOG_E(TAG, "Snapshot failed during preparation");
@@ -390,6 +394,10 @@ bool storage_db_snapshot_rdb_ensure_prepared(
         storage_db_snapshot_wait_for_prepared(db);
         return db->snapshot.status != STORAGE_DB_SNAPSHOT_STATUS_FAILED;
     }
+
+#if DEBUG == 1
+    assert(__sync_fetch_and_add(&db->snapshot.parallel_runs, -1) == 0);
+#endif
 
     // Prepare the snapshot
     return storage_db_snapshot_rdb_prepare(db);


### PR DESCRIPTION
This PR changes how cachegrand determines if a snapshot is being prepared to be generated, it switches from using the status field to an ad-hoc boolean field.

The reason behind this change is the current implementation, when a lot of worker runs in paralle, trigger the preparation code multiple time as consequence of how the status is swapped from the current one to the IN PREPARATION.
To solve that issue would be necessary to do not read the current state and then change it to IN PREPARATION, instead it would be necessary to "expect" a very specific and precise value, but the status at that stage can potentially be NONE, COMPLETED or FAILED, which makes it challenging to reliabily identify the expected status.

Here an example of the bug in action
```
[2023-04-17T09:30:04Z][INFO       ][worker][id: 28][cpu: 28][storage_db_snapshot] Snapshot started
[2023-04-17T09:30:04Z][INFO       ][worker][id: 44][cpu: 44][storage_db_snapshot] Snapshot progress <100.00%>, keys processed <0>, data written <0.00 MB>, eta: <0 seconds>
[2023-04-17T09:30:04Z][INFO       ][worker][id: 44][cpu: 44][storage_db_snapshot] Snapshot completed in <49 ms>
[2023-04-17T09:30:09Z][INFO       ][worker][id: 31][cpu: 31][storage_db_snapshot] Snapshot progress <0.00%>, keys processed <0>, data written <0.00 MB>, eta: <0 seconds>
[2023-04-17T09:30:09Z][INFO       ][worker][id: 29][cpu: 29][storage_db_snapshot] Snapshot started
[2023-04-17T09:30:09Z][INFO       ][worker][id: 14][cpu: 14][storage_db_snapshot] Snapshot started
```

It's possible to see that the Snapshot started is reported 3 times.

To solve the issue a new boolean flag is introduced, called `in_preparation`, which complements the `running` boolean flag, and it's used to determine if a worker is preparing the snapshot to be generated. This approach guarantees that the expected status for the CAS operation has to be `false` and if the CAS operation it's because another worker set it to `true`.

The fleg is set back to false, after the flag `running` is set to true, at the end of the preparation which ensures that the threads will start to safely see the `running` flag, which has precedence over the status check.

This bug is only affecting deployments which are using plenty of workers/