### PR TITLE
Rely on read tx for the hashtable consistency

### DIFF
--- a/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_armv8a_neon.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_armv8a_neon.h
@@ -18,13 +18,11 @@
 #include "hashtable.h"
 #include "hashtable_support_hash_search.h"
 
-static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_armv8a_neon_14(
+static inline uint32_t hashtable_mcmp_support_hash_search_armv8a_neon_14(
         hashtable_hash_half_t hash,
-        hashtable_hash_half_volatile_t* hashes,
-        uint32_t skip_indexes_mask) {
+        hashtable_hash_half_volatile_t* hashes) {
     uint32x4_t tmp;
     uint32_t compacted_result_mask = 0;
-    uint32_t skip_indexes_mask_inv = ~skip_indexes_mask;
     static const int32x4_t shift = {0, 1, 2, 3};
 
     uint32x4_t cmp_vector = vdupq_n_u32(hash);
@@ -49,6 +47,5 @@ static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_ar
     tmp = vshrq_n_u32(cmp_vector_10_13, 31);
     compacted_result_mask |=  vaddvq_u32(vshlq_u32(tmp, shift)) << 10;
 
-
-    return __builtin_ctz(compacted_result_mask & skip_indexes_mask_inv);
+    return compacted_result_mask;
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_avx.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_avx.h
@@ -18,12 +18,10 @@
 #include "hashtable.h"
 #include "hashtable_support_hash_search.h"
 
-static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_avx_14(
+static inline uint32_t hashtable_mcmp_support_hash_search_avx_14(
         hashtable_hash_half_t hash,
-        hashtable_hash_half_volatile_t* hashes,
-        uint32_t skip_indexes_mask) {
+        hashtable_hash_half_volatile_t* hashes) {
     uint32_t compacted_result_mask = 0;
-    uint32_t skip_indexes_mask_inv = ~skip_indexes_mask;
     __m256 cmp_vector = _mm256_castsi256_ps(_mm256_set1_epi32(hash));
 
     // The second load, load from the 6th uint32 to the 14th uint32, _mm256_loadu_si256 always loads 8 x uint32
@@ -35,5 +33,5 @@ static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_av
         compacted_result_mask |= (uint32_t)_mm256_movemask_ps(result_mask_vector) << (base_index);
     }
 
-    return _tzcnt_u32(compacted_result_mask & skip_indexes_mask_inv);
+    return compacted_result_mask;
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_avx2.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_avx2.h
@@ -23,12 +23,10 @@
  *
  * https://stackoverflow.com/a/62123631/169278
  **/
-static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_avx2_14(
+static inline uint32_t hashtable_mcmp_support_hash_search_avx2_14(
         hashtable_hash_half_t hash,
-        hashtable_hash_half_volatile_t* hashes,
-        uint32_t skip_indexes_mask) {
+        hashtable_hash_half_volatile_t* hashes) {
     uint32_t compacted_result_mask = 0;
-    uint32_t skip_indexes_mask_inv = ~skip_indexes_mask;
     __m256i cmp_vector = _mm256_set1_epi32(hash);
 
     // The second load, load from the 6th uint32 to the 14th uint32, _mm256_loadu_si256 always loads 8 x uint32
@@ -40,5 +38,5 @@ static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_av
         compacted_result_mask |= (uint32_t)_mm256_movemask_ps(_mm256_castsi256_ps(result_mask_vector)) << (base_index);
     }
 
-    return _tzcnt_u32(compacted_result_mask & skip_indexes_mask_inv);
+    return compacted_result_mask;
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_avx512f.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_avx512f.h
@@ -18,15 +18,13 @@
 #include "hashtable.h"
 #include "hashtable_support_hash_search.h"
 
-static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_avx512f_14(
+static inline uint32_t hashtable_mcmp_support_hash_search_avx512f_14(
         hashtable_hash_half_t hash,
-        hashtable_hash_half_volatile_t* hashes,
-        uint32_t skip_indexes_mask) {
-    uint32_t skip_indexes_mask_inv = ~(skip_indexes_mask | 0xC000);
+        hashtable_hash_half_volatile_t* hashes) {
     __m512i cmp_vector = _mm512_set1_epi32(hash);
 
     __m512i ring_vector = _mm512_loadu_si512((__m512i*)hashes);
     uint32_t compacted_result_mask = _mm512_cmpeq_epi32_mask(ring_vector, cmp_vector);
 
-    return _tzcnt_u32(compacted_result_mask & skip_indexes_mask_inv);
+    return compacted_result_mask;
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_loop.h
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_hash_search_loop.h
@@ -17,25 +17,22 @@
 #include "hashtable.h"
 #include "hashtable_support_hash_search.h"
 
-static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_loop_n(
+static inline uint32_t hashtable_mcmp_support_hash_search_loop_n(
         hashtable_hash_half_t hash,
         hashtable_hash_half_volatile_t* hashes,
-        uint32_t skip_indexes_mask,
         uint8_t n) {
-    uint32_t skip_indexes_mask_inv = ~skip_indexes_mask;
+    uint32_t return_val = 0;
     for(uint8_t index = 0; index < n; index++) {
-        uint32_t index_bitshift = (1u << index);
-        if (hashes[index] == hash && (index_bitshift & skip_indexes_mask_inv) == index_bitshift) {
-            return index;
+        if (hashes[index] == hash) {
+            return_val |= 1u << index;
         }
     }
 
-    return HASHTABLE_MCMP_SUPPORT_HASH_SEARCH_NOT_FOUND;
+    return return_val;
 }
 
-static inline hashtable_chunk_slot_index_t hashtable_mcmp_support_hash_search_loop_14(
+static inline uint32_t hashtable_mcmp_support_hash_search_loop_14(
         hashtable_hash_half_t hash,
-        hashtable_hash_half_volatile_t* hashes,
-        uint32_t skip_indexes_mask) {
-    return hashtable_mcmp_support_hash_search_loop_n(hash, hashes, skip_indexes_mask, 14);
+        hashtable_hash_half_volatile_t* hashes) {
+    return hashtable_mcmp_support_hash_search_loop_n(hash, hashes, 14);
 }

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -67,11 +67,11 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
 
     LOG_DI("hash_half = %lu", hash_half);
     LOG_DI("bucket_index = %lu", bucket_index);
-    LOG_DI("chunk_index_start = %lu", chunk_index_start_initial);
-    LOG_DI("hashtable_data->chunks_count = %lu", hashtable_data->chunks_count);
-    LOG_DI("hashtable_data->buckets_count = %lu", hashtable_data->buckets_count);
+    if (unlikely(!transaction_lock_for_read(transaction, &half_hashes_chunk->lock))) {
+        return false;
+    }
     LOG_DI("hashtable_data->buckets_count_real = %lu", hashtable_data->buckets_count_real);
-    LOG_DI("half_hashes_chunk->lock.lock = %d", half_hashes_chunk->lock.internal_data.transaction_id);
+    overflowed_chunks_counter = half_hashes_chunk->metadata.overflowed_chunks_counter;
     LOG_DI("half_hashes_chunk->metadata.is_full = %lu", half_hashes_chunk->metadata.is_full);
     LOG_DI("half_hashes_chunk->metadata.slots_occupied = %lu", half_hashes_chunk->metadata.slots_occupied);
     LOG_DI("half_hashes_chunk->metadata.overflowed_chunks_counter = %lu", overflowed_chunks_counter);

--- a/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
+++ b/src/data_structures/hashtable/mcmp/hashtable_support_op_arch.c
@@ -100,9 +100,13 @@ bool CONCAT(hashtable_mcmp_support_op_search_key, CACHEGRAND_HASHTABLE_MCMP_SUPP
             continue;
         }
 
-        // Increment the readers counter
+        // The first chunk is locked initially to read the overflowed_chunks_counter
+        if (likely(chunk_index != chunk_index_start_initial)) {
+            // Increment the readers counter (it will issue an atomic increment which will sync the cachelines as needed
+            // mimicking a memory fence)
         if (unlikely(!transaction_lock_for_read(transaction, &half_hashes_chunk->lock))) {
             return false;
+        }
         }
 
         skip_indexes_mask = 0;

--- a/src/storage/db/storage_db.c
+++ b/src/storage/db/storage_db.c
@@ -1082,7 +1082,7 @@ storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(
                 key_length,
                 &rmw_status,
                 &current_entry_index))) {
-            return NULL;
+            goto end_expired;
         }
 
         // If the current entry index still matches entry index the storage_db_op_rmw_abort will carry out the clean up
@@ -1099,7 +1099,9 @@ storage_db_entry_index_t *storage_db_get_entry_index_for_read_prep(
             storage_db_op_rmw_commit_delete(db, &rmw_status);
         }
 
+end_expired:
         entry_index = NULL;
+        transaction_release(&transaction);
     }
 
     return entry_index;

--- a/src/thread.h
+++ b/src/thread.h
@@ -8,7 +8,11 @@ extern "C" {
 extern thread_local uint32_t thread_current_core_index;
 extern thread_local uint32_t thread_current_numa_node_index;
 
+#ifdef __cplusplus
+extern int getcpu (unsigned int *, unsigned int *) __THROW;
+#else
 extern int getcpu (unsigned int *, unsigned int *);
+#endif
 
 void thread_flush_cached_core_index_and_numa_node_index();
 

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -159,11 +159,13 @@ static inline __attribute__((always_inline)) bool transaction_rwspinlock_write_l
 
 static inline __attribute__((always_inline)) void transaction_rwspinlock_readers_increment(
         transaction_rwspinlock_volatile_t *spinlock) {
+    assert(spinlock->internal_data.readers_count < UINT16_MAX);
     __sync_fetch_and_add(&spinlock->internal_data.readers_count, 1);
 }
 
 static inline __attribute__((always_inline)) void transaction_rwspinlock_readers_decrement(
         transaction_rwspinlock_volatile_t *spinlock) {
+    assert(spinlock->internal_data.readers_count > 0);
     __sync_fetch_and_sub(&spinlock->internal_data.readers_count, 1);
 }
 

--- a/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash-search.cpp
+++ b/tests/unit_tests/data_structures/hashtable/mpmc/test-hashtable-mpmc-support-hash-search.cpp
@@ -45,9 +45,8 @@
                     123, 234, 345, 456, 567, 678, 789, 890, 901, 12, 987, 876, 765, 654 \
             }; \
             hashtable_hash_half_t hash = 345; \
-            uint32_t skip_indexes_mask = 0; \
         \
-            REQUIRE(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == 2); \
+            REQUIRE(__builtin_ctz(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes)) == 2); \
         } \
         \
         SECTION("hash - not found") { \
@@ -55,9 +54,8 @@
                     123, 234, 345, 456, 567, 678, 789, 890, 901, 12, 987, 876, 765, 654 \
             }; \
             hashtable_hash_half_t hash = 999999; \
-            uint32_t skip_indexes_mask = 0; \
         \
-            REQUIRE(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == HASHTABLE_HALF_HASHES_CHUNK_SEARCH_MAX); \
+            REQUIRE(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes) == 0); \
         } \
         \
         SECTION("hash - multiple - find first") { \
@@ -65,19 +63,8 @@
                     123, 234, 345, 456, 567, 234, 789, 890, 901, 234, 987, 876, 765, 654 \
             }; \
             hashtable_hash_half_t hash = 234; \
-            uint32_t skip_indexes_mask = 0; \
         \
-            REQUIRE(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == 1); \
-        } \
-        \
-        SECTION("hash - multiple - find second") { \
-            hashtable_hash_half_volatile_t hashes[HASHTABLE_MCMP_HALF_HASHES_CHUNK_SLOTS_COUNT] = { \
-                    123, 234, 345, 456, 567, 234, 789, 890, 901, 234, 987, 876, 765, 654 \
-            }; \
-            hashtable_hash_half_t hash = 234; \
-            uint32_t skip_indexes_mask = 1 << 1; \
-        \
-            REQUIRE(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes, skip_indexes_mask) == 5); \
+            REQUIRE(__builtin_ctz(hashtable_mcmp_support_hash_search##SUFFIX(hash, hashes)) == 1); \
         } \
     }
 


### PR DESCRIPTION
Now that every operation on the hashtable is always behind a read or write transaction, it's not necessary to have to rely on a tricky logic and memory fences to ensure that a read will never cause an issue if a write changes something as they will never run in parallel.

The PR drops the memory fences, introduces some minor optimizations now that reads are consistent and clean up a lot of unnecessary logging.

The PR also contains a minor fix for a build warning when building C++ code (e.g. benchmarks or tests) and the necessary changes to update the set benchmark for the hashtable to the new paradigm implemented.