### PR TITLE
Enforce TTL

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1156,6 +1156,42 @@ bool config_process_string_values(
         }
     }
 
+    if (config->database->enforced_ttl) {
+        if (config->database->enforced_ttl->default_ttl_str) {
+            bool result = config_parse_string_time(
+                    config->database->enforced_ttl->default_ttl_str,
+                    strlen(config->database->enforced_ttl->default_ttl_str),
+                    false,
+                    false,
+                    true,
+                    &config->database->enforced_ttl->default_ttl_ms);
+
+            if (!result) {
+                LOG_E(TAG, "Failed to parse the default ttl");
+                return false;
+            }
+
+            config->database->enforced_ttl->default_ttl_ms *= 1000;
+        }
+
+        if (config->database->enforced_ttl->max_ttl_str) {
+            bool result = config_parse_string_time(
+                    config->database->enforced_ttl->max_ttl_str,
+                    strlen(config->database->enforced_ttl->max_ttl_str),
+                    false,
+                    false,
+                    true,
+                    &config->database->enforced_ttl->max_ttl_ms);
+
+            if (!result) {
+                LOG_E(TAG, "Failed to parse the max ttl");
+                return false;
+            }
+
+            config->database->enforced_ttl->max_ttl_ms *= 1000;
+        }
+    }
+
     return true;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -259,6 +259,14 @@ struct config_database_snapshots {
 };
 typedef struct config_database_snapshots config_database_snapshots_t;
 
+struct config_database_enforced_ttl {
+    char *default_ttl_str;
+    char *max_ttl_str;
+    int64_t default_ttl_ms;
+    int64_t max_ttl_ms;
+};
+typedef struct config_database_enforced_ttl config_database_enforced_ttl_t;
+
 struct config_database {
     config_database_limits_t *limits;
     config_database_keys_eviction_t *keys_eviction;
@@ -266,6 +274,7 @@ struct config_database {
     config_database_snapshots_t *snapshots;
     config_database_file_t *file;
     config_database_memory_t *memory;
+    config_database_enforced_ttl_t *enforced_ttl;
     int64_t max_user_databases;
 };
 typedef struct config_database config_database_t;

--- a/src/config_cyaml_schema.c
+++ b/src/config_cyaml_schema.c
@@ -289,6 +289,17 @@ const cyaml_schema_field_t config_database_backend_memory_schema[] = {
         CYAML_FIELD_END
 };
 
+// Schema for config -> database -> enforced_ttl
+const cyaml_schema_field_t config_database_enforced_ttl_schema[] = {
+        CYAML_FIELD_STRING_PTR(
+                "default", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                config_database_enforced_ttl_t, default_ttl_str, 0, 20),
+        CYAML_FIELD_STRING_PTR(
+                "max", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                config_database_enforced_ttl_t, max_ttl_str, 0, 20),
+        CYAML_FIELD_END
+};
+
 // Schema for config -> database -> limits -> hard
 const cyaml_schema_field_t config_database_limits_hard_schema[] = {
         CYAML_FIELD_UINT(
@@ -368,6 +379,9 @@ const cyaml_schema_field_t config_database_schema[] = {
         CYAML_FIELD_MAPPING_PTR(
                 "memory", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
                 config_database_t, memory, config_database_backend_memory_schema),
+        CYAML_FIELD_MAPPING_PTR(
+                "enforced_ttl", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                config_database_t, enforced_ttl, config_database_enforced_ttl_schema),
         CYAML_FIELD_UINT(
                 "max_user_databases", CYAML_FLAG_DEFAULT,
                 config_database_t, max_user_databases),

--- a/src/program.c
+++ b/src/program.c
@@ -618,6 +618,18 @@ bool program_config_setup_storage_db(
                                               ? program_context->config->database->snapshots->rotation->max_files
                                               : 0;
         config->snapshot.snapshot_at_shutdown = program_context->config->database->snapshots->snapshot_at_shutdown;
+
+        config->enforced_ttl.default_ms = STORAGE_DB_ENTRY_NO_EXPIRY;
+        config->enforced_ttl.max_ms = STORAGE_DB_ENTRY_NO_EXPIRY;
+
+        if (program_context->config->database->enforced_ttl) {
+            if (program_context->config->database->enforced_ttl->default_ttl_str) {
+                config->enforced_ttl.default_ms = program_context->config->database->enforced_ttl->default_ttl_ms;
+            }
+            if (program_context->config->database->enforced_ttl->max_ttl_str) {
+                config->enforced_ttl.max_ms = program_context->config->database->enforced_ttl->max_ttl_ms;
+            }
+        }
     }
 
     if (program_context->config->database->backend == CONFIG_DATABASE_BACKEND_FILE) {

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1223,10 +1223,8 @@ bool storage_db_op_set(
         }
     }
 
-    if (expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
-        if (db->config->enforced_ttl.default_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
-            expiry_time_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.default_ms;
-        }
+    if (expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY && db->config->enforced_ttl.default_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+        expiry_time_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.default_ms;
     } else if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
         int64_t max_ttl_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.max_ms;
         if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY && expiry_time_ms > max_ttl_ms) {
@@ -1365,10 +1363,8 @@ bool storage_db_op_rmw_commit_update(
         }
     }
 
-    if (expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
-        if (db->config->enforced_ttl.default_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
-            expiry_time_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.default_ms;
-        }
+    if (expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY && db->config->enforced_ttl.default_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+        expiry_time_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.default_ms;
     } else if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
         int64_t max_ttl_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.max_ms;
         if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY && expiry_time_ms > max_ttl_ms) {

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1223,6 +1223,17 @@ bool storage_db_op_set(
         }
     }
 
+    if (expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+        if (db->config->enforced_ttl.default_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+            expiry_time_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.default_ms;
+        }
+    } else if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+        int64_t max_ttl_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.max_ms;
+        if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY && expiry_time_ms > max_ttl_ms) {
+            expiry_time_ms = max_ttl_ms;
+        }
+    }
+
     // Fetch a new entry and assign the key and the value as needed
     entry_index->database_number = database_number;
     entry_index->value.size = value_chunk_sequence->size;
@@ -1351,6 +1362,17 @@ bool storage_db_op_rmw_commit_update(
                 rmw_status->hashtable.key_length)) {
             LOG_E(TAG, "Unable to write an index entry key");
             goto end;
+        }
+    }
+
+    if (expiry_time_ms == STORAGE_DB_ENTRY_NO_EXPIRY) {
+        if (db->config->enforced_ttl.default_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+            expiry_time_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.default_ms;
+        }
+    } else if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY) {
+        int64_t max_ttl_ms = clock_realtime_coarse_int64_ms() + db->config->enforced_ttl.max_ms;
+        if (db->config->enforced_ttl.max_ms != STORAGE_DB_ENTRY_NO_EXPIRY && expiry_time_ms > max_ttl_ms) {
+            expiry_time_ms = max_ttl_ms;
         }
     }
 

