### PR TITLE
Fix the month reported in the logs' timestamp

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -91,7 +91,7 @@ char* log_message_timestamp_str(
     gmtime_r(&timestamp, &tm);
 
     snprintf(dest, maxlen, "%04d-%02d-%02dT%02d:%02d:%02dZ",
-             1900 + tm.tm_year, tm.tm_mon, tm.tm_mday,
+             1900 + tm.tm_year, tm.tm_mon + 1, tm.tm_mday,
              tm.tm_hour, tm.tm_min, tm.tm_sec);
 
     return dest;

--- a/tests/unit_tests/log/test-log.cpp
+++ b/tests/unit_tests/log/test-log.cpp
@@ -121,7 +121,7 @@ TEST_CASE("log/log.c", "[log]") {
         char timestamp_dest_cmp[100] = { 0 };
         snprintf(timestamp_dest_cmp, sizeof(timestamp_dest_cmp),
                  "%04d-%02d-%02dT%02d:%02d:%02dZ",
-                 1900 + tm_cmp.tm_year, tm_cmp.tm_mon, tm_cmp.tm_mday,
+                 1900 + tm_cmp.tm_year, tm_cmp.tm_mon + 1, tm_cmp.tm_mday,
                  tm_cmp.tm_hour, tm_cmp.tm_min, tm_cmp.tm_sec);
 
         SECTION("validate format") {


### PR DESCRIPTION
This PR fixes the month reported in the logs' timestamp incrementing the month value returned by gmtime by 1, as gmtime returns the month from 0 to 11.