### PR TITLE
Further increase to 7.5s the tls receive before the handshake is completed

### DIFF
--- a/src/network/channel/network_channel_tls.c
+++ b/src/network/channel/network_channel_tls.c
@@ -87,7 +87,7 @@ int network_channel_tls_receive_internal_mbed(
                 context,
                 (char *)buffer,
                 buffer_length,
-                2000);
+                7500);
     }
 }
 


### PR DESCRIPTION
Further increase the TLS receive timeout before the handshake is completed to 7.5 seconds.

The redis-benchmark tool performs the connections sequentially and kicks off the handshake only at the very end of the process, with 100ms of connection latency will take up to 5 seconds for 50 connections therefore the new value is set to 7.5 to take into account a reasonable margin for slow connections.