### PR TITLE
Feat/update ubuntu build documentation

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -31,7 +31,7 @@ Example output
 
 ## Install the required packages
 
-### Ubuntu 22.04
+### Ubuntu 22.04 and Ubuntu 24.04
 
 `libatomic1` is not included directly as it's as dependency of `libatomic` which is a dependency itself of 
 `build-essential`.

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -49,24 +49,6 @@ sudo apt install \
     liblzf-dev
 ```
 
-### Ubuntu 20.04
-
-`libatomic1` is not included directly as it's as dependency of `libatomic` which is a dependency itself of
-`build-essential`.
-
-```shell
-sudo apt install \
-    build-essential cmake pkg-config git \
-    libnuma1 libnuma-dev \
-    libcurl4-openssl-dev libcurl4 \
-    libyaml-0-2 libyaml-dev \
-    libmbedtls-dev libmbedtls12 \
-    libpcre2-8-0 libpcre2-dev \
-    libjson-c-dev \
-    libhiredis-dev \
-    liblzf-dev
-```
-
 ### Debian 11
 
 `libatomic1` is not included directly as it's as dependency of `libatomic` which is a dependency itself of


### PR DESCRIPTION
This pull request includes updates to the documentation for building from source. The most important changes are the consolidation of Ubuntu installation instructions and the removal of outdated instructions for Ubuntu 20.04.

Documentation updates:

* [`docs/build-from-source.md`](diffhunk://#diff-98e27fe46505c0c406242be6aafa31c1e882a6206812438ff870db3075e14d7bL34-R34): Updated the section title to include both Ubuntu 22.04 and Ubuntu 24.04.
* [`docs/build-from-source.md`](diffhunk://#diff-98e27fe46505c0c406242be6aafa31c1e882a6206812438ff870db3075e14d7bL52-L69): Removed the outdated installation instructions for Ubuntu 20.04.