### PR TITLE
Bug fix tls redis benchmark

### DIFF
--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -164,7 +164,7 @@ bool network_channel_tls_handshake(
 
             default:
                 mbedtls_strerror(res, err_buffer, sizeof(err_buffer) - 1);
-                LOG_V(TAG, "Failed to perform the TLS handshake because <%s>", err_buffer);
+                LOG_V(TAG, "[FD:%5d] Failed to perform the TLS handshake because <%s>", network_channel->fd, err_buffer);
                 exit = true;
         }
     } while(!exit);

--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -87,7 +87,7 @@ int network_channel_tls_receive_internal_mbed(
                 context,
                 (char *)buffer,
                 buffer_length,
-                500);
+                2000);
     }
 }
 

--- a/src/network/network_tls.c
+++ b/src/network/network_tls.c
@@ -413,16 +413,7 @@ void network_tls_close_internal(
     int32_t res;
     while((res = mbedtls_ssl_close_notify(channel->tls.context)) < 0) {
         if (res != MBEDTLS_ERR_SSL_WANT_READ && res != MBEDTLS_ERR_SSL_WANT_WRITE) {
-            char errbuf[256] = { 0 };
-            mbedtls_strerror(res, errbuf, sizeof(errbuf) - 1);
-
-            LOG_V(
-                    TAG,
-                    "[FD:%5d][ERROR CLIENT] Error <%s (%d)> from client <%s>",
-                    channel->fd,
-                    errbuf,
-                    -res,
-                    channel->address.str);
+            break;
         }
     }
 }
@@ -455,7 +446,7 @@ network_op_result_t network_tls_receive_internal(
 
             return NETWORK_OP_RESULT_CLOSE_SOCKET;
         } else if (res == -ECANCELED) {
-            LOG_I(
+            LOG_V(
                     TAG,
                     "[FD:%5d][ERROR CLIENT] Send timeout to client <%s>",
                     channel->fd,
@@ -465,7 +456,7 @@ network_op_result_t network_tls_receive_internal(
             char errbuf[256] = { 0 };
             mbedtls_strerror(res, errbuf, sizeof(errbuf) - 1);
 
-            LOG_I(
+            LOG_V(
                     TAG,
                     "[FD:%5d][ERROR CLIENT] Error <%s (%d)> from client <%s>",
                     channel->fd,
@@ -517,7 +508,7 @@ network_op_result_t network_tls_send_direct_internal(
 
             return NETWORK_OP_RESULT_CLOSE_SOCKET;
         } else if (res == -ECANCELED) {
-            LOG_I(
+            LOG_V(
                     TAG,
                     "[FD:%5d][ERROR CLIENT] Send timeout to client <%s>",
                     channel->fd,
@@ -527,7 +518,7 @@ network_op_result_t network_tls_send_direct_internal(
             char errbuf[256] = { 0 };
             mbedtls_strerror(res, errbuf, sizeof(errbuf) - 1);
 
-            LOG_I(
+            LOG_V(
                     TAG,
                     "[FD:%5d][ERROR CLIENT] Error <%s (%d)> from client <%s>",
                     channel->fd,

--- a/src/worker/network/worker_network_op.c
+++ b/src/worker/network/worker_network_op.c
@@ -295,7 +295,8 @@ void worker_network_new_client_fiber_entrypoint(
         if (unlikely(!network_channel_tls_init(new_channel))) {
             LOG_W(
                     TAG,
-                    "TLS setup failed for the connection <%s>",
+                    "[FD:%5d] TLS setup failed for the connection <%s>",
+                    new_channel->fd,
                     new_channel->address.str);
             goto end;
         }
@@ -303,7 +304,8 @@ void worker_network_new_client_fiber_entrypoint(
         if (unlikely(!network_channel_tls_handshake(new_channel))) {
             LOG_V(
                     TAG,
-                    "TLS handshake failed for the connection <%s>",
+                    "[FD:%5d] TLS handshake failed for the connection <%s>",
+                    new_channel->fd,
                     new_channel->address.str);
             goto end;
         }


### PR DESCRIPTION
This PR raise the read timeout used for the TLS connections that haven't done the handshake yet previously introduced to 2 seconds as redis-benchmark will not carry it out until all the connections have been established.

The new value is 2 seconds to guarantee that there is plenty of time to establish the connections with the default settings.

The PR also improve the logging reducing the verbosity.