### PR TITLE
Distinguish between failures during prep or during processing

### DIFF
--- a/src/module/redis/fiber/module_redis_fiber_storage_db_snapshot_rdb.c
+++ b/src/module/redis/fiber/module_redis_fiber_storage_db_snapshot_rdb.c
@@ -119,7 +119,7 @@ void module_redis_fiber_storage_db_snapshot_rdb_fiber_entrypoint(
             storage_db_snapshot_rdb_flush_entry_index_to_be_deleted_queue(db);
 
             // Mark the snapshot as failed
-            storage_db_snapshot_failed(db);
+            storage_db_snapshot_failed(db, false);
         }
 
         // Release the lock

--- a/src/storage/db/storage_db_snapshot.h
+++ b/src/storage/db/storage_db_snapshot.h
@@ -28,7 +28,8 @@ void storage_db_snapshot_completed(
         storage_db_snapshot_status_t status);
 
 void storage_db_snapshot_failed(
-        storage_db_t *db);
+        storage_db_t *db,
+        bool during_preparation);
 
 bool storage_db_snapshot_enough_keys_data_changed(
         storage_db_t *db);
@@ -46,6 +47,9 @@ void storage_db_snapshot_wait_for_prepared(
         storage_db_t *db);
 
 bool storage_db_snapshot_rdb_prepare(
+        storage_db_t *db);
+
+bool storage_db_snapshot_is_failed(
         storage_db_t *db);
 
 bool storage_db_snapshot_rdb_ensure_prepared(


### PR DESCRIPTION
This PR fixes a bug in the design of how failures are handled by the snapshotting process introducing a flag to identify if a failure happened during the preparation phase or during the processing.

It's not a perfect solution, as currently it's woking because there are only 2 kind of failures, but any additional failure status would require anyway some major changes therefore for now it's good enough.