### PR TITLE
Disable required authentication by default

### DIFF
--- a/etc/cachegrand.yaml.skel
+++ b/etc/cachegrand.yaml.skel
@@ -38,17 +38,17 @@ modules:
 
       # If enabled, the client will have to authenticate before being able to execute any command, the password field
       # will be mandatory
-      require_authentication: true
+      require_authentication: false
 
       # Username, optional, if not set, the username will be set to "default"
       # username: "default"
 
       # Password, required when require_authentication is enabled
-      password: "changeme"
+      # password: "changeme"
 
-#      # List of commands that can be disabled for security reasons, optional
-#       disabled_commands:
-#       - "mset"
+      # List of commands that can be disabled for security reasons, optional
+      # disabled_commands:
+      # - "mset"
 
     network:
       # Timeouts for the read and write operations in milliseconds, set to -1 to disable or greater than 0 to enable


### PR DESCRIPTION
This PR disables the required authentication enabled by default in the skel config file.

It additional fix some style issues.