### PR TITLE
Mark as not in preparation after a snapshot failure

### DIFF
--- a/src/storage/db/storage_db_snapshot.c
+++ b/src/storage/db/storage_db_snapshot.c
@@ -366,6 +366,9 @@ end:
         if (snapshot_fd > 0) {
             close(snapshot_fd);
         }
+
+        db->snapshot.in_preparation = false;
+        MEMORY_FENCE_STORE();
     }
 
     return result;


### PR DESCRIPTION
This PR changes the snapshot business logic ensuring that if the preparation stage fails the status of in_preparation is switched back to false after the failure is internally reported.