### PR TITLE
Add build for ubuntu 24.04 when merging PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: danielealbano/lcov-action@v4
         with:
           gcov_path: /usr/bin/gcov-12
-          remove_patterns: 3rdparty,tests,catch2
+          remove_patterns: 3rdparty,tests,build/_deps
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,6 +33,14 @@ jobs:
             cxx: "g++-13",
             gcov: "gcov-13"
           }
+          - {
+            name: "Ubuntu 24.04 - GCC 14",
+            os: ubuntu-24.04,
+            triplet: x64-linux,
+            cc: "gcc-14",
+            cxx: "g++-14",
+            gcov: "gcov-14"
+          }
 
     steps:
       - name: Setup cmake

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         config:
           - {
-            name: "Ubuntu 22.04",
+            name: "Ubuntu 22.04 - GCC 12",
             os: ubuntu-22.04,
             triplet: x64-linux,
             cc: "gcc-12",

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,10 +58,10 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
 
-      - name: Build cachegrand-server
-        working-directory: ${{github.workspace}}/build
-        shell: bash
-        run: cmake --build . --target cachegrand-server -- -j $(nproc)
+#      - name: Build cachegrand-server
+#        working-directory: ${{github.workspace}}/build
+#        shell: bash
+#        run: cmake --build . --target cachegrand-server -- -j $(nproc)
 
       - name: Build cachegrand-tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: danielealbano/lcov-action@v4
         with:
           gcov_path: /usr/bin/gcov-12
-          remove_patterns: 3rdparty,tests,build/_deps
+          remove_patterns: 3rdparty,tests,./build/_deps,_deps
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,13 @@ jobs:
             cc: "gcc",
             cxx: "g++"
           }
+          - {
+            name: "Ubuntu 24.04",
+            os: ubuntu-24.04,
+            triplet: x64-linux,
+            cc: "gcc",
+            cxx: "g++"
+          }
 
     steps:
       - name: Setup cmake

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,10 +58,10 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
 
-#      - name: Build cachegrand-server
-#        working-directory: ${{github.workspace}}/build
-#        shell: bash
-#        run: cmake --build . --target cachegrand-server -- -j $(nproc)
+      - name: Build cachegrand-server
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: cmake --build . --target cachegrand-server -- -j $(nproc)
 
       - name: Build cachegrand-tests
         working-directory: ${{github.workspace}}/build
@@ -74,10 +74,11 @@ jobs:
         run: cd tests/unit_tests && sudo ./cachegrand-tests --order lex
 
       - name: Code Coverage - Generation
-        uses: danielealbano/lcov-action@v4
+        uses: danielealbano/lcov-action@v4.1
         with:
           gcov_path: /usr/bin/gcov-12
           remove_patterns: 3rdparty,tests,./build/_deps,_deps
+          extra_args: '--ignore-errors source --rc geninfo_unexecuted_blocks=1'
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,15 +58,10 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
 
-      - name: Build cachegrand-tests
+      - name: Build cachegrand-server and cachegrand-tests
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --target cachegrand-tests -- -j $(nproc)
-
-      - name: Build cachegrand-server
-        working-directory: ${{github.workspace}}/build
-        shell: bash
-        run: cmake --build . --target cachegrand-server -- -j $(nproc)
+        run: cmake --build . --target cachegrand-server cachegrand-tests  -- -j $(nproc)
 
       - name: Tests - Unit Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install required dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake pkg-config git libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev libmbedtls-dev libpcre2-8-0 libpcre2-dev libjson-c-dev valgrind libhiredis-dev liblzf-dev redis-tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake pkg-config git libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev libmbedtls-dev libpcre2-8-0 libpcre2-dev libjson-c-dev valgrind libhiredis-dev liblzf-dev redis-tools gcc-12 g++-12
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -56,7 +56,7 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{github.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
+        run: CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
 
       - name: Build cachegrand-tests
         working-directory: ${{github.workspace}}/build
@@ -74,7 +74,7 @@ jobs:
         run: cd tests/unit_tests && sudo ./cachegrand-tests --order lex
 
       - name: Code Coverage - Generation
-        uses: danielealbano/lcov-action@v3
+        uses: danielealbano/lcov-action@v4
         with:
           gcov_path: /usr/bin/gcov-12
           remove_patterns: 3rdparty,tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Code Coverage - Generation
         uses: danielealbano/lcov-action@v3
         with:
-          gcov_path: /usr/bin/gcov-9
+          gcov_path: /usr/bin/gcov
           remove_patterns: 3rdparty,tests
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: danielealbano/lcov-action@v4
         with:
           gcov_path: /usr/bin/gcov-12
-          remove_patterns: 3rdparty,tests
+          remove_patterns: 3rdparty,tests,catch2
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,10 +58,15 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
 
-      - name: Build cachegrand-server and cachegrand-tests
+      - name: Build cachegrand-server
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --target cachegrand-server cachegrand-tests  -- -j $(nproc)
+        run: cmake --build . --target cachegrand-server -- -j $(nproc)
+
+      - name: Build cachegrand-tests
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: cmake --build . --target cachegrand-tests -- -j $(nproc)
 
       - name: Tests - Unit Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Code Coverage - Generation
         uses: danielealbano/lcov-action@v3
         with:
-          gcov_path: /usr/bin/gcov
+          gcov_path: /usr/bin/gcov-12
           remove_patterns: 3rdparty,tests
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,15 +21,17 @@ jobs:
             name: "Ubuntu 22.04",
             os: ubuntu-22.04,
             triplet: x64-linux,
-            cc: "gcc",
-            cxx: "g++"
+            cc: "gcc-12",
+            cxx: "g++-12",
+            gcov: "gcov-12"
           }
           - {
-            name: "Ubuntu 24.04",
+            name: "Ubuntu 24.04 - GCC 13",
             os: ubuntu-24.04,
             triplet: x64-linux,
-            cc: "gcc",
-            cxx: "g++"
+            cc: "gcc-13",
+            cxx: "g++-13",
+            gcov: "gcov-13"
           }
 
     steps:
