### PR TITLE
Ensure that the hashtable for the redis commands is large enough

### DIFF
--- a/src/module/redis/module_redis_commands.c
+++ b/src/module/redis/module_redis_commands.c
@@ -85,7 +85,7 @@ hashtable_spsc_t *module_redis_commands_build_commands_hashtables(
         module_redis_command_info_t *command_infos,
         uint32_t command_infos_count) {
     hashtable_spsc_t *commands_hashtable = hashtable_spsc_new(
-            command_infos_count,
+            command_infos_count * 2,
             32,
             false);
     for(


### PR DESCRIPTION
This PR doubles the size of the hashtable used to map the redis commands to ensure it's large enough and doesn't have to search through too many keys.

The extra amount of memory used is not relevant.