### PR TITLE
Fix hashtable locking

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -31,7 +31,7 @@
 
 thread_local uint32_t transaction_manager_worker_index = 0;
 thread_local uint16_t transaction_manager_transaction_index = 0;
-thread_local pthread_once_t transaction_manager_init_once_control = PTHREAD_ONCE_INIT;
+thread_local bool_volatile_t transaction_manager_inited = false;
 
 void transaction_set_worker_index(
         uint32_t worker_index) {
@@ -59,7 +59,10 @@ uint16_t transaction_peek_current_thread_index() {
 
 bool transaction_acquire(
         transaction_t *transaction) {
-    pthread_once(&transaction_manager_init_once_control, transaction_manager_init);
+    if (unlikely(transaction_manager_inited == false)) {
+        transaction_manager_init();
+        transaction_manager_inited = true;
+    }
 
     transaction_manager_transaction_index++;
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -31,7 +31,7 @@
 
 thread_local uint32_t transaction_manager_worker_index = 0;
 thread_local uint16_t transaction_manager_transaction_index = 0;
-pthread_once_t transaction_manager_init_once_control = PTHREAD_ONCE_INIT;
+thread_local pthread_once_t transaction_manager_init_once_control = PTHREAD_ONCE_INIT;
 
 void transaction_set_worker_index(
         uint32_t worker_index) {

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -75,8 +75,10 @@ bool transaction_acquire(
     transaction->transaction_id.worker_index = transaction_manager_worker_index;
     transaction->transaction_id.transaction_index = transaction_manager_transaction_index;
 
+    // FFMA_OBJECT_SIZE_MIN should be 16 bytes, therefore the size of the locks list should be 16 / 8 = 2 by default
+    // and it should be enough for most of the cases
+    transaction->locks.size = FFMA_OBJECT_SIZE_MIN / sizeof(transaction_spinlock_lock_volatile_t*);
     transaction->locks.count = 0;
-    transaction->locks.size = 8;
     transaction->locks.list = ffma_mem_alloc(
             sizeof(transaction_spinlock_lock_volatile_t*) * transaction->locks.size);
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -66,8 +66,9 @@ bool transaction_acquire(
 
     transaction_manager_transaction_index++;
 
-    if (unlikely(transaction_manager_worker_index == 0 &&
-        transaction_manager_transaction_index == TRANSACTION_ID_NOT_ACQUIRED)) {
+    // Having both the worker index and the transaction index to 0 matches the transaction id not acquired value
+    // therefore we need to increment the transaction index by 1 to avoid it
+    if (unlikely(transaction_manager_worker_index == 0 && transaction_manager_transaction_index == 0)) {
         transaction_manager_transaction_index++;
     }
 

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -9,11 +9,12 @@ typedef struct transaction_spinlock_lock transaction_spinlock_lock_t;
 typedef _Volatile(transaction_spinlock_lock_t) transaction_spinlock_lock_volatile_t;
 
 typedef struct transaction_id transaction_id_t;
+typedef _Volatile(transaction_id_t) transaction_id_volatile_t;
 struct transaction_id {
     union {
         struct {
-            uint16_t worker_index;
-            uint16_t transaction_index;
+            uint16_volatile_t transaction_index;
+            uint16_volatile_t worker_index;
         };
         uint32_volatile_t id;
     };
@@ -21,7 +22,7 @@ struct transaction_id {
 
 typedef struct transaction transaction_t;
 struct transaction {
-    transaction_id_t transaction_id;
+    transaction_id_volatile_t transaction_id;
     struct {
         uint32_t count;
         uint32_t size;


### PR DESCRIPTION
This PR fixes a sneaky issue in the hashtable locking, the construct used to get the worker index only once per thread was actually being called only the very first time by only one thread causing all the other threads to have a worker_index of 0.

As consequence the locking was potentially generating overlappy transaction ids leading to a potential clash.

This behaviour was put in evidence by redis-benchmark which uses only 1 single key for all the requests unless the `--threads` option is passed.

The PR also changes 2 other aspects:
- drops the pthread_once, as it's necessary to check per thread a simple boolean can do the job and simplify the checks and the logic, and also providing a minor but nice speed improvement.
- reduce the amount of spinlock traced by defaylt to reduce the amount of memory allocated, infact the vast majority of cases need just 1 spinlock tracked therefore the size of the list initialized by default has been set to the size of the smallest object that can be initialized by FFMA, 16 bytes.