@@ -48,7 +50,16 @@ jobs:
           fetch-depth: 2
 
       - name: Install required dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake pkg-config git libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev libmbedtls-dev libpcre2-8-0 libpcre2-dev libjson-c-dev valgrind libhiredis-dev liblzf-dev redis-tools gcc-12 g++-12
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake pkg-config git libnuma1 libnuma-dev libcurl4-openssl-dev libcurl4 libyaml-0-2 libyaml-dev libmbedtls-dev libpcre2-8-0 libpcre2-dev libjson-c-dev valgrind libhiredis-dev liblzf-dev redis-tools lcov
+
+      - name: Report build tool versions
+        shell: bash
+        run: |
+          echo "CC version: $(${{matrix.config.cc}} --version)"
+          echo "CXX version: $(${{matrix.config.cxx}} --version)"
+          echo "gcov version: $(${{matrix.config.gcov}} --version)"
+          echo "cmake version: $(cmake --version)"
+          echo "lcov version: $(lcov --version)"
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -56,7 +67,7 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{github.workspace}}/build
-        run: CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
+        run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake $GITHUB_WORKSPACE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_HASH_ALGORITHM_T1HA2=1 -DBUILD_TESTS=1 -DBUILD_INTERNAL_BENCHES=1
 
       - name: Build cachegrand-server
         working-directory: ${{github.workspace}}/build
@@ -74,16 +85,16 @@ jobs:
         run: cd tests/unit_tests && sudo ./cachegrand-tests --order lex
 
       - name: Code Coverage - Generation
-        uses: danielealbano/lcov-action@v4.1
-        with:
-          gcov_path: /usr/bin/gcov-12
-          remove_patterns: 3rdparty,tests,./build/_deps,_deps
-          extra_args: '--ignore-errors source --rc geninfo_unexecuted_blocks=1'
+        run: |
+          cd ${{github.workspace}}/build
+          lcov --gcov-tool ${{matrix.config.gcov}} --capture --directory . --exclude catch2 --output-file coverage.info
+          lcov --gcov-tool ${{matrix.config.gcov}} --remove coverage.info '3rdparty/*' 'tests/*' '/usr/*' '_deps/*' --output-file coverage.info
+          lcov --gcov-tool ${{matrix.config.gcov}} --list coverage.info
 
       - uses: codecov/codecov-action@v3
         with:
-          files: ${{github.workspace}}/coverage.info
-          flags: unittests # optional
+          files: ${{github.workspace}}/build/coverage.info
+          flags: unittests
           name: cachegrand-server
           fail_ci_if_error: false
           verbose: false

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -12,10 +12,13 @@ SET(CATCH_BUILD_TESTING OFF CACHE BOOL "CATCH_BUILD_TESTING")
 SET(CATCH_INSTALL_DOCS OFF CACHE BOOL "CATCH_INSTALL_DOCS")
 
 # Fetch Catch2
+# catch2 has to stay pinned to v3.3.2 as newer versions introduced a regression that is causing the Catch2 assertions to
+# fail when used from a thread different from the one that start the actual test. The tests need to be updated to stop
+# using REQUIRE within the additional threads before we can upgrade to a newer version.
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v3.7.1)
+        GIT_TAG        v3.3.2)
 FetchContent_MakeAvailable(Catch2)
 
 # Build tests

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(CATCH_INSTALL_DOCS OFF CACHE BOOL "CATCH_INSTALL_DOCS")
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v3.3.2)
+        GIT_TAG        v3.7.1)
 FetchContent_MakeAvailable(Catch2)
 
 # Build tests

--- a/tools/cmake/build-types/build-types.cmake
+++ b/tools/cmake/build-types/build-types.cmake
@@ -21,6 +21,8 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-inline>)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-fno-omit-frame-pointer>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-omit-frame-pointer>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-fprofile-update=atomic>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fprofile-update=atomic>)
 
     # gcov linking required by gcc
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
This pull request includes a new job configuration for Ubuntu 24.04 in the build and test workflow. 

* [`.github/workflows/build_and_test.yml`](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2R27-R33): Added a new job configuration for "Ubuntu 24.04" with `os` set to `ubuntu-24.04`, `triplet` set to `x64-linux`, and compilers `gcc` and `g++`.