### PR TITLE
Bug catch negative counters

### DIFF
--- a/src/storage/db/storage_db_counters.c
+++ b/src/storage/db/storage_db_counters.c
@@ -105,6 +105,8 @@ void storage_db_counters_sum_global(
         next_slot_index = found_slot_index + 1;
         workers_to_find--;
     }
+    assert(counters->keys_count >= 0);
+    assert(counters->data_size >= 0);
 }
 
 void storage_db_counters_sum_per_db(

--- a/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
+++ b/src/worker/fiber/worker_fiber_storage_db_keys_eviction.c
@@ -37,7 +37,7 @@
 
 #include "worker_fiber_storage_db_keys_eviction.h"
 
-#define TAG "worker_fiber_storage_db_initialize"
+#define TAG "worker_fiber_storage_db_keys_eviction"
 
 thread_local bool worker_fiber_storage_db_keys_eviction_fiber_negative_counters_reported = false;
 
@@ -92,16 +92,19 @@ void worker_fiber_storage_db_keys_eviction_fiber_entrypoint(
                 continue;
             }
 
-            if (unlikely(
-                    (counters.keys_count <= 0 || counters.data_size <= 0) &&
-                    !worker_fiber_storage_db_keys_eviction_fiber_negative_counters_reported)) {
-                LOG_E(
-                        TAG,
-                        "The counters are invalid, keys_count=%ld, data_size=%ld",
-                        counters.keys_count,
-                        counters.data_size);
+            if (unlikely(counters.keys_count <= 0 || counters.data_size <= 0)) {
+                if (unlikely(!worker_fiber_storage_db_keys_eviction_fiber_negative_counters_reported)) {
+                    LOG_E(
+                            TAG,
+                            "The counters are invalid, keys_count=%ld, data_size=%ld",
+                            counters.keys_count,
+                            counters.data_size);
 
-                worker_fiber_storage_db_keys_eviction_fiber_negative_counters_reported = true;
+                    worker_fiber_storage_db_keys_eviction_fiber_negative_counters_reported = true;
+                }
+
+                last_run = clock_monotonic_coarse_int64_ms();
+                continue;
             }
 
             // Run the eviction


### PR DESCRIPTION
This PR introduces a check to catch negative counters.

In some circumstances the counters can go temporarely negative and although cachegrand can be require to be restarted, currently only the fiber that evicts the keys is impacted.

The code changes therefore will prevent the keys eviction from running and will report once the anomaly.