### PR TITLE
Fix tls handshake wait blocks listener accept

### DIFF
--- a/src/network/channel/network_channel.h
+++ b/src/network/channel/network_channel.h
@@ -66,6 +66,7 @@ struct network_channel {
     } buffers;
     struct {
         bool enabled;
+        bool handshake_completed;
         bool ktls;
         bool mbedtls;
         void *context;

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -76,10 +76,19 @@ int network_channel_tls_receive_internal_mbed(
         void *context,
         unsigned char *buffer,
         size_t buffer_length) {
-    return worker_op_network_receive(
-            context,
-            (char *)buffer,
-            buffer_length);
+    network_channel_t *channel = context;
+    if (likely(network_channel_tls_is_handshake_completed(channel))) {
+        return worker_op_network_receive(
+                context,
+                (char *)buffer,
+                buffer_length);
+    } else {
+        return worker_op_network_receive_timeout(
+                context,
+                (char *)buffer,
+                buffer_length,
+                500);
+    }
 }
 
 bool network_channel_tls_ktls_supports_mbedtls_cipher_suite(

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -160,6 +160,8 @@ bool network_channel_tls_handshake(
         }
     } while(!exit);
 
+    network_channel_tls_set_handshake_completed(network_channel, return_res);
+
     return return_res;
 }
 

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -408,7 +408,10 @@ bool network_channel_tls_shutdown(
 
 void network_channel_tls_free(
         network_channel_t *network_channel) {
-    assert(network_channel->tls.context != NULL);
+    if (network_channel->tls.context == NULL) {
+        return;
+    }
+
     mbedtls_ssl_free(network_channel->tls.context);
     ffma_mem_free(network_channel->tls.context);
     network_channel->tls.context = NULL;

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -401,6 +401,17 @@ bool network_channel_tls_uses_mbedtls(
     return network_channel->tls.mbedtls;
 }
 
+bool network_channel_tls_is_handshake_completed(
+        network_channel_t *network_channel) {
+    return network_channel->tls.handshake_completed;
+}
+
+void network_channel_tls_set_handshake_completed(
+        network_channel_t *network_channel,
+        bool handshake_completed) {
+    network_channel->tls.handshake_completed = handshake_completed;
+}
+
 bool network_channel_tls_shutdown(
         network_channel_t *network_channel) {
     return mbedtls_ssl_close_notify(network_channel->tls.context) == 0;

--- a/src/network/channel/network_channel_tls.h
+++ b/src/network/channel/network_channel_tls.h
@@ -70,6 +70,13 @@ void network_channel_tls_set_mbedtls(
 bool network_channel_tls_uses_mbedtls(
         network_channel_t *network_channel);
 
+bool network_channel_tls_is_handshake_completed(
+        network_channel_t *network_channel);
+
+void network_channel_tls_set_handshake_completed(
+        network_channel_t *network_channel,
+        bool handshake_completed);
+
 bool network_channel_tls_shutdown(
         network_channel_t *network_channel);
 

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -394,8 +394,9 @@ network_op_result_t network_close(
         // Free up the memory
         network_channel_tls_free(channel);
 
-        // Mark the connection as not using TLS anymore
+        // Mark the connection as not using TLS anymore and reset all the TLS related flags
         network_channel_tls_set_enabled(channel, false);
+        network_channel_tls_set_handshake_completed(channel, false);
         network_channel_tls_set_mbedtls(channel, false);
         network_channel_tls_set_ktls(channel, false);
     }

--- a/src/worker/network/worker_network_iouring_op.c
+++ b/src/worker/network/worker_network_iouring_op.c
@@ -395,6 +395,23 @@ int32_t worker_network_iouring_op_network_receive_internal(
     return res;
 }
 
+int32_t worker_network_iouring_op_network_receive_timeout(
+        network_channel_t *channel,
+        char* buffer,
+        size_t buffer_length,
+        uint32_t timeout_ms) {
+    kernel_timespec_t kernel_timespec = {
+            .tv_sec = timeout_ms / 1000,
+            .tv_nsec = (timeout_ms % 1000) * 1000000,
+    };
+
+    return worker_network_iouring_op_network_receive_internal(
+            channel,
+            buffer,
+            buffer_length,
+            &kernel_timespec);
+}
+
 int32_t worker_network_iouring_op_network_receive(
         network_channel_t *channel,
         char* buffer,
@@ -541,6 +558,7 @@ bool worker_network_iouring_op_register() {
     worker_op_network_channel_free = worker_network_iouring_network_channel_free;
     worker_op_network_accept = worker_network_iouring_op_network_accept;
     worker_op_network_receive = worker_network_iouring_op_network_receive;
+    worker_op_network_receive_timeout = worker_network_iouring_op_network_receive_timeout;
     worker_op_network_send = worker_network_iouring_op_network_send;
     worker_op_network_close = worker_network_iouring_op_network_close;
 

--- a/src/worker/network/worker_network_iouring_op.h
+++ b/src/worker/network/worker_network_iouring_op.h
@@ -22,6 +22,12 @@ bool worker_network_iouring_op_network_close(
         network_channel_t *channel,
         bool shutdown_may_fail);
 
+int32_t worker_network_iouring_op_network_receive_timeout(
+        network_channel_t *channel,
+        char* buffer,
+        size_t buffer_length,
+        uint32_t timeout_ms);
+
 int32_t worker_network_iouring_op_network_receive(
         network_channel_t *channel,
         char* buffer,

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -72,6 +72,7 @@ worker_op_network_channel_size_fp_t* worker_op_network_channel_size;
 worker_op_network_channel_free_fp_t* worker_op_network_channel_free;
 worker_op_network_accept_fp_t* worker_op_network_accept;
 worker_op_network_receive_fp_t* worker_op_network_receive;
+worker_op_network_receive_timeout_fp_t* worker_op_network_receive_timeout;
 worker_op_network_send_fp_t* worker_op_network_send;
 worker_op_network_close_fp_t* worker_op_network_close;
 

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -286,20 +286,87 @@ void worker_network_new_client_fiber_entrypoint(
 
     network_channel_t *new_channel = user_data;
     bool tls_enabled = new_channel->tls.enabled;
+    bool tls_handshake_completed = false;
 
     stats->network.active_connections++;
-    if (tls_enabled) {
-        stats->network.active_tls_connections++;
-    }
-
     stats->network.accepted_connections++;
+
     if (tls_enabled) {
+        if (unlikely(!network_channel_tls_init(new_channel))) {
+            LOG_W(
+                    TAG,
+                    "TLS setup failed for the connection <%s>",
+                    new_channel->address.str);
+            goto end;
+        }
+
+        if (unlikely(!network_channel_tls_handshake(new_channel))) {
+            LOG_V(
+                    TAG,
+                    "TLS handshake failed for the connection <%s>",
+                    new_channel->address.str);
+            goto end;
+        }
+
+        tls_handshake_completed = true;
+        stats->network.active_tls_connections++;
         stats->network.accepted_tls_connections++;
+
+        if (network_channel_tls_ktls_supports_mbedtls_cipher_suite(new_channel)) {
+            LOG_D(
+                    TAG,
+                    "kTLS supports the cipher, it can be enabled for the connection <%s>",
+                    new_channel->address.str);
+            if (network_channel_tls_setup_ktls(new_channel)) {
+                // Enable kTLS and ensure mbedtls is disabled
+                network_channel_tls_set_ktls(
+                        new_channel,
+                        true);
+                network_channel_tls_set_mbedtls(
+                        new_channel,
+                        false);
+
+                LOG_D(
+                        TAG,
+                        "kTLS successfully enabled for connection <%s>",
+                        new_channel->address.str);
+            } else {
+                LOG_D(
+                        TAG,
+                        "Failed to enable kTLS for the connection <%s>, switching to mbedtls",
+                        new_channel->address.str);
+            }
+        }
+
+        // If kTLS can't be enabled or its activation fails, enable mbedtls
+        if (!network_channel_tls_uses_ktls(new_channel)) {
+            network_channel_tls_set_mbedtls(
+                    new_channel,
+                    true);
+        }
+
+        // If the client has sent a client certificate, report the common name in the logs
+        if (network_channel_tls_has_peer_certificate(new_channel)) {
+            const char *cn = NULL;
+            size_t cn_length = 0;
+
+            if (network_channel_tls_peer_certificate_get_cn(
+                    new_channel,
+                    &cn,
+                    &cn_length)) {
+                LOG_D(
+                        TAG,
+                        "TLS client certificate common name: %.*s",
+                        (int)cn_length,
+                        cn);
+            }
+        }
     }
 
     // Handover the new connection to the module
     module_get_by_id(new_channel->module_id)->connection_accept(new_channel);
 
+end:
     // TODO: when it gets here new_channel might have been already freed, the flow should always close the connection
     //       the connection here and not from within the module
     if (new_channel->status != NETWORK_CHANNEL_STATUS_CLOSED) {
@@ -308,7 +375,10 @@ void worker_network_new_client_fiber_entrypoint(
 
     // Updates the amount of active connections
     stats->network.active_connections--;
-    if (tls_enabled) {
+
+    // Check if tls was enabled at the beginning of the connection, as the channel, when it gets closed, has its
+    // properties, including tls.enabled, reset to the default values
+    if (tls_enabled && tls_handshake_completed) {
         stats->network.active_tls_connections--;
     }
 

--- a/src/worker/network/worker_network_op.h
+++ b/src/worker/network/worker_network_op.h
@@ -40,6 +40,12 @@ typedef int32_t (worker_op_network_receive_fp_t)(
         char* buffer,
         size_t buffer_length);
 
+typedef int32_t (worker_op_network_receive_timeout_fp_t)(
+        network_channel_t *channel,
+        char* buffer,
+        size_t buffer_length,
+        uint32_t timeout_ms);
+
 typedef int32_t (worker_op_network_send_fp_t)(
         network_channel_t *channel,
         char* buffer,
@@ -78,6 +84,7 @@ extern worker_op_network_channel_multi_free_fp_t* worker_op_network_channel_mult
 extern worker_op_network_channel_free_fp_t* worker_op_network_channel_free;
 extern worker_op_network_accept_fp_t* worker_op_network_accept;
 extern worker_op_network_receive_fp_t* worker_op_network_receive;
+extern worker_op_network_receive_timeout_fp_t* worker_op_network_receive_timeout;
 extern worker_op_network_send_fp_t* worker_op_network_send;
 extern worker_op_network_close_fp_t* worker_op_network_close;
 extern worker_op_network_channel_size_fp_t* worker_op_network_channel_size;


### PR DESCRIPTION
This PR changes when the TLS handshake is performed as currently a TCP/IP connection initiated on a TLS-enabled port will prevent the listener from starting its accept wait-loop until it completes the handshakes or fails it.

As consequence of the implementation, this behaviour can easily be used for DDOS attacks.

The PR moves the TLS handshake into the fiber created to handle the incoming connection ensuring that the TLS handshake itself will run the read and write operations in that fiber and not in the listener fiber leaving the listener fiber able to go back to accepting new connections.

To further improve the security, also a new flag to track the handshake status has been introduced and it's used to decide how much time a receive operation shall wait: if set to false, the receive operation will only wait up to 500ms for each read, ensuring that stalling TCP/IP connections over a TLS-enabled port will not saturate the allowed connections for no reason.
As part of this additional implementation, a new receive timeout callback has been introduced in the worker network stack and its counterpart in the io_uring worker network stack support has been implemented.