### PR TITLE
Set the interval ms to 7 days as expected by the tests

### DIFF
--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-fixture.cpp
@@ -129,6 +129,7 @@ TestModulesRedisCommandFixture::TestModulesRedisCommandFixture() {
             .interval_str = "7d",
             .min_data_changed_str = "0",
             .snapshot_at_shutdown = false,
+            .interval_ms = 7 * 86400 * 1000,
             .min_keys_changed = 0,
             .rotation = nullptr,
     };


### PR DESCRIPTION
This PR fixes the unrequested snapshotting done during the tests as they should be done only when requested by the tests themselves.