--- a/src/storage/db/storage_db.h
+++ b/src/storage/db/storage_db.h
@@ -104,6 +104,10 @@ struct storage_db_config {
     storage_db_config_limits_t limits;
     storage_db_config_snapshot_t snapshot;
     uint32_t max_user_databases;
+    struct {
+        storage_db_expiry_time_ms_t default_ms;
+        storage_db_expiry_time_ms_t max_ms;
+    } enforced_ttl;
     union {
         struct {
             char *basedir_path;

--- a/tests/unit_tests/modules/redis/command/test-modules-redis-command-enforced-ttl.cpp
+++ b/tests/unit_tests/modules/redis/command/test-modules-redis-command-enforced-ttl.cpp
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2018-2023 Daniele Salvatore Albano
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license.  See the LICENSE file for details.
+ **/
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdbool>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/types.h>
+
+#include "clock.h"
+#include "exttypes.h"
+#include "spinlock.h"
+#include "transaction.h"
+#include "transaction_spinlock.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_voidptr.h"
+#include "data_structures/ring_bounded_queue_spsc/ring_bounded_queue_spsc_uint128.h"
+#include "data_structures/double_linked_list/double_linked_list.h"
+#include "data_structures/slots_bitmap_mpmc/slots_bitmap_mpmc.h"
+#include "data_structures/hashtable/mcmp/hashtable.h"
+#include "data_structures/hashtable/spsc/hashtable_spsc.h"
+#include "config.h"
+#include "fiber/fiber.h"
+#include "worker/worker_stats.h"
+#include "worker/worker_context.h"
+#include "signal_handler_thread.h"
+#include "storage/io/storage_io_common.h"
+#include "storage/channel/storage_channel.h"
+#include "storage/db/storage_db.h"
+#include "epoch_gc.h"
+#include "epoch_gc_worker.h"
+
+#include "program.h"
+
+#include "test-modules-redis-command-fixture.hpp"
+
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+
+TEST_CASE_METHOD(TestModulesRedisCommandFixture, "Redis - command - Enforced TTL", "[redis][command][enforced_ttl]") {
+    db->config->enforced_ttl.default_ms = 86400UL * 1000UL;
+    db->config->enforced_ttl.max_ms = 7 * 86400UL * 1000UL;
+
+    char *a_key = "a_key";
+    char *a_value = "a_value";
+
+    SECTION("No TTL - Use default") {
+        int64_t before_timestamp = clock_realtime_coarse_int64_ms();
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                std::vector<std::string>{"SET", a_key, a_value},
+                "+OK\r\n"));
+        int64_t after_timestamp = clock_realtime_coarse_int64_ms();
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(
+                db,
+                0,
+                a_key,
+                strlen(a_key));
+
+        REQUIRE(entry_index != nullptr);
+        REQUIRE(entry_index->expiry_time_ms >= before_timestamp + db->config->enforced_ttl.default_ms);
+        REQUIRE(entry_index->expiry_time_ms <= after_timestamp + db->config->enforced_ttl.default_ms);
+    }
+
+    SECTION("With TTL - 500ms") {
+        int64_t before_timestamp = clock_realtime_coarse_int64_ms();
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                std::vector<std::string>{"SET", a_key, a_value, "PX", "500"},
+                "+OK\r\n"));
+        int64_t after_timestamp = clock_realtime_coarse_int64_ms();
+
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(
+                db,
+                0,
+                a_key,
+                strlen(a_key));
+
+        REQUIRE(entry_index != nullptr);
+        REQUIRE(entry_index->expiry_time_ms >= before_timestamp + 500 - 10);
+        REQUIRE(entry_index->expiry_time_ms <= after_timestamp + 500 + 10);
+    }
+
+    SECTION("With TTL - 5s") {
+        int64_t before_timestamp = clock_realtime_coarse_int64_ms();
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                std::vector<std::string>{"SET", a_key, a_value, "EX", "5"},
+                "+OK\r\n"));
+        int64_t after_timestamp = clock_realtime_coarse_int64_ms();
+
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(
+                db,
+                0,
+                a_key,
+                strlen(a_key));
+
+        REQUIRE(entry_index != nullptr);
+        REQUIRE(entry_index->expiry_time_ms >= before_timestamp + 5000 - 10);
+        REQUIRE(entry_index->expiry_time_ms <= after_timestamp + 5000 + 10);
+    }
+
+    SECTION("With TTL - greater than max") {
+        char greater_than_max_ttl[32];
+        sprintf(greater_than_max_ttl, "%lu", db->config->enforced_ttl.max_ms + 1);
+
+        int64_t before_timestamp = clock_realtime_coarse_int64_ms();
+        REQUIRE(send_recv_resp_command_text_and_validate_recv(
+                std::vector<std::string>{"SET", a_key, a_value, "PX", greater_than_max_ttl},
+                "+OK\r\n"));
+        int64_t after_timestamp = clock_realtime_coarse_int64_ms();
+
+        storage_db_entry_index_t *entry_index = storage_db_get_entry_index(
+                db,
+                0,
+                a_key,
+                strlen(a_key));
+
+        REQUIRE(entry_index != nullptr);
+        REQUIRE(entry_index->expiry_time_ms >= before_timestamp + db->config->enforced_ttl.max_ms);
+        REQUIRE(entry_index->expiry_time_ms <= after_timestamp + db->config->enforced_ttl.max_ms);
+    }
+}

