### PR TITLE
Report the liburing version when starting up

### DIFF
--- a/src/program_startup_report.c
+++ b/src/program_startup_report.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <sys/sysinfo.h>
 #include <sys/utsname.h>
+#include <liburing.h>
 
 #include "misc.h"
 #include "intrinsics.h"
@@ -82,6 +83,14 @@ void program_startup_report_machine_memory() {
     }
 }
 
+void program_startup_report_machine_liburing() {
+    LOG_I(
+            TAG,
+            "> liburing: v%d.%d",
+            io_uring_major_version(),
+            io_uring_minor_version());
+}
+
 void program_startup_report_machine_tls() {
     LOG_I(
             TAG,
@@ -113,6 +122,7 @@ void program_startup_report() {
     program_startup_report_build();
     program_startup_report_machine_uname();
     program_startup_report_machine_memory();
+    program_startup_report_machine_liburing();
     program_startup_report_machine_tls();
     program_startup_report_machine_clock();
 }


### PR DESCRIPTION
This pull request includes changes to the `src/program_startup_report.c` file to add a new report for the `liburing` library version. The most important changes include adding the necessary include directive for `liburing.h`, defining a new function to log the `liburing` version, and calling this new function within the main program startup report function.

Additions related to `liburing`:

* [`src/program_startup_report.c`](diffhunk://#diff-b52ddd5bd53488e986d006272cc0b6267bf250bc54336237af417e76cc0246adR15): Added `#include <liburing.h>` to include the necessary header for `liburing` functions.
* [`src/program_startup_report.c`](diffhunk://#diff-b52ddd5bd53488e986d006272cc0b6267bf250bc54336237af417e76cc0246adR86-R93): Defined a new function `program_startup_report_machine_liburing()` to log the `liburing` version using `io_uring_major_version()` and `io_uring_minor_version()`.
* [`src/program_startup_report.c`](diffhunk://#diff-b52ddd5bd53488e986d006272cc0b6267bf250bc54336237af417e76cc0246adR125): Updated the `program_startup_report()` function to call the newly defined `program_startup_report_machine_liburing()` function.