--- a/tests/unit_tests/test-config.cpp
+++ b/tests/unit_tests/test-config.cpp
@@ -177,6 +177,9 @@ database:
   keys_eviction:
     policy: lru
     only_ttl: true
+  enforced_ttl:
+    default: 24h
+    max: 30d
 sentry:
   enable: true
 logs:
@@ -1404,13 +1407,15 @@ TEST_CASE("config.c", "[config]") {
                     })
 
             REQUIRE(config != nullptr);
+            REQUIRE(err == CYAML_OK);
+            REQUIRE(cyaml_logger_context.data == nullptr);
+            REQUIRE(cyaml_logger_context.data_length == 0);
             REQUIRE(config->network->backend == CONFIG_NETWORK_BACKEND_IO_URING);
             REQUIRE(config->modules_count == 1);
             REQUIRE(config->cpus_count == 1);
             REQUIRE(config->logs_count == 2);
-            REQUIRE(cyaml_logger_context.data == nullptr);
-            REQUIRE(cyaml_logger_context.data_length == 0);
-            REQUIRE(err == CYAML_OK);
+            REQUIRE(config->database->enforced_ttl->default_ttl_ms == 1UL * 86400UL * 1000UL);
+            REQUIRE(config->database->enforced_ttl->max_ttl_ms == 30UL * 86400UL * 1000UL);
 
             cyaml_free(config_cyaml_config, config_top_schema, config, 0);
         }


### PR DESCRIPTION
This PR implements a new functionality to allow the enforcment of the TTL via a default value, which, when enabled, is applied when the TTL is not set, and a max value, which, when enabled, limit the TTL to the max value if there is a ttl set.

The new config file properties are under an optional section named `enforced_ttl` and are named `default` and `max`, the properties are optional as well although one or the other has to be present for the YAML config file to be valid.

The default ttl and max ttl properties support time units, so it's possible to write `7d` instead of `604800` or `1h` instead of `3600`.

Example with a default TTL set to 1d
```
127.0.0.1:6379> SET a_key a_value
OK
127.0.0.1:6379> TTL a_key
(integer) 86397
127.0.0.1:6379> SET a_key a_value
OK
127.0.0.1:6379> PTTL a_key
(integer) 86396632
127.0.0.1:6379> 
```

Example with a max TTL set to 7d
```
127.0.0.1:6379> SET a_key a_value EX 1234567
OK
127.0.0.1:6379> TTL a_key
(integer) 604798
127.0.0.1:6379> PTTL a_key
(integer) 604796556
```

If the parameters are not set cachegrand will behave normally as expected
```
127.0.0.1:6379> SET a_key a_value
OK
127.0.0.1:6379> TTL a_key
(integer) -1
127.0.0.1:6379> PTTL a_key
(integer) -1
127.0.0.1:6379> SET a_key a_value EX 1234567
OK
127.0.0.1:6379> TTL a_key
(integer) 1234566
127.0.0.1:6379> PTTL a_key
(integer) 1234563896
```